### PR TITLE
lego: add method to expose API core

### DIFF
--- a/lego/client.go
+++ b/lego/client.go
@@ -72,3 +72,8 @@ func (c *Client) GetToSURL() string {
 func (c *Client) GetExternalAccountRequired() bool {
 	return c.core.GetDirectory().Meta.ExternalAccountRequired
 }
+
+// Core exposes the low-level core API for this client.
+func (c *Client) Core() *api.Core {
+	return c.core
+}


### PR DESCRIPTION
This adds the Core function to the lego client object, allowing
access to the lower-level core API when it's needed.