### PR TITLE
Adds log when no renewal.

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -168,7 +168,10 @@ func needRenewal(x509Cert *x509.Certificate, domain string, days int) bool {
 	}
 
 	if days >= 0 {
-		if int(time.Until(x509Cert.NotAfter).Hours()/24.0) > days {
+		notAfter := int(time.Until(x509Cert.NotAfter).Hours() / 24.0)
+		if notAfter > days {
+			log.Printf("[%s] The certificate expires in %d days, the number of days defined to perform the renewal is %d: no renewal.",
+				domain, notAfter, days)
 			return false
 		}
 	}

--- a/cmd/cmd_renew_test.go
+++ b/cmd/cmd_renew_test.go
@@ -1,7 +1,9 @@
 package cmd // import "github.com/xenolf/lego/cmd"
 
 import (
+	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -51,6 +53,66 @@ func Test_merge(t *testing.T) {
 			t.Parallel()
 
 			actual := merge(test.prevDomains, test.nextDomains)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_needRenewal(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		x509Cert *x509.Certificate
+		days     int
+		expected bool
+	}{
+		{
+			desc: "30 days, NotAfter now",
+			x509Cert: &x509.Certificate{
+				NotAfter: time.Now(),
+			},
+			days:     30,
+			expected: true,
+		},
+		{
+			desc: "30 days, NotAfter 31 days",
+			x509Cert: &x509.Certificate{
+				NotAfter: time.Now().Add(31*24*time.Hour + 1*time.Second),
+			},
+			days:     30,
+			expected: false,
+		},
+		{
+			desc: "30 days, NotAfter 30 days",
+			x509Cert: &x509.Certificate{
+				NotAfter: time.Now().Add(30 * 24 * time.Hour),
+			},
+			days:     30,
+			expected: true,
+		},
+		{
+			desc: "0 days, NotAfter 30 days: only the day of the expiration",
+			x509Cert: &x509.Certificate{
+				NotAfter: time.Now().Add(30 * 24 * time.Hour),
+			},
+			days:     0,
+			expected: false,
+		},
+		{
+			desc: "-1 days, NotAfter 30 days: always renew",
+			x509Cert: &x509.Certificate{
+				NotAfter: time.Now().Add(30 * 24 * time.Hour),
+			},
+			days:     -1,
+			expected: true,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+
+			actual := needRenewal(test.x509Cert, "foo.com", test.days)
+
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
Adds a log when certificates are not renew.

Related to https://github.com/xenolf/lego/issues/816#issuecomment-470945090