### PR TITLE
Add 'manual' provider to the output of dnshelp

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -46,6 +46,7 @@ func allDNSCodes() string {
 		"lightsail",
 		"linode",
 		"linodev4",
+		"manual",
 		"mydnsjp",
 		"namecheap",
 		"namedotcom",

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -13,7 +14,8 @@ import (
 )
 
 func allDNSCodes() string {
-	return strings.Join([]string{
+	providers := []string{
+		"manual",
 		"acme-dns",
 		"alidns",
 		"auroradns",
@@ -46,7 +48,6 @@ func allDNSCodes() string {
 		"lightsail",
 		"linode",
 		"linodev4",
-		"manual",
 		"mydnsjp",
 		"namecheap",
 		"namedotcom",
@@ -68,7 +69,9 @@ func allDNSCodes() string {
 		"vscale",
 		"vultr",
 		"zoneee",
-	}, ", ")
+	}
+	sort.Strings(providers)
+	return strings.Join(providers, ", ")
 }
 
 func displayDNSHelp(name string) {

--- a/internal/dnsdocs/dns.go.tmpl
+++ b/internal/dnsdocs/dns.go.tmpl
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -13,11 +14,14 @@ import (
 )
 
 func allDNSCodes() string {
-	return strings.Join([]string{
+	providers := []string{
+		"manual",
 {{- range $provider := .Providers }}
 		"{{ $provider.Code }}",
 {{- end}}
-	}, ", ")
+	}
+	sort.Strings(providers)
+	return strings.Join(providers, ", ")
 }
 
 func displayDNSHelp(name string) {


### PR DESCRIPTION
The output of `./lego dnshelp` was missing `manual` as a DNS provider.