### PR TITLE
httpreq: Allow use environment vars from a _FILE file

### DIFF
--- a/providers/dns/httpreq/httpreq.go
+++ b/providers/dns/httpreq/httpreq.go
@@ -69,8 +69,8 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 	config := NewDefaultConfig()
 	config.Mode = os.Getenv("HTTPREQ_MODE")
-	config.Username = os.Getenv("HTTPREQ_USERNAME")
-	config.Password = os.Getenv("HTTPREQ_PASSWORD")
+	config.Username = env.GetOrFile("HTTPREQ_USERNAME")
+	config.Password = env.GetOrFile("HTTPREQ_PASSWORD")
 	config.Endpoint = endpoint
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/httpreq/httpreq.go
+++ b/providers/dns/httpreq/httpreq.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"time"
 
@@ -68,7 +67,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 	}
 
 	config := NewDefaultConfig()
-	config.Mode = os.Getenv("HTTPREQ_MODE")
+	config.Mode = env.GetOrFile("HTTPREQ_MODE")
 	config.Username = env.GetOrFile("HTTPREQ_USERNAME")
 	config.Password = env.GetOrFile("HTTPREQ_PASSWORD")
 	config.Endpoint = endpoint


### PR DESCRIPTION
Uses the `env.GetOrFile` to look for the environment variable and if it is
not found it tries to get the value from a file referred to in the
corresponding environment variable suffixed with `_FILE`.

Supports `HTTPREQ_USERNAME` and `HTTPREQ_PASSWORD`.

Closes #999 