### PR TITLE
Don't deactivate valid authorizations

### DIFF
--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -61,9 +61,21 @@ func (c *Certifier) getAuthorizations(order acme.ExtendedOrder) ([]acme.Authoriz
 }
 
 func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder) {
-	for _, auth := range order.Authorizations {
-		if c.core.Authorizations.Deactivate(auth) != nil {
-			log.Infof("Unable to deactivate the authorization: %s", auth)
+	for _, authzURL := range order.Authorizations {
+		auth, err := c.core.Authorizations.Get(authzURL)
+		if err != nil {
+			log.Infof("Unable to get the authorization for: %s", authzURL)
+			continue
+		}
+
+		if auth.Status == acme.StatusValid {
+			log.Infof("Skipping deactivating of valid auth: %s", authzURL)
+			continue
+		}
+
+		log.Infof("Deactivating auth: %s", authzURL)
+		if c.core.Authorizations.Deactivate(authzURL) != nil {
+			log.Infof("Unable to deactivate the authorization: %s", authzURL)
 		}
 	}
 }


### PR DESCRIPTION
### Use Case

I use certificates that for domains that span multiple GCP accounts. In the past, I've used `lego` to request those certs. I've done this by calling lego a couple times, and expecting the first times to fail. eg:
```
DOMS=(--domains="proj1.example.com" --domains="proj2.example.com")

# This would fail, but validates the challenges in proj1
GCE_PROJECT=proj1 lego ${DOMS[*]} --dns="gcloud" --accept-tos run

# This skips the previously validated challenges, and upon completion, issues a cert
GCE_PROJECT=proj2 lego ${DOMS[*]} --dns="gcloud" --accept-tos run
```

### Problem

PR https://github.com/go-acme/lego/pull/851 breaks this behavior. With that change, when the first run of `lego` fails to complete all challenges, it deactivates _all_ of them. This makes the previous use case impossible.

### Fix

This can be mitigated by changing the first `lego` run to only use `proj1.example.com`. It would succeed, and then the subsequent run would skip the validated challenges. However, this causes an extra cert issuance.

Instead, `deactivateAuthorizations` should not deactivate validated certs.

I tested this on my use case. It seems to work.