### PR TITLE
Support LEGO_EXPERIMENTAL_CNAME_SUPPORT validation in duckdns provider

### DIFF
--- a/providers/dns/duckdns/duckdns.go
+++ b/providers/dns/duckdns/duckdns.go
@@ -25,7 +25,7 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the DNSProvider
 func NewDefaultConfig() *Config {
 	return &Config{
-		DomainName: env.GetOrDefaultString("DUCKDNS_DOMAIN",""),
+		DomainName:         env.GetOrDefaultString("DUCKDNS_DOMAIN", ""),
 		PropagationTimeout: env.GetOrDefaultSecond("DUCKDNS_PROPAGATION_TIMEOUT", dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond("DUCKDNS_POLLING_INTERVAL", dns01.DefaultPollingInterval),
 		SequenceInterval:   env.GetOrDefaultSecond("DUCKDNS_SEQUENCE_INTERVAL", dns01.DefaultPropagationTimeout),
@@ -70,17 +70,17 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 // Present creates a TXT record to fulfill the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// get the duckdns domain name
-	duckDnsDomain := GetDomain(d.config.DomainName,domain)
+	duckDNSDomain := GetDomain(d.config.DomainName, domain)
 
-	_, txtRecord := dns01.GetRecord(duckDnsDomain, keyAuth)
-	return d.updateTxtRecord(duckDnsDomain, d.config.Token, txtRecord, false)
+	_, txtRecord := dns01.GetRecord(duckDNSDomain, keyAuth)
+	return d.updateTxtRecord(duckDNSDomain, d.config.Token, txtRecord, false)
 }
 
 // CleanUp clears DuckDNS TXT record
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// get the duckdns domain name
-	duckDnsDomain := GetDomain(d.config.DomainName,domain)
-	return d.updateTxtRecord(duckDnsDomain, d.config.Token, "", true)
+	duckDNSDomain := GetDomain(d.config.DomainName, domain)
+	return d.updateTxtRecord(duckDNSDomain, d.config.Token, "", true)
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.
@@ -95,10 +95,10 @@ func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
 }
 
+// GetDomain return the domain name to be used to set the txt record
 // Check whether the domain named in the configuration value DUCKDNS_DOMAIN
 // is empty. If it is empty the requested domain is used, otherwise the configured domain.
-// This is needed when the CNAME validation takes place.
-func GetDomain(configDomain string, dnsDomain string)  string {
+func GetDomain(configDomain string, dnsDomain string) string {
 	if configDomain != "" {
 		return configDomain
 	}


### PR DESCRIPTION
There is a experimental feature called CNAME validation (LEGO_EXPERIMENTAL_CNAME_SUPPORT) where you can create a cname record pointing to another domain where the txt record has to be created.

The duckdns provider is always using the validation domain name to create the record. If you use the provider with cname valiation you have a fixed domain where you have to set the txt record.

I created a new config entry DUCKDNS_DOMAIN that points to the domain where the txt record should be set. The value is only used, when it is not empty.

#1580