### PR TITLE
exec: serial behavior

### DIFF
--- a/providers/dns/exec/exec.go
+++ b/providers/dns/exec/exec.go
@@ -105,3 +105,9 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
 }
+
+// Sequential All DNS challenges for this provider will be resolved sequentially.
+// Returns the interval between each iteration.
+func (d *DNSProvider) Sequential() time.Duration {
+	return d.config.PropagationTimeout
+}


### PR DESCRIPTION
When requesting wildcard cert with SAN (--domains example.com
--domains *.example.com) I noticed 2 different TXT records are presented
in short succession, then one of them overwrites the other, and
eventually one of the authorizations fails.

Based on what other DNS providers do, I think Sequential() is required in
exec provider, too.