### PR TITLE
linodev4: propagation timeout configuration.

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -833,6 +833,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "LINODE_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "LINODE_POLLING_INTERVAL":	Time between DNS propagation check`)
+		ew.writeln(`	- "LINODE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
 		ew.writeln(`	- "LINODE_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_linodev4.md
+++ b/docs/content/dns/zz_gen_linodev4.md
@@ -41,6 +41,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 |--------------------------------|-------------|
 | `LINODE_HTTP_TIMEOUT` | API request timeout |
 | `LINODE_POLLING_INTERVAL` | Time between DNS propagation check |
+| `LINODE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 | `LINODE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/linodev4/linodev4.toml
+++ b/providers/dns/linodev4/linodev4.toml
@@ -11,6 +11,7 @@ Example = ''''''
     LINODE_TOKEN = "API token"
   [Configuration.Additional]
     LINODE_POLLING_INTERVAL = "Time between DNS propagation check"
+    LINODE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     LINODE_TTL = "The TTL of the TXT record used for the DNS challenge"
     LINODE_HTTP_TIMEOUT = "API request timeout"
 


### PR DESCRIPTION
Allow to configure the propagation timeout for Linode v4.

Fixes #960 