### PR TITLE
docs: clarify installation-from-source instructions

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -45,8 +45,8 @@ Requirements:
 - `go` v1.12+
 - environment variable: `GO111MODULE=on`
 
-To install from sources, just run:
+To install the latest development version from sources, just run:
 
 ```bash
-go get -u github.com/go-acme/lego/cmd/lego
+go get -u github.com/go-acme/lego/v3/cmd/lego
 ```


### PR DESCRIPTION
Using `github.com/go-acme/lego/cmd/lego` confuses `go get`. It fetches `github.com/go-acme/lego@v2.7.2+incompatible` (among others) and stumbles over a type error with that version.

Correcting the go get path to `github.com/go-acme/lego/v3/cmd/lego` does the right thing.

fixes #993