### PR TITLE
Update dnspod, because of API breaking changes.

### DIFF
--- a/docs/content/dns/zz_gen_dnspod.md
+++ b/docs/content/dns/zz_gen_dnspod.md
@@ -53,7 +53,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 ## More information
 
 - [API documentation](https://www.dnspod.com/docs/index.html)
-- [Go client](https://github.com/decker502/dnspod-go)
+- [Go client](https://github.com/nrdcg/dnspod-go)
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 <!-- providers/dns/dnspod/dnspod.toml -->

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/cloudflare/cloudflare-go v0.10.2
 	github.com/cpu/goacmedns v0.0.1
-	github.com/decker502/dnspod-go v0.2.0
 	github.com/dnsimple/dnsimple-go v0.30.0
 	github.com/exoscale/egoscale v0.18.1
 	github.com/gophercloud/gophercloud v0.3.0
@@ -31,6 +30,7 @@ require (
 	github.com/miekg/dns v1.1.15
 	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04
 	github.com/nrdcg/auroradns v1.0.0
+	github.com/nrdcg/dnspod-go v0.3.0
 	github.com/nrdcg/goinwx v0.6.1
 	github.com/nrdcg/namesilo v0.2.1
 	github.com/oracle/oci-go-sdk v7.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decker502/dnspod-go v0.2.0 h1:6dwhUFCYbC5bgpebLKn7PrI43e/5mn9tpUL9YcYCdTU=
-github.com/decker502/dnspod-go v0.2.0/go.mod h1:qsurYu1FgxcDwfSwXJdLt4kRsBLZeosEb9uq4Sy+08g=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
@@ -212,6 +210,8 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/nrdcg/auroradns v1.0.0 h1:b+NpSqNG6HzMqX2ohGQe4Q/G0WQq8pduWCiZ19vdLY8=
 github.com/nrdcg/auroradns v1.0.0/go.mod h1:6JPXKzIRzZzMqtTDgueIhTi6rFf1QvYE/HzqidhOhjw=
+github.com/nrdcg/dnspod-go v0.3.0 h1:EbYggdEGFGq17Vp7sUwd9PyHZv5mMxJwX7nBPukKNoU=
+github.com/nrdcg/dnspod-go v0.3.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=
 github.com/nrdcg/goinwx v0.6.1 h1:AJnjoWPELyCtofhGcmzzcEMFd9YdF2JB/LgutWsWt/s=
 github.com/nrdcg/goinwx v0.6.1/go.mod h1:XPiut7enlbEdntAqalBIqcYcTEVhpv/dKWgDCX2SwKQ=
 github.com/nrdcg/namesilo v0.2.1 h1:kLjCjsufdW/IlC+iSfAqj0iQGgKjlbUUeDJio5Y6eMg=

--- a/providers/dns/dnspod/dnspod.go
+++ b/providers/dns/dnspod/dnspod.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	dnspod "github.com/decker502/dnspod-go"
 	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/platform/config/env"
+	"github.com/nrdcg/dnspod-go"
 )
 
 // Config is used to configure the creation of the DNSProvider
@@ -68,7 +68,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	params := dnspod.CommonParams{LoginToken: config.LoginToken, Format: "json"}
 
 	client := dnspod.NewClient(params)
-	client.HttpClient = config.HTTPClient
+	client.HTTPClient = config.HTTPClient
 
 	return &DNSProvider{client: client, config: config}, nil
 }

--- a/providers/dns/dnspod/dnspod.toml
+++ b/providers/dns/dnspod/dnspod.toml
@@ -17,4 +17,4 @@ Example = ''''''
 
 [Links]
   API = "https://www.dnspod.com/docs/index.html"
-  GoClient = "https://github.com/decker502/dnspod-go"
+  GoClient = "https://github.com/nrdcg/dnspod-go"


### PR DESCRIPTION
Fixes  #1031

Like https://github.com/decker502/dnspod-go doesn't really seem to be maintained, I created a fork in the "natural reserve of DNS clients in Golang": https://github.com/nrdcg/dnspod-go

I also cleaned a bit the code.

https://github.com/decker502/dnspod-go/compare/master...nrdcg:master
