### PR TITLE
challenge/dns01: pass challenge domain to the Present/CleanUp methods

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -91,7 +91,7 @@ func (c *Challenge) PreSolve(authz acme.Authorization) error {
 		return err
 	}
 
-	err = c.provider.Present(authz.Identifier.Value, chlng.Token, keyAuth)
+	err = c.provider.Present(domain, chlng.Token, keyAuth)
 	if err != nil {
 		return fmt.Errorf("[%s] acme: error presenting token: %s", domain, err)
 	}
@@ -143,7 +143,8 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 // CleanUp cleans the challenge.
 func (c *Challenge) CleanUp(authz acme.Authorization) error {
-	log.Infof("[%s] acme: Cleaning DNS-01 challenge", challenge.GetTargetedDomain(authz))
+	domain := challenge.GetTargetedDomain(authz)
+	log.Infof("[%s] acme: Cleaning DNS-01 challenge", domain)
 
 	chlng, err := challenge.FindChallenge(challenge.DNS01, authz)
 	if err != nil {
@@ -155,7 +156,7 @@ func (c *Challenge) CleanUp(authz acme.Authorization) error {
 		return err
 	}
 
-	return c.provider.CleanUp(authz.Identifier.Value, chlng.Token, keyAuth)
+	return c.provider.CleanUp(domain, chlng.Token, keyAuth)
 }
 
 func (c *Challenge) Sequential() (bool, time.Duration) {


### PR DESCRIPTION
When requesting certs for "abc.example.com", "*.abc.example.com" together, two DNS challenges are required with the same domain "_acme-challenge.abc.example.com". The two TXT values must be added together as separate records on the same domain.

Currently the Present/CleanUp callbacks are invoked twice with "abc.example.com" as the first argument in both invocations. This makes it hard to distinguish the two challenges and clean them up correctly.

With this change the second invocation of Present/CleanUp uses "*.abc.example.com" as the first argument as expected.