### PR TITLE
Allow for using header X-Forwarded-Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ if err != nil {
 // because we aren't running as root and can't bind a listener to port 80 and 443 
 // (used later when we attempt to pass challenges). Keep in mind that we still
 // need to proxy challenge traffic to port 5002 and 5001.
-client.SetHTTPAddress(":5002")
+client.SetHTTPAddress(":5002", false)
 client.SetTLSAddress(":5001")
 
 // New users will need to register

--- a/acme/client.go
+++ b/acme/client.go
@@ -128,14 +128,14 @@ func (c *Client) SetChallengeProvider(challenge Challenge, p ChallengeProvider) 
 //
 // NOTE: This REPLACES any custom HTTP provider previously set by calling
 // c.SetChallengeProvider with the default HTTP challenge provider.
-func (c *Client) SetHTTPAddress(iface string) error {
+func (c *Client) SetHTTPAddress(iface string, allowXForwardedHost bool) error {
 	host, port, err := net.SplitHostPort(iface)
 	if err != nil {
 		return err
 	}
 
 	if chlng, ok := c.solvers[HTTP01]; ok {
-		chlng.(*httpChallenge).provider = NewHTTPProviderServer(host, port)
+		chlng.(*httpChallenge).provider = NewHTTPProviderServer(host, port, allowXForwardedHost)
 	}
 
 	return nil

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -75,7 +75,7 @@ func TestClientOptPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not create client: %v", err)
 	}
-	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort))
+	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort), false)
 	client.SetTLSAddress(net.JoinHostPort(optHost, optPort))
 
 	httpSolver, ok := client.solvers[HTTP01].(*httpChallenge)
@@ -108,7 +108,7 @@ func TestClientOptPort(t *testing.T) {
 
 	// test setting different host
 	optHost = "127.0.0.1"
-	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort))
+	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort), false)
 	client.SetTLSAddress(net.JoinHostPort(optHost, optPort))
 
 	if got := httpSolver.provider.(*HTTPProviderServer).iface; got != optHost {

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -103,7 +103,7 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		if strings.Index(c.GlobalString("http"), ":") == -1 {
 			logger().Fatalf("The --http switch only accepts interface:port or :port for its argument.")
 		}
-		client.SetHTTPAddress(c.GlobalString("http"))
+		client.SetHTTPAddress(c.GlobalString("http"), false)
 	}
 
 	if c.GlobalIsSet("tls") {


### PR DESCRIPTION
Using `X-Forwarded-Host` header would be useful for proxies