### PR TITLE
cloudflare: add support for API tokens

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -220,7 +220,9 @@ func displayDNSHelp(name string) error {
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "CF_API_EMAIL":	Account email`)
 		ew.writeln(`	- "CF_API_KEY":	API key`)
-		ew.writeln(`	- "CLOUDFLARE_API_KEY":	Alias to CLOUDFLARE_API_KEY`)
+		ew.writeln(`	- "CF_API_TOKEN":	API token`)
+		ew.writeln(`	- "CLOUDFLARE_API_KEY":	Alias to CF_API_KEY`)
+		ew.writeln(`	- "CLOUDFLARE_API_TOKEN":	Alias to CF_API_TOKEN`)
 		ew.writeln(`	- "CLOUDFLARE_EMAIL":	Alias to CF_API_EMAIL`)
 		ew.writeln()
 

--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -24,6 +24,11 @@ Here is an example bash command using the Cloudflare provider:
 CLOUDFLARE_EMAIL=foo@bar.com \
 CLOUDFLARE_API_KEY=b9841238feb177a84330febba8a83208921177bffe733 \
 lego --dns cloudflare --domains my.domain.com --email my@email.com run
+
+# or
+
+CLOUDFLARE_API_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
+lego --dns cloudflare --domains my.domain.com --email my@email.com run
 ```
 
 
@@ -35,7 +40,9 @@ lego --dns cloudflare --domains my.domain.com --email my@email.com run
 |-----------------------|-------------|
 | `CF_API_EMAIL` | Account email |
 | `CF_API_KEY` | API key |
-| `CLOUDFLARE_API_KEY` | Alias to CLOUDFLARE_API_KEY |
+| `CF_API_TOKEN` | API token |
+| `CLOUDFLARE_API_KEY` | Alias to CF_API_KEY |
+| `CLOUDFLARE_API_TOKEN` | Alias to CF_API_TOKEN |
 | `CLOUDFLARE_EMAIL` | Alias to CF_API_EMAIL |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
@@ -54,7 +61,20 @@ More information [here](/lego/dns/#configuration-and-credentials).
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here](/lego/dns/#configuration-and-credentials).
 
-The Global API Key needs to be used, not the Origin CA Key.
+## Description
+
+You may use `CF_API_EMAIL` and `CF_API_KEY` to authenticate, or `CF_API_TOKEN`.
+
+### API keys
+
+If using API keys (`CF_API_EMAIL` and `CF_API_KEY`), the Global API Key needs to be used, not the Origin CA Key.
+
+### API tokens
+
+If using [API tokens](https://api.cloudflare.com/#getting-started-endpoints) (`CF_API_TOKEN`), the following permissions are required:
+
+* `Zone:Read`
+* `DNS:Edit`
 
 
 

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -78,24 +78,24 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("cloudflare: the configuration of the DNS provider is nil")
 	}
 
-	var client *cloudflare.API
-	var err error
-
 	if config.TTL < minTTL {
 		return nil, fmt.Errorf("cloudflare: invalid TTL, TTL (%d) must be greater than %d", config.TTL, minTTL)
 	}
 
-	if config.AuthToken != "" {
-		client, err = cloudflare.NewWithAPIToken(config.AuthToken, cloudflare.HTTPClient(config.HTTPClient))
-	} else {
-		client, err = cloudflare.New(config.AuthKey, config.AuthEmail, cloudflare.HTTPClient(config.HTTPClient))
-	}
-
+	client, err := getClient(config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DNSProvider{client: client, config: config}, nil
+}
+
+func getClient(config *Config) (*cloudflare.API, error) {
+	if config.AuthToken == "" {
+		return cloudflare.New(config.AuthKey, config.AuthEmail, cloudflare.HTTPClient(config.HTTPClient))
+	}
+
+	return cloudflare.NewWithAPIToken(config.AuthToken, cloudflare.HTTPClient(config.HTTPClient))
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.

--- a/providers/dns/cloudflare/cloudflare.toml
+++ b/providers/dns/cloudflare/cloudflare.toml
@@ -8,18 +8,32 @@ Example = '''
 CLOUDFLARE_EMAIL=foo@bar.com \
 CLOUDFLARE_API_KEY=b9841238feb177a84330febba8a83208921177bffe733 \
 lego --dns cloudflare --domains my.domain.com --email my@email.com run
+# or
+CLOUDFLARE_API_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
+lego --dns cloudflare --domains my.domain.com --email my@email.com run
 '''
 
 Additional = '''
-The Global API Key needs to be used, not the Origin CA Key.
+## Description
+
+You may use `CF_API_EMAIL` and `CF_API_KEY` to authenticate, or `CF_API_TOKEN` (currently in open beta, subject to change).
+
+If using [API tokens](https://api.cloudflare.com/#getting-started-endpoints) (`CF_API_TOKEN`), the following permissions are required:
+
+* Zone:Read
+* DNS:Edit
+
+If using API keys (`CF_API_EMAIL` and `CF_API_KEY`), the Global API Key needs to be used, not the Origin CA Key.
 '''
 
 [Configuration]
   [Configuration.Credentials]
     CF_API_EMAIL = "Account email"
     CF_API_KEY = "API key"
+    CF_API_TOKEN = "API token"
     CLOUDFLARE_EMAIL = "Alias to CF_API_EMAIL"
-    CLOUDFLARE_API_KEY = "Alias to CLOUDFLARE_API_KEY"
+    CLOUDFLARE_API_KEY = "Alias to CF_API_KEY"
+    CLOUDFLARE_API_TOKEN = "Alias to CF_API_TOKEN"
   [Configuration.Additional]
     CLOUDFLARE_POLLING_INTERVAL = "Time between DNS propagation check"
     CLOUDFLARE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"

--- a/providers/dns/cloudflare/cloudflare.toml
+++ b/providers/dns/cloudflare/cloudflare.toml
@@ -8,7 +8,9 @@ Example = '''
 CLOUDFLARE_EMAIL=foo@bar.com \
 CLOUDFLARE_API_KEY=b9841238feb177a84330febba8a83208921177bffe733 \
 lego --dns cloudflare --domains my.domain.com --email my@email.com run
+
 # or
+
 CLOUDFLARE_API_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
 lego --dns cloudflare --domains my.domain.com --email my@email.com run
 '''
@@ -16,14 +18,18 @@ lego --dns cloudflare --domains my.domain.com --email my@email.com run
 Additional = '''
 ## Description
 
-You may use `CF_API_EMAIL` and `CF_API_KEY` to authenticate, or `CF_API_TOKEN` (currently in open beta, subject to change).
+You may use `CF_API_EMAIL` and `CF_API_KEY` to authenticate, or `CF_API_TOKEN`.
+
+### API keys
+
+If using API keys (`CF_API_EMAIL` and `CF_API_KEY`), the Global API Key needs to be used, not the Origin CA Key.
+
+### API tokens
 
 If using [API tokens](https://api.cloudflare.com/#getting-started-endpoints) (`CF_API_TOKEN`), the following permissions are required:
 
-* Zone:Read
-* DNS:Edit
-
-If using API keys (`CF_API_EMAIL` and `CF_API_KEY`), the Global API Key needs to be used, not the Origin CA Key.
+* `Zone:Read`
+* `DNS:Edit`
 '''
 
 [Configuration]


### PR DESCRIPTION
To limit the scope of operations that can be performed, add support for API tokens (currently in public beta) to be used in place of the global API key. To quote the Cloudflare API docs:

> API Tokens provide a new way to authenticate with the Cloudflare API. They allow for scoped and permissioned access to resources [...]

Note that there is [currently a bug in the API when using tokens for authentication](https://community.cloudflare.com/t/restricted-api-keys/13647/109) causing 500 errors to be returned, so this should not be merged until that is fixed. I just wanted to open the PR to get any feedback in the meantime.

Resolves #890.