### PR TITLE
Strip newlines when reading environment variables from `_FILE` suffixed files.

### DIFF
--- a/platform/config/env/env.go
+++ b/platform/config/env/env.go
@@ -159,5 +159,5 @@ func GetOrFile(envVar string) string {
 		return ""
 	}
 
-	return string(fileContents)
+	return strings.TrimSuffix(string(fileContents), "\n")
 }

--- a/platform/config/env/env_test.go
+++ b/platform/config/env/env_test.go
@@ -289,25 +289,44 @@ func TestGetOrFile_ReadsFiles(t *testing.T) {
 	varEnvFileName := "TEST_LEGO_ENV_VAR_FILE"
 	varEnvName := "TEST_LEGO_ENV_VAR"
 
-	err := os.Unsetenv(varEnvFileName)
-	require.NoError(t, err)
-	err = os.Unsetenv(varEnvName)
-	require.NoError(t, err)
+	testCases := []struct {
+		desc        string
+		fileContent []byte
+	}{
+		{
+			desc:        "simple",
+			fileContent: []byte("lego_file"),
+		},
+		{
+			desc:        "with an empty last line",
+			fileContent: []byte("lego_file\n"),
+		},
+	}
 
-	file, err := ioutil.TempFile("", "lego")
-	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
 
-	err = ioutil.WriteFile(file.Name(), []byte("lego_file\n"), 0644)
-	require.NoError(t, err)
+			err := os.Unsetenv(varEnvFileName)
+			require.NoError(t, err)
+			err = os.Unsetenv(varEnvName)
+			require.NoError(t, err)
 
-	err = os.Setenv(varEnvFileName, file.Name())
-	require.NoError(t, err)
-	defer os.Unsetenv(varEnvFileName)
+			file, err := ioutil.TempFile("", "lego")
+			require.NoError(t, err)
+			defer os.Remove(file.Name())
 
-	value := GetOrFile(varEnvName)
+			err = ioutil.WriteFile(file.Name(), []byte("lego_file\n"), 0644)
+			require.NoError(t, err)
 
-	assert.Equal(t, "lego_file", value)
+			err = os.Setenv(varEnvFileName, file.Name())
+			require.NoError(t, err)
+			defer os.Unsetenv(varEnvFileName)
+
+			value := GetOrFile(varEnvName)
+
+			assert.Equal(t, "lego_file", value)
+		})
+	}
 }
 
 func TestGetOrFile_PrefersEnvVars(t *testing.T) {

--- a/platform/config/env/env_test.go
+++ b/platform/config/env/env_test.go
@@ -298,7 +298,7 @@ func TestGetOrFile_ReadsFiles(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
-	err = ioutil.WriteFile(file.Name(), []byte("lego_file"), 0644)
+	err = ioutil.WriteFile(file.Name(), []byte("lego_file\n"), 0644)
 	require.NoError(t, err)
 
 	err = os.Setenv(varEnvFileName, file.Name())


### PR DESCRIPTION
Closes #871.