### PR TITLE
namedotcom: fix fqdn parsing when solving dns01 challenge

### DIFF
--- a/providers/dns/namedotcom/namedotcom.go
+++ b/providers/dns/namedotcom/namedotcom.go
@@ -174,8 +174,7 @@ func (d *DNSProvider) extractRecordName(fqdn string) (string, string, error) {
 	parts := strings.Split(name, ".")
 	if len(parts) > 2 {
 		cutoff := len(parts) - 2
-		return strings.Join(parts[0:cutoff], "."), strings.Join(parts[cutoff:len(parts)], "."), nil
-	} else {
-		return "", "", fmt.Errorf("namedotcom: extractRecordName unable to parse fqdn=%s", fqdn)
+		return strings.Join(parts[0:cutoff], "."), strings.Join(parts[cutoff:], "."), nil
 	}
+	return "", "", fmt.Errorf("namedotcom: extractRecordName unable to parse fqdn=%s", fqdn)
 }

--- a/providers/dns/namedotcom/namedotcom.go
+++ b/providers/dns/namedotcom/namedotcom.go
@@ -94,15 +94,20 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
 
+	host, baseDomain, err := d.extractRecordName(fqdn)
+	if err != nil {
+		return err
+	}
+
 	request := &namecom.Record{
-		DomainName: domain,
-		Host:       d.extractRecordName(fqdn, domain),
+		DomainName: baseDomain,
+		Host:       host,
 		Type:       "TXT",
 		TTL:        uint32(d.config.TTL),
 		Answer:     value,
 	}
 
-	_, err := d.client.CreateRecord(request)
+	_, err = d.client.CreateRecord(request)
 	if err != nil {
 		return fmt.Errorf("namedotcom: API call failed: %v", err)
 	}
@@ -161,10 +166,16 @@ func (d *DNSProvider) getRecords(domain string) ([]*namecom.Record, error) {
 	return records, nil
 }
 
-func (d *DNSProvider) extractRecordName(fqdn, domain string) string {
+// extractRecordName parses fqdn into the hostname and baseDomain portions
+// for example, given fqdn: "_acme-challenge.foo.example.com" it returns:
+// "_acme-challenge.foo", "example.com"
+func (d *DNSProvider) extractRecordName(fqdn string) (string, string, error) {
 	name := dns01.UnFqdn(fqdn)
-	if idx := strings.Index(name, "."+domain); idx != -1 {
-		return name[:idx]
+	parts := strings.Split(name, ".")
+	if len(parts) > 2 {
+		cutoff := len(parts) - 2
+		return strings.Join(parts[0:cutoff], "."), strings.Join(parts[cutoff:len(parts)], "."), nil
+	} else {
+		return "", "", fmt.Errorf("namedotcom: extractRecordName unable to parse fqdn=%s", fqdn)
 	}
-	return name
 }


### PR DESCRIPTION
Given a request to add a TXT record for
"_acme-challenge.foo.example.com" the previous code would try to
create a "_acme-challenge" record on domain "foo.example.com"
instead of a "_acme-challenge.foo" record on domain "example.com".

I've tested this with a domain I host at `name.com` and was able to 
successfully pass the dns01 challenge after applying this change.

Fixes #543