### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: lego
+version: '1.0'
+summary: Let's Encrypt client and ACME library written in Go
+description: |
+  Let's Encrypt client and ACME library written in Go.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  lego:
+    plugin: go
+    source: https://github.com/xenolf/lego.git
+    go-importpath: github.com/xenolf/lego
+    build-packages:
+      - build-essential
+apps:
+  lego:
+    command: bin/lego
+    plugs:
+      - home


### PR DESCRIPTION
I've opened this PR to request support for building a snap package of lego.

To give you a bit more context, snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntus from 14.04, as well as Debian, Manjaro, Fedora, OpenSUSE, Arch, and many others distributions. Snaps come with automatic updates, which could be quite useful for applications with focus on security and privacy, like lego. Also, we have a considerable audience of users in the Snap Store (snapcraft.io/store), so this could give extra exposure to your project.

Snaps can be built locally using the snapcraft cli tool, build/CI systems (e.g. Travis) or online via build.snapcraft.io, which is a free service for snap users.

Now, the technobabble to get a snap built locally with snapcraft:

1. Install snapcraft tool and checkout the forked repo that has the snapcraft.yaml file for building the snap.

```bash
snap install snapcraft --classic --beta

git clone https://github.com/igorljubuncic/lego.git
cd lego
git checkout add-snapcraft

snapcraft
```

This command will generate a `<lego-version>.snap` file, something like `lego_1.0_amd64.snap`.

2. Test the snap.

Lego can be installed and tested locally with:

```bash
snap install lego_1.0_amd64.snap --dangerous
```

The `--dangerous` flag is necessary because the snap isn't in the store yet, and isn't signed.

Once installed, the lego command can be executed, e.g.: `snap run lego <options>`

3. Register snap name and upload snap to the store.

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the lego name in the store. 

```bash
snapcraft login
snapcraft register
```

- Upload a built snap to the store. We use channels to differentiate risk levels - edge, beta, candidate, stable. Edge is typically used to host the latest build from git master. You can promote to other channels once you're happy with the tests/

```bash
snapcraft push lego_1.0_amd64.snap --release edge
```

4. Clean test install.

You can do this on a clean machine (install from store and run). No need for the --dangerous flag anymore.

```bash
snap install lego --edge
```

Once (and if) you are happy, you can push a stable release to the stable channel, update the store page, and promote the application online. We can help there, and we'd be glad to feature your application in our store. We can also help with any questions or issues you may have.
