### PR TITLE
fix: use token as unique ID.

### DIFF
--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -32,6 +32,7 @@ var load = loader.EnvLoader{
 }
 
 func TestMain(m *testing.M) {
+	os.Setenv("LEGO_E2E_TESTS", "LEGO_E2E_TESTS")
 	os.Exit(load.MainTest(m))
 }
 
@@ -258,10 +259,14 @@ func TestChallengeTLS_Client_Obtain(t *testing.T) {
 	require.NoError(t, err)
 	user.registration = reg
 
+	// https://github.com/letsencrypt/pebble/issues/285
+	privateKeyCSR, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
 	request := certificate.ObtainRequest{
 		Domains:    []string{"acme.wtf"},
 		Bundle:     true,
-		PrivateKey: privateKey,
+		PrivateKey: privateKeyCSR,
 	}
 	resource, err := client.Certificate.Obtain(request)
 	require.NoError(t, err)

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -103,10 +103,14 @@ func TestChallengeDNS_Client_Obtain(t *testing.T) {
 
 	domains := []string{"*.légo.acme", "légo.acme"}
 
+	// https://github.com/letsencrypt/pebble/issues/285
+	privateKeyCSR, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
 	request := certificate.ObtainRequest{
 		Domains:    domains,
 		Bundle:     true,
-		PrivateKey: privateKey,
+		PrivateKey: privateKeyCSR,
 	}
 	resource, err := client.Certificate.Obtain(request)
 	require.NoError(t, err)

--- a/providers/dns/auroradns/auroradns.go
+++ b/providers/dns/auroradns/auroradns.go
@@ -127,7 +127,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	d.recordIDsMu.Lock()
-	d.recordIDs[fqdn] = newRecord.ID
+	d.recordIDs[token] = newRecord.ID
 	d.recordIDsMu.Unlock()
 
 	return nil
@@ -138,7 +138,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _ := dns01.GetRecord(domain, keyAuth)
 
 	d.recordIDsMu.Lock()
-	recordID, ok := d.recordIDs[fqdn]
+	recordID, ok := d.recordIDs[token]
 	d.recordIDsMu.Unlock()
 
 	if !ok {
@@ -163,7 +163,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}
 
 	d.recordIDsMu.Lock()
-	delete(d.recordIDs, fqdn)
+	delete(d.recordIDs, token)
 	d.recordIDsMu.Unlock()
 
 	return nil

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -94,7 +94,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	d.recordIDsMu.Lock()
-	d.recordIDs[fqdn] = respData.DomainRecord.ID
+	d.recordIDs[token] = respData.DomainRecord.ID
 	d.recordIDsMu.Unlock()
 
 	return nil
@@ -111,7 +111,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// get the record's unique ID from when we created it
 	d.recordIDsMu.Lock()
-	recordID, ok := d.recordIDs[fqdn]
+	recordID, ok := d.recordIDs[token]
 	d.recordIDsMu.Unlock()
 	if !ok {
 		return fmt.Errorf("digitalocean: unknown record ID for '%s'", fqdn)
@@ -124,7 +124,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// Delete record ID from map
 	d.recordIDsMu.Lock()
-	delete(d.recordIDs, fqdn)
+	delete(d.recordIDs, token)
 	d.recordIDsMu.Unlock()
 
 	return nil

--- a/providers/dns/digitalocean/digitalocean_test.go
+++ b/providers/dns/digitalocean/digitalocean_test.go
@@ -163,9 +163,9 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 	})
 
 	provider.recordIDsMu.Lock()
-	provider.recordIDs["_acme-challenge.example.com."] = 1234567
+	provider.recordIDs["token"] = 1234567
 	provider.recordIDsMu.Unlock()
 
-	err := provider.CleanUp("example.com", "", "")
+	err := provider.CleanUp("example.com", "token", "")
 	require.NoError(t, err, "fail to remove TXT record")
 }

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -141,7 +141,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	d.recordIDsMu.Lock()
-	d.recordIDs[fqdn] = respData.ID
+	d.recordIDs[token] = respData.ID
 	d.recordIDsMu.Unlock()
 
 	return nil
@@ -153,7 +153,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// get the record's unique ID from when we created it
 	d.recordIDsMu.Lock()
-	recordID, ok := d.recordIDs[fqdn]
+	recordID, ok := d.recordIDs[token]
 	d.recordIDsMu.Unlock()
 	if !ok {
 		return fmt.Errorf("ovh: unknown record ID for '%s'", fqdn)
@@ -182,7 +182,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// Delete record ID from map
 	d.recordIDsMu.Lock()
-	delete(d.recordIDs, fqdn)
+	delete(d.recordIDs, token)
 	d.recordIDsMu.Unlock()
 
 	return nil


### PR DESCRIPTION
Use `token` instead of `fqdn` as unique ID to find record ID for:
- Aurora DNS
- Cloudflare
- Digital Ocean
- OVH

The token allows to distinct wildcard domain (`*.example.com`) and root domain (`example.com`)

Closes #998