### PR TITLE
cloudflare: fix panic when accessing record cache

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -105,7 +105,11 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, fmt.Errorf("cloudflare: %v", err)
 	}
 
-	return &DNSProvider{client: client, config: config}, nil
+	return &DNSProvider{
+		client:    client,
+		config:    config,
+		recordIDs: make(map[string]string),
+	}, nil
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.


### PR DESCRIPTION
This amends #1003, where I missed the missing map initialization for Cloudflare in my review.

```console
$ export CLOUDFLARE_EMAIL=... CLOUDFLARE_API_KEY=... CLOUDFLARE_DOMAIN=...
$ go test -v github.com/go-acme/lego/v3/providers/dns/cloudflare -run TestLivePresent
=== RUN   TestLivePresent
--- FAIL: TestLivePresent (0.64s)
panic: assignment to entry in nil map [recovered]
    panic: assignment to entry in nil map

goroutine 7 [running]:
testing.tRunner.func1(0xc00010a100)
    $GOROOT/src/testing/testing.go:874 +0x3a3
panic(0x78ba60, 0x8731b0)
    $GOROOT/src/runtime/panic.go:679 +0x1b2
github.com/go-acme/lego/v3/providers/dns/cloudflare.(*DNSProvider).Present(0xc00000e640, 0xc00001e3f2, 0x8, 0x0, 0x0, 0x7fe85a, 0x6, 0xc000048f60, 0x47fef6)
    $LEGOROOT/providers/dns/cloudflare/cloudflare.go:152 +0x3ce
```