### PR TITLE
vultr: quote TXT record

### DIFF
--- a/providers/dns/vultr/vultr.go
+++ b/providers/dns/vultr/vultr.go
@@ -90,7 +90,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	name := d.extractRecordName(fqdn, zoneDomain)
 
-	err = d.client.DNSRecord.Create(ctx, zoneDomain, "TXT", name, value, d.config.TTL, 0)
+	err = d.client.DNSRecord.Create(ctx, zoneDomain, "TXT", `"`+name+`"`, value, d.config.TTL, 0)
 	if err != nil {
 		return fmt.Errorf("vultr: API call failed: %v", err)
 	}

--- a/providers/dns/vultr/vultr.go
+++ b/providers/dns/vultr/vultr.go
@@ -90,7 +90,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	name := d.extractRecordName(fqdn, zoneDomain)
 
-	err = d.client.DNSRecord.Create(ctx, zoneDomain, "TXT", `"`+name+`"`, value, d.config.TTL, 0)
+	err = d.client.DNSRecord.Create(ctx, zoneDomain, "TXT", name, `"`+value+`"`, d.config.TTL, 0)
 	if err != nil {
 		return fmt.Errorf("vultr: API call failed: %v", err)
 	}


### PR DESCRIPTION
This will address #939 where the TXT value needs to be encapsulated in quotes. This is a quick fix to address the issue at hand. 

However in the long term I will look into updating the API or GoVultr itself to handle this more gracefully.

Fix  #939