### PR TITLE
namecheap: add sandbox support.

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -946,6 +946,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln(`	- "NAMECHEAP_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "NAMECHEAP_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "NAMECHEAP_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
+		ew.writeln(`	- "NAMECHEAP_SANDBOX":	Activate the sandbox (boolean)`)
 		ew.writeln(`	- "NAMECHEAP_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_namecheap.md
+++ b/docs/content/dns/zz_gen_namecheap.md
@@ -18,9 +18,13 @@ Configuration for [Namecheap](https://www.namecheap.com).
 
 - Code: `namecheap`
 
-{{% notice note %}}
-_Please contribute by adding a CLI example._
-{{% /notice %}}
+Here is an example bash command using the Namecheap provider:
+
+```bash
+NAMECHEAP_API_USER=user \
+NAMECHEAP_API_KEY=key \
+lego --dns namecheap --email someaccount@email.com --domains "foo.email.com" run
+```
 
 
 
@@ -43,6 +47,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 | `NAMECHEAP_HTTP_TIMEOUT` | API request timeout |
 | `NAMECHEAP_POLLING_INTERVAL` | Time between DNS propagation check |
 | `NAMECHEAP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `NAMECHEAP_SANDBOX` | Activate the sandbox (boolean) |
 | `NAMECHEAP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	defaultBaseURL = "https://api.namecheap.com/xml.response"
+	sandboxBaseURL = "https://api.sandbox.namecheap.com/xml.response"
 	getIPURL       = "https://dynamicdns.park-your-domain.com/getip"
 )
 
@@ -60,8 +61,13 @@ type Config struct {
 
 // NewDefaultConfig returns a default configuration for the DNSProvider
 func NewDefaultConfig() *Config {
+	baseURL := defaultBaseURL
+	if env.GetOrDefaultBool("NAMECHEAP_SANDBOX", false) {
+		baseURL = sandboxBaseURL
+	}
+
 	return &Config{
-		BaseURL:            defaultBaseURL,
+		BaseURL:            baseURL,
 		Debug:              env.GetOrDefaultBool("NAMECHEAP_DEBUG", false),
 		TTL:                env.GetOrDefaultInt("NAMECHEAP_TTL", dns01.DefaultTTL),
 		PropagationTimeout: env.GetOrDefaultSecond("NAMECHEAP_PROPAGATION_TIMEOUT", 60*time.Minute),

--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -4,7 +4,11 @@ URL = "https://www.namecheap.com"
 Code = "namecheap"
 Since = "v0.3.0"
 
-Example = ''''''
+Example = '''
+NAMECHEAP_API_USER=user \
+NAMECHEAP_API_KEY=key \
+lego --dns namecheap --email someaccount@email.com --domains "foo.email.com" run
+'''
 
 [Configuration]
   [Configuration.Credentials]
@@ -15,6 +19,7 @@ Example = ''''''
     NAMECHEAP_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     NAMECHEAP_TTL = "The TTL of the TXT record used for the DNS challenge"
     NAMECHEAP_HTTP_TIMEOUT = "API request timeout"
+    NAMECHEAP_SANDBOX = "Activate the sandbox (boolean)"
 
 [Links]
   API = "https://www.namecheap.com/support/api/methods.aspx"


### PR DESCRIPTION
Add sandbox support through the env var `NAMECHEAP_SANDBOX` (boolean)

Uses the production API URL by default.

Fixes #1040