### PR TITLE
doc: improve Route53 documentation.

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1200,10 +1200,10 @@ func displayDNSHelp(name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "AWS_ACCESS_KEY_ID":	Managed by the AWS client`)
+		ew.writeln(`	- "AWS_ACCESS_KEY_ID":	Managed by the AWS client ('AWS_ACCESS_KEY_ID_FILE' is not supported)`)
 		ew.writeln(`	- "AWS_HOSTED_ZONE_ID":	Override the hosted zone ID`)
-		ew.writeln(`	- "AWS_REGION":	Managed by the AWS client`)
-		ew.writeln(`	- "AWS_SECRET_ACCESS_KEY":	Managed by the AWS client`)
+		ew.writeln(`	- "AWS_REGION":	Managed by the AWS client ('AWS_REGION_FILE' is not supported)`)
+		ew.writeln(`	- "AWS_SECRET_ACCESS_KEY":	Managed by the AWS client ('AWS_SECRET_ACCESS_KEY_FILE' is not supported)`)
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -29,10 +29,10 @@ _Please contribute by adding a CLI example._
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `AWS_ACCESS_KEY_ID` | Managed by the AWS client |
+| `AWS_ACCESS_KEY_ID` | Managed by the AWS client (`AWS_ACCESS_KEY_ID_FILE` is not supported) |
 | `AWS_HOSTED_ZONE_ID` | Override the hosted zone ID |
-| `AWS_REGION` | Managed by the AWS client |
-| `AWS_SECRET_ACCESS_KEY` | Managed by the AWS client |
+| `AWS_REGION` | Managed by the AWS client (`AWS_REGION_FILE` is not supported) |
+| `AWS_SECRET_ACCESS_KEY` | Managed by the AWS client (`AWS_SECRET_ACCESS_KEY_FILE` is not supported) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here](/lego/dns/#configuration-and-credentials).
@@ -60,7 +60,10 @@ AWS Credentials are automatically detected in the following locations and priori
 
 If `AWS_HOSTED_ZONE_ID` is not set, Lego tries to determine the correct public hosted zone via the FQDN.
 
-See also: [sessions](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html)
+See also:
+
+- [sessions](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html)
+- [Setting AWS Credentials](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html#setup-credentials-setting)
 
 ## Policy
 

--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -17,7 +17,10 @@ AWS Credentials are automatically detected in the following locations and priori
 
 If `AWS_HOSTED_ZONE_ID` is not set, Lego tries to determine the correct public hosted zone via the FQDN.
 
-See also: [sessions](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html)
+See also:
+
+- [sessions](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html)
+- [Setting AWS Credentials](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html#setup-credentials-setting)
 
 ## Policy
 
@@ -54,9 +57,9 @@ The following AWS IAM policy document describes the permissions required for leg
 
 [Configuration]
   [Configuration.Credentials]
-    AWS_ACCESS_KEY_ID = "Managed by the AWS client"
-    AWS_SECRET_ACCESS_KEY = "Managed by the AWS client"
-    AWS_REGION = "Managed by the AWS client"
+    AWS_ACCESS_KEY_ID = "Managed by the AWS client (`AWS_ACCESS_KEY_ID_FILE` is not supported)"
+    AWS_SECRET_ACCESS_KEY = "Managed by the AWS client (`AWS_SECRET_ACCESS_KEY_FILE` is not supported)"
+    AWS_REGION = "Managed by the AWS client (`AWS_REGION_FILE` is not supported)"
     AWS_HOSTED_ZONE_ID = "Override the hosted zone ID"
   [Configuration.Additional]
     AWS_MAX_RETRIES = "The number of maximum returns the service will use to make an individual API request"


### PR DESCRIPTION
- adds explicit exclusions about `_FILE` suffix
- adds a link about Setting AWS Credentials

Fixes #1033