### PR TITLE
chore: update cenkalti/backoff to v4.

### DIFF
--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-acme/lego/v3/acme"
 	"github.com/go-acme/lego/v3/acme/api/internal/nonces"
 	"github.com/go-acme/lego/v3/acme/api/internal/secure"

--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-acme/lego/v3/acme"
 	"github.com/go-acme/lego/v3/acme/api"
 	"github.com/go-acme/lego/v3/challenge"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.0
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190808125512-07798873deee
 	github.com/aws/aws-sdk-go v1.23.0
-	github.com/cenkalti/backoff/v3 v3.0.0
+	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/cloudflare/cloudflare-go v0.10.2
 	github.com/cpu/goacmedns v0.0.1
 	github.com/dnsimple/dnsimple-go v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod 
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
-github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
+github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/providers/dns/hostingde/client.go
+++ b/providers/dns/hostingde/client.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
+	"github.com/cenkalti/backoff/v4"
 )
 
 const defaultBaseURL = "https://secure.hosting.de/api/dns/v1/json"


### PR DESCRIPTION
The latest versions (since v3.2.0) of `cenkalti/backoff` contains a major regression.

```console
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6de565]

goroutine 7 [running]:
testing.tRunner.func1(0xc0000fc100)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:874 +0x3a3
panic(0x774520, 0xaa4f40)
	/home/ldez/.gvm/gos/go1.13.6/src/runtime/panic.go:679 +0x1b2
time.(*Timer).Stop(...)
	/home/ldez/.gvm/gos/go1.13.6/src/time/sleep.go:74
github.com/cenkalti/backoff/v3.(*defaultTimer).Stop(0xc000232070)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/timer.go:32 +0x25
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer.func1(0x869cc0, 0xc000232070)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:45 +0x31
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc000249c78, 0x7f939c39e078, 0xc000234240, 0x0, 0x869cc0, 0xc000232070, 0x0, 0x0)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:53 +0x34d
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:25

```


An issue has been already reported in `cenkalti/backoff`: https://github.com/cenkalti/backoff/issues/87

So I updated the major version (v4.0.0)

For information:
<details>
<summary>tests output with v3.2.1 of `cenkalti/backoff`</summary>

```console
rm -rf dist/ builds/ cover.out
go test -v -cover ./...
?   	github.com/go-acme/lego/v3/acme	[no test files]
=== RUN   TestCertificateService_Get_issuerRelUp
--- FAIL: TestCertificateService_Get_issuerRelUp (0.16s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6de565]

goroutine 7 [running]:
testing.tRunner.func1(0xc0000fc100)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:874 +0x3a3
panic(0x774520, 0xaa4f40)
	/home/ldez/.gvm/gos/go1.13.6/src/runtime/panic.go:679 +0x1b2
time.(*Timer).Stop(...)
	/home/ldez/.gvm/gos/go1.13.6/src/time/sleep.go:74
github.com/cenkalti/backoff/v3.(*defaultTimer).Stop(0xc000232070)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/timer.go:32 +0x25
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer.func1(0x869cc0, 0xc000232070)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:45 +0x31
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc000249c78, 0x7f939c39e078, 0xc000234240, 0x0, 0x869cc0, 0xc000232070, 0x0, 0x0)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:53 +0x34d
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:25
github.com/go-acme/lego/v3/acme/api.(*Core).retrievablePost(0xc000260000, 0xc00022c060, 0x22, 0xacf2e0, 0x0, 0x0, 0x0, 0x0, 0xc0000e7d00, 0xc00022c060, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:107 +0x224
github.com/go-acme/lego/v3/acme/api.(*Core).postAsGet(...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:76
github.com/go-acme/lego/v3/acme/api.(*CertificateService).get(0xc0002600c0, 0xc00022c060, 0x22, 0xc00022c060, 0x22, 0x22, 0xc, 0x22, 0xc, 0x1)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/certificate.go:62 +0x9d
github.com/go-acme/lego/v3/acme/api.(*CertificateService).Get(0xc0002600c0, 0xc00022c060, 0x22, 0x7e8301, 0xc, 0xc00022c060, 0x22, 0x79c5c0, 0xc000076660, 0xc000260000, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/certificate.go:23 +0x64
github.com/go-acme/lego/v3/acme/api.TestCertificateService_Get_issuerRelUp(0xc0000fc100)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/certificate_test.go:102 +0x367
testing.tRunner(0xc0000fc100, 0x802038)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:960 +0x350
FAIL	github.com/go-acme/lego/v3/acme/api	0.181s
=== RUN   TestNotHoldingLockWhileMakingHTTPRequests
--- PASS: TestNotHoldingLockWhileMakingHTTPRequests (0.25s)
PASS
coverage: 58.3% of statements
ok  	github.com/go-acme/lego/v3/acme/api/internal/nonces	(cached)	coverage: 58.3% of statements
=== RUN   TestNotHoldingLockWhileMakingHTTPRequests
--- PASS: TestNotHoldingLockWhileMakingHTTPRequests (0.26s)
PASS
coverage: 0.0% of statements
ok  	github.com/go-acme/lego/v3/acme/api/internal/secure	(cached)	coverage: 0.0% of statements
=== RUN   TestDo_UserAgentOnAllHTTPMethod
=== RUN   TestDo_UserAgentOnAllHTTPMethod/GET
=== RUN   TestDo_UserAgentOnAllHTTPMethod/HEAD
=== RUN   TestDo_UserAgentOnAllHTTPMethod/POST
--- PASS: TestDo_UserAgentOnAllHTTPMethod (0.00s)
    --- PASS: TestDo_UserAgentOnAllHTTPMethod/GET (0.00s)
    --- PASS: TestDo_UserAgentOnAllHTTPMethod/HEAD (0.00s)
    --- PASS: TestDo_UserAgentOnAllHTTPMethod/POST (0.00s)
=== RUN   TestDo_CustomUserAgent
--- PASS: TestDo_CustomUserAgent (0.00s)
PASS
coverage: 52.7% of statements
ok  	github.com/go-acme/lego/v3/acme/api/internal/sender	(cached)	coverage: 52.7% of statements
=== RUN   TestGeneratePrivateKey
--- PASS: TestGeneratePrivateKey (0.16s)
=== RUN   TestGenerateCSR
=== RUN   TestGenerateCSR/without_SAN
=== PAUSE TestGenerateCSR/without_SAN
=== RUN   TestGenerateCSR/without_SAN#01
=== PAUSE TestGenerateCSR/without_SAN#01
=== RUN   TestGenerateCSR/with_SAN
=== PAUSE TestGenerateCSR/with_SAN
=== RUN   TestGenerateCSR/no_domain
=== PAUSE TestGenerateCSR/no_domain
=== RUN   TestGenerateCSR/no_domain_with_SAN
=== PAUSE TestGenerateCSR/no_domain_with_SAN
=== RUN   TestGenerateCSR/private_key_nil
=== PAUSE TestGenerateCSR/private_key_nil
=== CONT  TestGenerateCSR/without_SAN
=== CONT  TestGenerateCSR/no_domain
=== CONT  TestGenerateCSR/private_key_nil
=== CONT  TestGenerateCSR/with_SAN
=== CONT  TestGenerateCSR/without_SAN#01
=== CONT  TestGenerateCSR/no_domain_with_SAN
--- PASS: TestGenerateCSR (0.00s)
    --- PASS: TestGenerateCSR/private_key_nil (0.00s)
    --- PASS: TestGenerateCSR/without_SAN (0.00s)
    --- PASS: TestGenerateCSR/no_domain (0.00s)
    --- PASS: TestGenerateCSR/with_SAN (0.00s)
    --- PASS: TestGenerateCSR/without_SAN#01 (0.00s)
    --- PASS: TestGenerateCSR/no_domain_with_SAN (0.00s)
=== RUN   TestPEMEncode
--- PASS: TestPEMEncode (0.00s)
=== RUN   TestParsePEMCertificate
--- PASS: TestParsePEMCertificate (0.35s)
PASS
coverage: 29.5% of statements
ok  	github.com/go-acme/lego/v3/certcrypto	(cached)	coverage: 29.5% of statements
=== RUN   Test_checkResponse
--- FAIL: Test_checkResponse (0.37s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6dcb85]

goroutine 7 [running]:
testing.tRunner.func1(0xc0000f4100)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:874 +0x3a3
panic(0x770580, 0xaa5fe0)
	/home/ldez/.gvm/gos/go1.13.6/src/runtime/panic.go:679 +0x1b2
time.(*Timer).Stop(...)
	/home/ldez/.gvm/gos/go1.13.6/src/time/sleep.go:74
github.com/cenkalti/backoff/v3.(*defaultTimer).Stop(0xc0003a0078)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/timer.go:32 +0x25
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer.func1(0x8650e0, 0xc0003a0078)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:45 +0x31
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc0003eba28, 0x7fcbf911b078, 0xc0003d8240, 0x0, 0x8650e0, 0xc0003a0078, 0x0, 0x0)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:53 +0x34d
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:25
github.com/go-acme/lego/v3/acme/api.(*Core).retrievablePost(0xc0003fc000, 0xc0003d4060, 0x22, 0xad0560, 0x0, 0x0, 0x0, 0x0, 0xc0003a6680, 0xa71120, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:107 +0x210
github.com/go-acme/lego/v3/acme/api.(*Core).postAsGet(...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:76
github.com/go-acme/lego/v3/acme/api.(*CertificateService).get(0xc0003fc0c0, 0xc0003d4060, 0x22, 0xc0000e7c20, 0x4e290b, 0x40d9c6, 0x713b4e, 0xa5a7a8, 0xa5a7f8, 0x2a)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/certificate.go:62 +0x7f
github.com/go-acme/lego/v3/acme/api.(*CertificateService).Get(0xc0003fc0c0, 0xc0003d4060, 0x22, 0xc0003d4000, 0xc0000e7c68, 0x203000, 0x203000, 0x203000, 0x22, 0xc0003d4060, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/certificate.go:23 +0x5a
github.com/go-acme/lego/v3/certificate.(*Certifier).checkResponse(0xc0000e7e98, 0x7e2803, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/certificate/certificates.go:296 +0x141
github.com/go-acme/lego/v3/certificate.Test_checkResponse(0xc0000f4100)
	/home/ldez/sources/go/src/github.com/go-acme/lego/certificate/certificates_test.go:105 +0x3e9
testing.tRunner(0xc0000f4100, 0x7fddd8)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:960 +0x350
FAIL	github.com/go-acme/lego/v3/certificate	0.413s
?   	github.com/go-acme/lego/v3/challenge	[no test files]
=== RUN   TestDNSProviderManual
=== RUN   TestDNSProviderManual/Press_enter
lego: Please create the following TXT record in your example.com. zone:
_acme-challenge.example.com. 120 IN TXT "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"
lego: Press 'Enter' when you are done
lego: You can now remove this TXT record from your example.com. zone:
_acme-challenge.example.com. 120 IN TXT "..."
=== RUN   TestDNSProviderManual/Missing_enter
lego: Please create the following TXT record in your example.com. zone:
_acme-challenge.example.com. 120 IN TXT "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"
lego: Press 'Enter' when you are done
--- PASS: TestDNSProviderManual (0.44s)
    --- PASS: TestDNSProviderManual/Press_enter (0.44s)
    --- PASS: TestDNSProviderManual/Missing_enter (0.00s)
=== RUN   TestChallenge_PreSolve
=== RUN   TestChallenge_PreSolve/success
2020/01/12 14:11:38 [INFO] [example.com] acme: Preparing to solve DNS-01
=== RUN   TestChallenge_PreSolve/validate_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Preparing to solve DNS-01
=== RUN   TestChallenge_PreSolve/preCheck_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Preparing to solve DNS-01
=== RUN   TestChallenge_PreSolve/present_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Preparing to solve DNS-01
=== RUN   TestChallenge_PreSolve/cleanUp_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Preparing to solve DNS-01
--- PASS: TestChallenge_PreSolve (0.00s)
    --- PASS: TestChallenge_PreSolve/success (0.00s)
    --- PASS: TestChallenge_PreSolve/validate_fail (0.00s)
    --- PASS: TestChallenge_PreSolve/preCheck_fail (0.00s)
    --- PASS: TestChallenge_PreSolve/present_fail (0.00s)
    --- PASS: TestChallenge_PreSolve/cleanUp_fail (0.00s)
=== RUN   TestChallenge_Solve
=== RUN   TestChallenge_Solve/success
2020/01/12 14:11:38 [INFO] [example.com] acme: Trying to solve DNS-01
2020/01/12 14:11:38 [INFO] [example.com] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/01/12 14:11:38 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
=== RUN   TestChallenge_Solve/validate_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Trying to solve DNS-01
2020/01/12 14:11:38 [INFO] [example.com] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/01/12 14:11:38 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
=== RUN   TestChallenge_Solve/preCheck_fail
2020/01/12 14:11:38 [INFO] [example.com] acme: Trying to solve DNS-01
2020/01/12 14:11:38 [INFO] [example.com] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/01/12 14:11:38 [INFO] Wait for propagation [timeout: 2s, interval: 500ms]
2020/01/12 14:11:38 [INFO] [example.com] acme: Waiting for DNS record propagation.
2020/01/12 14:11:39 [INFO] [example.com] acme: Waiting for DNS record propagation.
2020/01/12 14:11:39 [INFO] [example.com] acme: Waiting for DNS record propagation.
2020/01/12 14:11:40 [INFO] [example.com] acme: Waiting for DNS record propagation.
=== RUN   TestChallenge_Solve/present_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Trying to solve DNS-01
2020/01/12 14:11:40 [INFO] [example.com] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/01/12 14:11:40 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
=== RUN   TestChallenge_Solve/cleanUp_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Trying to solve DNS-01
2020/01/12 14:11:40 [INFO] [example.com] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/01/12 14:11:40 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
--- PASS: TestChallenge_Solve (2.01s)
    --- PASS: TestChallenge_Solve/success (0.00s)
    --- PASS: TestChallenge_Solve/validate_fail (0.00s)
    --- PASS: TestChallenge_Solve/preCheck_fail (2.00s)
    --- PASS: TestChallenge_Solve/present_fail (0.00s)
    --- PASS: TestChallenge_Solve/cleanUp_fail (0.00s)
=== RUN   TestChallenge_CleanUp
=== RUN   TestChallenge_CleanUp/success
2020/01/12 14:11:40 [INFO] [example.com] acme: Cleaning DNS-01 challenge
=== RUN   TestChallenge_CleanUp/validate_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Cleaning DNS-01 challenge
=== RUN   TestChallenge_CleanUp/preCheck_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Cleaning DNS-01 challenge
=== RUN   TestChallenge_CleanUp/present_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Cleaning DNS-01 challenge
=== RUN   TestChallenge_CleanUp/cleanUp_fail
2020/01/12 14:11:40 [INFO] [example.com] acme: Cleaning DNS-01 challenge
--- PASS: TestChallenge_CleanUp (0.01s)
    --- PASS: TestChallenge_CleanUp/success (0.00s)
    --- PASS: TestChallenge_CleanUp/validate_fail (0.00s)
    --- PASS: TestChallenge_CleanUp/preCheck_fail (0.00s)
    --- PASS: TestChallenge_CleanUp/present_fail (0.00s)
    --- PASS: TestChallenge_CleanUp/cleanUp_fail (0.00s)
=== RUN   TestToFqdn
=== RUN   TestToFqdn/simple
=== PAUSE TestToFqdn/simple
=== RUN   TestToFqdn/already_FQDN
=== PAUSE TestToFqdn/already_FQDN
=== CONT  TestToFqdn/simple
=== CONT  TestToFqdn/already_FQDN
--- PASS: TestToFqdn (0.00s)
    --- PASS: TestToFqdn/simple (0.00s)
    --- PASS: TestToFqdn/already_FQDN (0.00s)
=== RUN   TestUnFqdn
=== RUN   TestUnFqdn/simple
=== PAUSE TestUnFqdn/simple
=== RUN   TestUnFqdn/already_domain
=== PAUSE TestUnFqdn/already_domain
=== CONT  TestUnFqdn/simple
=== CONT  TestUnFqdn/already_domain
--- PASS: TestUnFqdn (0.00s)
    --- PASS: TestUnFqdn/simple (0.00s)
    --- PASS: TestUnFqdn/already_domain (0.00s)
=== RUN   TestLookupNameserversOK
=== RUN   TestLookupNameserversOK/books.google.com.ng.
=== PAUSE TestLookupNameserversOK/books.google.com.ng.
=== RUN   TestLookupNameserversOK/www.google.com.
=== PAUSE TestLookupNameserversOK/www.google.com.
=== RUN   TestLookupNameserversOK/physics.georgetown.edu.
=== PAUSE TestLookupNameserversOK/physics.georgetown.edu.
=== CONT  TestLookupNameserversOK/books.google.com.ng.
=== CONT  TestLookupNameserversOK/physics.georgetown.edu.
=== CONT  TestLookupNameserversOK/www.google.com.
--- PASS: TestLookupNameserversOK (0.00s)
    --- PASS: TestLookupNameserversOK/books.google.com.ng. (1.53s)
    --- PASS: TestLookupNameserversOK/www.google.com. (1.78s)
    --- PASS: TestLookupNameserversOK/physics.georgetown.edu. (1.88s)
=== RUN   TestLookupNameserversErr
=== RUN   TestLookupNameserversErr/invalid_tld
=== PAUSE TestLookupNameserversErr/invalid_tld
=== CONT  TestLookupNameserversErr/invalid_tld
--- PASS: TestLookupNameserversErr (0.00s)
    --- PASS: TestLookupNameserversErr/invalid_tld (0.11s)
=== RUN   TestFindZoneByFqdnCustom
=== RUN   TestFindZoneByFqdnCustom/domain_is_a_CNAME
=== RUN   TestFindZoneByFqdnCustom/domain_is_a_non-existent_subdomain
=== RUN   TestFindZoneByFqdnCustom/domain_is_a_eTLD
=== RUN   TestFindZoneByFqdnCustom/domain_is_a_cross-zone_CNAME
=== RUN   TestFindZoneByFqdnCustom/NXDOMAIN
=== RUN   TestFindZoneByFqdnCustom/several_non_existent_nameservers
=== RUN   TestFindZoneByFqdnCustom/only_non_existent_nameservers
=== RUN   TestFindZoneByFqdnCustom/no_nameservers
--- PASS: TestFindZoneByFqdnCustom (1.01s)
    --- PASS: TestFindZoneByFqdnCustom/domain_is_a_CNAME (0.11s)
    --- PASS: TestFindZoneByFqdnCustom/domain_is_a_non-existent_subdomain (0.10s)
    --- PASS: TestFindZoneByFqdnCustom/domain_is_a_eTLD (0.26s)
    --- PASS: TestFindZoneByFqdnCustom/domain_is_a_cross-zone_CNAME (0.25s)
    --- PASS: TestFindZoneByFqdnCustom/NXDOMAIN (0.15s)
    --- PASS: TestFindZoneByFqdnCustom/several_non_existent_nameservers (0.13s)
    --- PASS: TestFindZoneByFqdnCustom/only_non_existent_nameservers (0.00s)
    --- PASS: TestFindZoneByFqdnCustom/no_nameservers (0.00s)
=== RUN   TestFindPrimayNsByFqdnCustom
=== RUN   TestFindPrimayNsByFqdnCustom/domain_is_a_CNAME
=== RUN   TestFindPrimayNsByFqdnCustom/domain_is_a_non-existent_subdomain
=== RUN   TestFindPrimayNsByFqdnCustom/domain_is_a_eTLD
=== RUN   TestFindPrimayNsByFqdnCustom/domain_is_a_cross-zone_CNAME
=== RUN   TestFindPrimayNsByFqdnCustom/NXDOMAIN
=== RUN   TestFindPrimayNsByFqdnCustom/several_non_existent_nameservers
=== RUN   TestFindPrimayNsByFqdnCustom/only_non_existent_nameservers
=== RUN   TestFindPrimayNsByFqdnCustom/no_nameservers
--- PASS: TestFindPrimayNsByFqdnCustom (1.00s)
    --- PASS: TestFindPrimayNsByFqdnCustom/domain_is_a_CNAME (0.10s)
    --- PASS: TestFindPrimayNsByFqdnCustom/domain_is_a_non-existent_subdomain (0.10s)
    --- PASS: TestFindPrimayNsByFqdnCustom/domain_is_a_eTLD (0.34s)
    --- PASS: TestFindPrimayNsByFqdnCustom/domain_is_a_cross-zone_CNAME (0.16s)
    --- PASS: TestFindPrimayNsByFqdnCustom/NXDOMAIN (0.15s)
    --- PASS: TestFindPrimayNsByFqdnCustom/several_non_existent_nameservers (0.13s)
    --- PASS: TestFindPrimayNsByFqdnCustom/only_non_existent_nameservers (0.00s)
    --- PASS: TestFindPrimayNsByFqdnCustom/no_nameservers (0.00s)
=== RUN   TestResolveConfServers
=== RUN   TestResolveConfServers/fixtures/resolv.conf.1
=== RUN   TestResolveConfServers/fixtures/resolv.conf.nonexistant
--- PASS: TestResolveConfServers (0.00s)
    --- PASS: TestResolveConfServers/fixtures/resolv.conf.1 (0.00s)
    --- PASS: TestResolveConfServers/fixtures/resolv.conf.nonexistant (0.00s)
=== RUN   TestCheckDNSPropagation
=== RUN   TestCheckDNSPropagation/success
=== PAUSE TestCheckDNSPropagation/success
=== RUN   TestCheckDNSPropagation/no_TXT_record
=== PAUSE TestCheckDNSPropagation/no_TXT_record
=== CONT  TestCheckDNSPropagation/success
=== CONT  TestCheckDNSPropagation/no_TXT_record
--- PASS: TestCheckDNSPropagation (0.00s)
    --- PASS: TestCheckDNSPropagation/no_TXT_record (0.47s)
    --- PASS: TestCheckDNSPropagation/success (0.60s)
=== RUN   TestCheckAuthoritativeNss
=== RUN   TestCheckAuthoritativeNss/TXT_RR_w/_expected_value
=== PAUSE TestCheckAuthoritativeNss/TXT_RR_w/_expected_value
=== RUN   TestCheckAuthoritativeNss/No_TXT_RR
=== PAUSE TestCheckAuthoritativeNss/No_TXT_RR
=== CONT  TestCheckAuthoritativeNss/TXT_RR_w/_expected_value
=== CONT  TestCheckAuthoritativeNss/No_TXT_RR
--- PASS: TestCheckAuthoritativeNss (0.00s)
    --- PASS: TestCheckAuthoritativeNss/No_TXT_RR (0.12s)
    --- PASS: TestCheckAuthoritativeNss/TXT_RR_w/_expected_value (0.51s)
=== RUN   TestCheckAuthoritativeNssErr
=== RUN   TestCheckAuthoritativeNssErr/TXT_RR_/w_unexpected_value
=== PAUSE TestCheckAuthoritativeNssErr/TXT_RR_/w_unexpected_value
=== RUN   TestCheckAuthoritativeNssErr/No_TXT_RR
=== PAUSE TestCheckAuthoritativeNssErr/No_TXT_RR
=== CONT  TestCheckAuthoritativeNssErr/TXT_RR_/w_unexpected_value
=== CONT  TestCheckAuthoritativeNssErr/No_TXT_RR
--- PASS: TestCheckAuthoritativeNssErr (0.00s)
    --- PASS: TestCheckAuthoritativeNssErr/No_TXT_RR (0.07s)
    --- PASS: TestCheckAuthoritativeNssErr/TXT_RR_/w_unexpected_value (0.21s)
PASS
coverage: 80.2% of statements
ok  	github.com/go-acme/lego/v3/challenge/dns01	(cached)	coverage: 80.2% of statements
=== RUN   TestParseForwardedHeader
=== RUN   TestParseForwardedHeader/empty_input
=== PAUSE TestParseForwardedHeader/empty_input
=== RUN   TestParseForwardedHeader/simple_case
=== PAUSE TestParseForwardedHeader/simple_case
=== RUN   TestParseForwardedHeader/quoted-string
=== PAUSE TestParseForwardedHeader/quoted-string
=== RUN   TestParseForwardedHeader/multiple_entries
=== PAUSE TestParseForwardedHeader/multiple_entries
=== RUN   TestParseForwardedHeader/whitespace
=== PAUSE TestParseForwardedHeader/whitespace
=== RUN   TestParseForwardedHeader/unterminated_quote
=== PAUSE TestParseForwardedHeader/unterminated_quote
=== RUN   TestParseForwardedHeader/unexpected_quote
=== PAUSE TestParseForwardedHeader/unexpected_quote
=== RUN   TestParseForwardedHeader/invalid_token
=== PAUSE TestParseForwardedHeader/invalid_token
=== CONT  TestParseForwardedHeader/empty_input
=== CONT  TestParseForwardedHeader/whitespace
=== CONT  TestParseForwardedHeader/simple_case
=== CONT  TestParseForwardedHeader/unexpected_quote
=== CONT  TestParseForwardedHeader/invalid_token
=== CONT  TestParseForwardedHeader/multiple_entries
=== CONT  TestParseForwardedHeader/unterminated_quote
=== CONT  TestParseForwardedHeader/quoted-string
--- PASS: TestParseForwardedHeader (0.00s)
    --- PASS: TestParseForwardedHeader/empty_input (0.00s)
    --- PASS: TestParseForwardedHeader/whitespace (0.00s)
    --- PASS: TestParseForwardedHeader/simple_case (0.00s)
    --- PASS: TestParseForwardedHeader/unexpected_quote (0.00s)
    --- PASS: TestParseForwardedHeader/invalid_token (0.00s)
    --- PASS: TestParseForwardedHeader/multiple_entries (0.00s)
    --- PASS: TestParseForwardedHeader/unterminated_quote (0.00s)
    --- PASS: TestParseForwardedHeader/quoted-string (0.00s)
=== RUN   TestChallenge
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
--- PASS: TestChallenge (0.01s)
=== RUN   TestChallengeInvalidPort
2020/01/12 14:11:37 [INFO] [localhost:123456] acme: Trying to solve HTTP-01
--- PASS: TestChallengeInvalidPort (0.00s)
=== RUN   TestChallengeWithProxy
=== RUN   TestChallengeWithProxy/no_proxy
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/empty_string
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/empty_Host
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_Host
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/Host_mismatch
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain example.com with method GET but the domain did not match any challenge. Please ensure your are passing the Host header properly.
=== RUN   TestChallengeWithProxy/Host_mismatch_(ignoring_forwarding_header)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain example.com with method GET but the domain did not match any challenge. Please ensure your are passing the Host header properly.
=== RUN   TestChallengeWithProxy/matching_X-Forwarded-Host
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_X-Forwarded-Host_(multiple_fields)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_X-Forwarded-Host_(chain_value)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/X-Forwarded-Host_mismatch
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the X-Forwarded-Host header properly.
=== RUN   TestChallengeWithProxy/X-Forwarded-Host_mismatch_(multiple_fields)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the X-Forwarded-Host header properly.
=== RUN   TestChallengeWithProxy/matching_X-Something-Else
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_X-Something-Else_(multiple_fields)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_X-Something-Else_(chain_value)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/X-Something-Else_mismatch
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the X-Something-Else header properly.
=== RUN   TestChallengeWithProxy/X-Something-Else_mismatch_(multiple_fields)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the X-Something-Else header properly.
=== RUN   TestChallengeWithProxy/X-Something-Else_mismatch_(chain_value)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the X-Something-Else header properly.
=== RUN   TestChallengeWithProxy/matching_Forwarded
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:37 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_Forwarded_(multiple_fields)
2020/01/12 14:11:37 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/matching_Forwarded_(chain_value)
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [INFO] [localhost:23457] Served key authentication
=== RUN   TestChallengeWithProxy/Forwarded_mismatch
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the Forwarded header properly.
=== RUN   TestChallengeWithProxy/Forwarded_mismatch_(missing_information)
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the Forwarded header properly.
=== RUN   TestChallengeWithProxy/Forwarded_mismatch_(multiple_fields)
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the Forwarded header properly.
=== RUN   TestChallengeWithProxy/Forwarded_mismatch_(chain_value)
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve HTTP-01
2020/01/12 14:11:38 [WARN] Received request for domain localhost:23457 with method GET but the domain did not match any challenge. Please ensure your are passing the Forwarded header properly.
--- PASS: TestChallengeWithProxy (0.23s)
    --- PASS: TestChallengeWithProxy/no_proxy (0.01s)
    --- PASS: TestChallengeWithProxy/empty_string (0.01s)
    --- PASS: TestChallengeWithProxy/empty_Host (0.03s)
    --- PASS: TestChallengeWithProxy/matching_Host (0.00s)
    --- PASS: TestChallengeWithProxy/Host_mismatch (0.00s)
    --- PASS: TestChallengeWithProxy/Host_mismatch_(ignoring_forwarding_header) (0.00s)
    --- PASS: TestChallengeWithProxy/matching_X-Forwarded-Host (0.00s)
    --- PASS: TestChallengeWithProxy/matching_X-Forwarded-Host_(multiple_fields) (0.01s)
    --- PASS: TestChallengeWithProxy/matching_X-Forwarded-Host_(chain_value) (0.01s)
    --- PASS: TestChallengeWithProxy/X-Forwarded-Host_mismatch (0.01s)
    --- PASS: TestChallengeWithProxy/X-Forwarded-Host_mismatch_(multiple_fields) (0.02s)
    --- PASS: TestChallengeWithProxy/matching_X-Something-Else (0.01s)
    --- PASS: TestChallengeWithProxy/matching_X-Something-Else_(multiple_fields) (0.01s)
    --- PASS: TestChallengeWithProxy/matching_X-Something-Else_(chain_value) (0.01s)
    --- PASS: TestChallengeWithProxy/X-Something-Else_mismatch (0.02s)
    --- PASS: TestChallengeWithProxy/X-Something-Else_mismatch_(multiple_fields) (0.01s)
    --- PASS: TestChallengeWithProxy/X-Something-Else_mismatch_(chain_value) (0.00s)
    --- PASS: TestChallengeWithProxy/matching_Forwarded (0.01s)
    --- PASS: TestChallengeWithProxy/matching_Forwarded_(multiple_fields) (0.01s)
    --- PASS: TestChallengeWithProxy/matching_Forwarded_(chain_value) (0.01s)
    --- PASS: TestChallengeWithProxy/Forwarded_mismatch (0.01s)
    --- PASS: TestChallengeWithProxy/Forwarded_mismatch_(missing_information) (0.01s)
    --- PASS: TestChallengeWithProxy/Forwarded_mismatch_(multiple_fields) (0.01s)
    --- PASS: TestChallengeWithProxy/Forwarded_mismatch_(chain_value) (0.00s)
PASS
coverage: 89.7% of statements
ok  	github.com/go-acme/lego/v3/challenge/http01	(cached)	coverage: 89.7% of statements
=== RUN   TestProber_Solve
=== RUN   TestProber_Solve/success
=== PAUSE TestProber_Solve/success
=== RUN   TestProber_Solve/already_valid
=== PAUSE TestProber_Solve/already_valid
=== RUN   TestProber_Solve/when_preSolve_fail,_auth_is_flagged_as_error_and_skipped
=== PAUSE TestProber_Solve/when_preSolve_fail,_auth_is_flagged_as_error_and_skipped
=== RUN   TestProber_Solve/errors_at_different_stages
=== PAUSE TestProber_Solve/errors_at_different_stages
=== CONT  TestProber_Solve/success
2020/01/12 14:20:17 [INFO] [acme.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [lego.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [mydomain.wtf] acme: use http-01 solver
=== CONT  TestProber_Solve/errors_at_different_stages
2020/01/12 14:20:17 [INFO] [acme.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [lego.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [mydomain.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [WARN] [mydomain.wtf] acme: error cleaning up: clean error mydomain.wtf 
=== CONT  TestProber_Solve/when_preSolve_fail,_auth_is_flagged_as_error_and_skipped
2020/01/12 14:20:17 [INFO] [acme.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [lego.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [INFO] [mydomain.wtf] acme: use http-01 solver
2020/01/12 14:20:17 [WARN] [acme.wtf] acme: error cleaning up: clean error acme.wtf 
=== CONT  TestProber_Solve/already_valid
2020/01/12 14:20:17 [INFO] [acme.wtf] acme: authorization already valid; skipping challenge
2020/01/12 14:20:17 [INFO] [lego.wtf] acme: authorization already valid; skipping challenge
2020/01/12 14:20:17 [INFO] [mydomain.wtf] acme: authorization already valid; skipping challenge
--- PASS: TestProber_Solve (0.00s)
    --- PASS: TestProber_Solve/success (0.00s)
    --- PASS: TestProber_Solve/errors_at_different_stages (0.00s)
    --- PASS: TestProber_Solve/when_preSolve_fail,_auth_is_flagged_as_error_and_skipped (0.00s)
    --- PASS: TestProber_Solve/already_valid (0.00s)
=== RUN   TestByType
--- PASS: TestByType (0.00s)
=== RUN   TestValidate
=== RUN   TestValidate/POST-unexpected
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x544085]

goroutine 20 [running]:
testing.tRunner.func1(0xc00011a900)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:874 +0x3a3
panic(0x7d4fa0, 0xb5b370)
	/home/ldez/.gvm/gos/go1.13.6/src/runtime/panic.go:679 +0x1b2
time.(*Timer).Stop(...)
	/home/ldez/.gvm/gos/go1.13.6/src/time/sleep.go:74
github.com/cenkalti/backoff/v3.(*defaultTimer).Stop(0xc0000100d8)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/timer.go:32 +0x25
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer.func1(0x8dff60, 0xc0000100d8)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:45 +0x31
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc000127a88, 0x7f2ff88fc188, 0xc00000ece0, 0x0, 0x8dff60, 0xc0000100d8, 0x0, 0x0)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:53 +0x34d
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:25
github.com/go-acme/lego/v3/acme/api.(*Core).retrievablePost(0xc000232000, 0xc000025b60, 0x1b, 0xc00002aee8, 0x2, 0x8, 0x7a55a0, 0xc0000f0510, 0x8028e0, 0x1, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:107 +0x210
github.com/go-acme/lego/v3/acme/api.(*Core).post(0xc000232000, 0xc000025b60, 0x1b, 0x7cd120, 0xb85b30, 0x7a55a0, 0xc0000f0510, 0xf, 0x0, 0x0)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:70 +0xf5
github.com/go-acme/lego/v3/acme/api.(*ChallengeService).New(0xc0002320c0, 0xc000025b60, 0x1b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/challenge.go:20 +0xbf
github.com/go-acme/lego/v3/challenge/resolver.validate(0xc000232000, 0x85594f, 0xb, 0x8542cc, 0x7, 0xc000025b60, 0x1b, 0x0, 0x0, 0x0, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/challenge/resolver/solver_manager.go:80 +0x6e
github.com/go-acme/lego/v3/challenge/resolver.TestValidate.func3(0xc00011a900)
	/home/ldez/sources/go/src/github.com/go-acme/lego/challenge/resolver/solver_manager_test.go:141 +0x15e
testing.tRunner(0xc00011a900, 0xc0001fe270)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:960 +0x350
FAIL	github.com/go-acme/lego/v3/challenge/resolver	0.050s
=== RUN   TestChallenge
2020/01/12 14:11:38 [INFO] [localhost:23457] acme: Trying to solve TLS-ALPN-01
--- PASS: TestChallenge (0.11s)
=== RUN   TestChallengeInvalidPort
2020/01/12 14:11:38 [INFO] [localhost:123456] acme: Trying to solve TLS-ALPN-01
--- PASS: TestChallengeInvalidPort (0.13s)
PASS
coverage: 76.2% of statements
ok  	github.com/go-acme/lego/v3/challenge/tlsalpn01	(cached)	coverage: 76.2% of statements
=== RUN   Test_merge
=== RUN   Test_merge/all_empty
=== PAUSE Test_merge/all_empty
=== RUN   Test_merge/next_empty
=== PAUSE Test_merge/next_empty
=== RUN   Test_merge/prev_empty
=== PAUSE Test_merge/prev_empty
=== RUN   Test_merge/merge_append
=== PAUSE Test_merge/merge_append
=== RUN   Test_merge/merge_same
=== PAUSE Test_merge/merge_same
=== CONT  Test_merge/all_empty
=== CONT  Test_merge/merge_same
=== CONT  Test_merge/merge_append
=== CONT  Test_merge/prev_empty
=== CONT  Test_merge/next_empty
--- PASS: Test_merge (0.00s)
    --- PASS: Test_merge/all_empty (0.00s)
    --- PASS: Test_merge/merge_same (0.00s)
    --- PASS: Test_merge/merge_append (0.00s)
    --- PASS: Test_merge/prev_empty (0.00s)
    --- PASS: Test_merge/next_empty (0.00s)
=== RUN   Test_needRenewal
=== RUN   Test_needRenewal/30_days,_NotAfter_now
=== RUN   Test_needRenewal/30_days,_NotAfter_31_days
2020/01/12 14:11:42 [foo.com] The certificate expires in 31 days, the number of days defined to perform the renewal is 30: no renewal.
=== RUN   Test_needRenewal/30_days,_NotAfter_30_days
=== RUN   Test_needRenewal/0_days,_NotAfter_30_days:_only_the_day_of_the_expiration
2020/01/12 14:11:42 [foo.com] The certificate expires in 29 days, the number of days defined to perform the renewal is 0: no renewal.
=== RUN   Test_needRenewal/-1_days,_NotAfter_30_days:_always_renew
--- PASS: Test_needRenewal (0.00s)
    --- PASS: Test_needRenewal/30_days,_NotAfter_now (0.00s)
    --- PASS: Test_needRenewal/30_days,_NotAfter_31_days (0.00s)
    --- PASS: Test_needRenewal/30_days,_NotAfter_30_days (0.00s)
    --- PASS: Test_needRenewal/0_days,_NotAfter_30_days:_only_the_day_of_the_expiration (0.00s)
    --- PASS: Test_needRenewal/-1_days,_NotAfter_30_days:_always_renew (0.00s)
PASS
coverage: 1.1% of statements
ok  	github.com/go-acme/lego/v3/cmd	(cached)	coverage: 1.1% of statements
?   	github.com/go-acme/lego/v3/cmd/lego	[no test files]
skipping test: e2e tests are disabled. (no 'CI' or 'LEGO_E2E_TESTS' env var)
PASS
ok  	github.com/go-acme/lego/v3/e2e	0.035s
skipping test: e2e tests are disabled. (no 'CI' or 'LEGO_E2E_TESTS' env var)
PASS
ok  	github.com/go-acme/lego/v3/e2e/dnschallenge	0.074s
?   	github.com/go-acme/lego/v3/e2e/loader	[no test files]
?   	github.com/go-acme/lego/v3/internal	[no test files]
?   	github.com/go-acme/lego/v3/internal/dnsdocs	[no test files]
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
PASS
coverage: 57.6% of statements
ok  	github.com/go-acme/lego/v3/lego	(cached)	coverage: 57.6% of statements
?   	github.com/go-acme/lego/v3/log	[no test files]
=== RUN   TestGetWithFallback
=== RUN   TestGetWithFallback/no_groups
=== RUN   TestGetWithFallback/empty_groups
=== RUN   TestGetWithFallback/missing_env_var
=== RUN   TestGetWithFallback/all_env_var_in_a_groups_are_missing
=== RUN   TestGetWithFallback/only_the_first_env_var_have_a_value
=== RUN   TestGetWithFallback/only_the_second_env_var_have_a_value
=== RUN   TestGetWithFallback/all_env_vars_in_a_groups_have_a_value
--- PASS: TestGetWithFallback (0.00s)
    --- PASS: TestGetWithFallback/no_groups (0.00s)
    --- PASS: TestGetWithFallback/empty_groups (0.00s)
    --- PASS: TestGetWithFallback/missing_env_var (0.00s)
    --- PASS: TestGetWithFallback/all_env_var_in_a_groups_are_missing (0.00s)
    --- PASS: TestGetWithFallback/only_the_first_env_var_have_a_value (0.00s)
    --- PASS: TestGetWithFallback/only_the_second_env_var_have_a_value (0.00s)
    --- PASS: TestGetWithFallback/all_env_vars_in_a_groups_have_a_value (0.00s)
=== RUN   TestGetOrDefaultInt
=== RUN   TestGetOrDefaultInt/valid_value
=== RUN   TestGetOrDefaultInt/invalid_content,_use_default_value
=== RUN   TestGetOrDefaultInt/valid_negative_value
=== RUN   TestGetOrDefaultInt/float:_invalid_type,_use_default_value
--- PASS: TestGetOrDefaultInt (0.00s)
    --- PASS: TestGetOrDefaultInt/valid_value (0.00s)
    --- PASS: TestGetOrDefaultInt/invalid_content,_use_default_value (0.00s)
    --- PASS: TestGetOrDefaultInt/valid_negative_value (0.00s)
    --- PASS: TestGetOrDefaultInt/float:_invalid_type,_use_default_value (0.00s)
=== RUN   TestGetOrDefaultSecond
=== RUN   TestGetOrDefaultSecond/valid_value
=== RUN   TestGetOrDefaultSecond/invalid_content,_use_default_value
=== RUN   TestGetOrDefaultSecond/invalid_content,_negative_value
=== RUN   TestGetOrDefaultSecond/float:_invalid_type,_use_default_value
--- PASS: TestGetOrDefaultSecond (0.00s)
    --- PASS: TestGetOrDefaultSecond/valid_value (0.00s)
    --- PASS: TestGetOrDefaultSecond/invalid_content,_use_default_value (0.00s)
    --- PASS: TestGetOrDefaultSecond/invalid_content,_negative_value (0.00s)
    --- PASS: TestGetOrDefaultSecond/float:_invalid_type,_use_default_value (0.00s)
=== RUN   TestGetOrDefaultString
=== RUN   TestGetOrDefaultString/missing_env_var
=== RUN   TestGetOrDefaultString/with_env_var
--- PASS: TestGetOrDefaultString (0.00s)
    --- PASS: TestGetOrDefaultString/missing_env_var (0.00s)
    --- PASS: TestGetOrDefaultString/with_env_var (0.00s)
=== RUN   TestGetOrDefaultBool
=== RUN   TestGetOrDefaultBool/missing_env_var
=== RUN   TestGetOrDefaultBool/with_env_var
=== RUN   TestGetOrDefaultBool/invalid_value
--- PASS: TestGetOrDefaultBool (0.00s)
    --- PASS: TestGetOrDefaultBool/missing_env_var (0.00s)
    --- PASS: TestGetOrDefaultBool/with_env_var (0.00s)
    --- PASS: TestGetOrDefaultBool/invalid_value (0.00s)
=== RUN   TestGetOrFile_ReadsEnvVars
--- PASS: TestGetOrFile_ReadsEnvVars (0.00s)
=== RUN   TestGetOrFile_ReadsFiles
=== RUN   TestGetOrFile_ReadsFiles/simple
=== RUN   TestGetOrFile_ReadsFiles/with_an_empty_last_line
--- PASS: TestGetOrFile_ReadsFiles (0.00s)
    --- PASS: TestGetOrFile_ReadsFiles/simple (0.00s)
    --- PASS: TestGetOrFile_ReadsFiles/with_an_empty_last_line (0.00s)
=== RUN   TestGetOrFile_PrefersEnvVars
--- PASS: TestGetOrFile_PrefersEnvVars (0.00s)
PASS
coverage: 79.7% of statements
ok  	github.com/go-acme/lego/v3/platform/config/env	(cached)	coverage: 79.7% of statements
=== RUN   TestEnvTest
=== RUN   TestEnvTest/simple
=== RUN   TestEnvTest/missing_env_var
=== RUN   TestEnvTest/WithDomain
=== RUN   TestEnvTest/WithDomain_missing_env_var
=== RUN   TestEnvTest/WithDomain_missing_domain
=== RUN   TestEnvTest/WithLiveTestRequirements
=== RUN   TestEnvTest/WithLiveTestRequirements_non_required_var_missing
=== RUN   TestEnvTest/WithLiveTestRequirements_required_var_missing
=== RUN   TestEnvTest/WithLiveTestRequirements_WithDomain
=== RUN   TestEnvTest/WithLiveTestRequirements_WithDomain_without_domain
=== RUN   TestEnvTest/WithLiveTestExtra_true
=== RUN   TestEnvTest/WithLiveTestExtra_false
=== RUN   TestEnvTest/WithLiveTestRequirements_WithLiveTestExtra_true
=== RUN   TestEnvTest/WithLiveTestRequirements_WithLiveTestExtra_false
=== RUN   TestEnvTest/WithLiveTestRequirements_require_env_var_missing_WithLiveTestExtra_true
--- PASS: TestEnvTest (0.00s)
    --- PASS: TestEnvTest/simple (0.00s)
    --- PASS: TestEnvTest/missing_env_var (0.00s)
    --- PASS: TestEnvTest/WithDomain (0.00s)
    --- PASS: TestEnvTest/WithDomain_missing_env_var (0.00s)
    --- PASS: TestEnvTest/WithDomain_missing_domain (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_non_required_var_missing (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_required_var_missing (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_WithDomain (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_WithDomain_without_domain (0.00s)
    --- PASS: TestEnvTest/WithLiveTestExtra_true (0.00s)
    --- PASS: TestEnvTest/WithLiveTestExtra_false (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_WithLiveTestExtra_true (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_WithLiveTestExtra_false (0.00s)
    --- PASS: TestEnvTest/WithLiveTestRequirements_require_env_var_missing_WithLiveTestExtra_true (0.00s)
=== RUN   TestEnvTest_RestoreEnv
--- PASS: TestEnvTest_RestoreEnv (0.00s)
=== RUN   TestEnvTest_ClearEnv
--- PASS: TestEnvTest_ClearEnv (0.00s)
PASS
coverage: 54.9% of statements
ok  	github.com/go-acme/lego/v3/platform/tester	(cached)	coverage: 54.9% of statements
=== RUN   TestForTimeout
2020/01/12 14:11:42 [INFO] Wait for  [timeout: 3s, interval: 1s]
--- PASS: TestForTimeout (3.00s)
PASS
coverage: 83.3% of statements
ok  	github.com/go-acme/lego/v3/platform/wait	(cached)	coverage: 83.3% of statements
=== RUN   TestKnownDNSProviderSuccess
--- PASS: TestKnownDNSProviderSuccess (0.00s)
=== RUN   TestKnownDNSProviderError
--- PASS: TestKnownDNSProviderError (0.00s)
=== RUN   TestUnknownDNSProvider
--- PASS: TestUnknownDNSProvider (0.00s)
PASS
coverage: 4.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns	(cached)	coverage: 4.6% of statements
=== RUN   TestPresent
=== RUN   TestPresent/present_when_client_storage_returns_unexpected_error
=== RUN   TestPresent/present_when_client_storage_returns_ErrDomainNotFound
=== RUN   TestPresent/present_when_client_UpdateTXTRecord_returns_unexpected_error
=== RUN   TestPresent/present_when_everything_works
--- PASS: TestPresent (0.00s)
    --- PASS: TestPresent/present_when_client_storage_returns_unexpected_error (0.00s)
    --- PASS: TestPresent/present_when_client_storage_returns_ErrDomainNotFound (0.00s)
    --- PASS: TestPresent/present_when_client_UpdateTXTRecord_returns_unexpected_error (0.00s)
    --- PASS: TestPresent/present_when_everything_works (0.00s)
=== RUN   TestRegister
=== RUN   TestRegister/register_when_acme-dns_client_returns_an_error
=== RUN   TestRegister/register_when_acme-dns_storage_put_returns_an_error
=== RUN   TestRegister/register_when_acme-dns_storage_save_returns_an_error
=== RUN   TestRegister/register_when_everything_works
--- PASS: TestRegister (0.00s)
    --- PASS: TestRegister/register_when_acme-dns_client_returns_an_error (0.00s)
    --- PASS: TestRegister/register_when_acme-dns_storage_put_returns_an_error (0.00s)
    --- PASS: TestRegister/register_when_acme-dns_storage_save_returns_an_error (0.00s)
    --- PASS: TestRegister/register_when_everything_works (0.00s)
PASS
coverage: 66.7% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/acmedns	(cached)	coverage: 66.7% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    alidns_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    alidns_test.go:139: skipping live test
PASS
coverage: 20.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/alidns	(cached)	coverage: 20.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_user_id
=== RUN   TestNewDNSProvider/missing_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_user_id (0.00s)
    --- PASS: TestNewDNSProvider/missing_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_user_id
=== RUN   TestNewDNSProviderConfig/missing_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_user_id (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_key (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.05s)
=== RUN   TestDNSProvider_CleanUp
--- PASS: TestDNSProvider_CleanUp (0.00s)
PASS
coverage: 80.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/auroradns	(cached)	coverage: 80.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_user_id
=== RUN   TestNewDNSProvider/missing_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_user_id (0.00s)
    --- PASS: TestNewDNSProvider/missing_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_user_id
=== RUN   TestNewDNSProviderConfig/missing_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_user_id (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    autodns_test.go:125: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    autodns_test.go:138: skipping live test
PASS
coverage: 19.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/autodns	(cached)	coverage: 19.0% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_client_ID
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_client_ID (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/SubscriptionID_missing
=== RUN   TestNewDNSProviderConfig/ResourceGroup_missing
=== RUN   TestNewDNSProviderConfig/use_metadata
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/SubscriptionID_missing (0.00s)
    --- PASS: TestNewDNSProviderConfig/ResourceGroup_missing (0.00s)
    --- PASS: TestNewDNSProviderConfig/use_metadata (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    azure_test.go:157: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    azure_test.go:170: skipping live test
PASS
coverage: 45.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/azure	(cached)	coverage: 45.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_bindman_manager_address
=== RUN   TestNewDNSProvider/empty_bindman_manager_address
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_bindman_manager_address (0.00s)
    --- PASS: TestNewDNSProvider/empty_bindman_manager_address (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_base_URL
=== RUN   TestNewDNSProviderConfig/missing_base_URL#01
=== RUN   TestNewDNSProviderConfig/missing_config
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_base_URL (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_base_URL#01 (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_config (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/success_when_add_record_function_return_no_error
time="2020-01-12T14:11:44+01:00" level=info msg="Record to check: '&{_acme-challenge.hello.test.com. _EYMkjukXEMcXbnvpT6WLESzfYhxH190NKTBo3cpu-E TXT}'"
=== RUN   TestDNSProvider_Present/error_when_add_record_function_return_an_error
time="2020-01-12T14:11:44+01:00" level=info msg="Record to check: '&{_acme-challenge.hello.test.com. _EYMkjukXEMcXbnvpT6WLESzfYhxH190NKTBo3cpu-E TXT}'"
--- PASS: TestDNSProvider_Present (0.00s)
    --- PASS: TestDNSProvider_Present/success_when_add_record_function_return_no_error (0.00s)
    --- PASS: TestDNSProvider_Present/error_when_add_record_function_return_an_error (0.00s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/success_when_remove_record_function_return_no_error
=== RUN   TestDNSProvider_CleanUp/error_when_remove_record_function_return_an_error
--- PASS: TestDNSProvider_CleanUp (0.00s)
    --- PASS: TestDNSProvider_CleanUp/success_when_remove_record_function_return_no_error (0.00s)
    --- PASS: TestDNSProvider_CleanUp/error_when_remove_record_function_return_an_error (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    bindman_test.go:193: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    bindman_test.go:206: skipping live test
PASS
coverage: 95.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/bindman	(cached)	coverage: 95.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_server_url
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_password
=== RUN   TestNewDNSProvider/missing_config_name
=== RUN   TestNewDNSProvider/missing_DNS_view
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_server_url (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_config_name (0.00s)
    --- PASS: TestNewDNSProvider/missing_DNS_view (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_base_URL
=== RUN   TestNewDNSProviderConfig/missing_username
=== RUN   TestNewDNSProviderConfig/missing_password
=== RUN   TestNewDNSProviderConfig/missing_config_name
=== RUN   TestNewDNSProviderConfig/missing_DNS_view
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_base_URL (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_password (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_config_name (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_DNS_view (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    bluecat_test.go:216: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    bluecat_test.go:229: skipping live test
PASS
coverage: 8.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/bluecat	(cached)	coverage: 8.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/no_token
=== RUN   TestNewDNSProvider/invalid_endpoint
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/no_token (0.00s)
    --- PASS: TestNewDNSProvider/invalid_endpoint (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_token
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_token (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    checkdomain_test.go:102: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    checkdomain_test.go:115: skipping live test
=== RUN   Test_getDomainIDByName
--- PASS: Test_getDomainIDByName (0.00s)
=== RUN   Test_checkNameservers
--- PASS: Test_checkNameservers (0.00s)
=== RUN   Test_createRecord
--- PASS: Test_createRecord (0.00s)
=== RUN   Test_deleteTXTRecord
--- PASS: Test_deleteTXTRecord (0.00s)
PASS
coverage: 68.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/checkdomain	(cached)	coverage: 68.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success_email,_API_key
=== RUN   TestNewDNSProvider/success_API_token
=== RUN   TestNewDNSProvider/success_separate_API_tokens
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_email
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success_email,_API_key (0.00s)
    --- PASS: TestNewDNSProvider/success_API_token (0.00s)
    --- PASS: TestNewDNSProvider/success_separate_API_tokens (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_email (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderWithToken
=== RUN   TestNewDNSProviderWithToken/same_client_when_zone_token_is_missing
=== RUN   TestNewDNSProviderWithToken/same_client_when_zone_token_equals_dns_token
=== RUN   TestNewDNSProviderWithToken/failure_when_only_zone_api_given
=== RUN   TestNewDNSProviderWithToken/different_clients_when_zone_and_dns_token_differ
=== RUN   TestNewDNSProviderWithToken/aliases_work_as_expected
--- PASS: TestNewDNSProviderWithToken (0.00s)
    --- PASS: TestNewDNSProviderWithToken/same_client_when_zone_token_is_missing (0.00s)
    --- PASS: TestNewDNSProviderWithToken/same_client_when_zone_token_equals_dns_token (0.00s)
    --- PASS: TestNewDNSProviderWithToken/failure_when_only_zone_api_given (0.00s)
    --- PASS: TestNewDNSProviderWithToken/different_clients_when_zone_and_dns_token_differ (0.00s)
    --- PASS: TestNewDNSProviderWithToken/aliases_work_as_expected (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success_with_email_and_api_key
=== RUN   TestNewDNSProviderConfig/success_with_api_token
=== RUN   TestNewDNSProviderConfig/prefer_api_token
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_email
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_api_token,_fallback_to_api_key/email
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_with_email_and_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_with_api_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/prefer_api_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_email (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_token,_fallback_to_api_key/email (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    cloudflare_test.go:270: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    cloudflare_test.go:283: skipping live test
PASS
coverage: 35.2% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/cloudflare	(cached)	coverage: 35.2% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_auth-id
=== RUN   TestNewDNSProvider/missing_auth-password
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_auth-id (0.00s)
    --- PASS: TestNewDNSProvider/missing_auth-password (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_auth-id
=== RUN   TestNewDNSProviderConfig/missing_auth-password
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_auth-id (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_auth-password (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    cloudns_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    cloudns_test.go:139: skipping live test
PASS
coverage: 37.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/cloudns	(cached)	coverage: 37.8% of statements
=== RUN   TestClientGetZone
=== RUN   TestClientGetZone/zone_found
=== RUN   TestClientGetZone/zone_not_found
--- PASS: TestClientGetZone (0.32s)
    --- PASS: TestClientGetZone/zone_found (0.31s)
    --- PASS: TestClientGetZone/zone_not_found (0.00s)
=== RUN   TestClientFindTxtRecord
=== RUN   TestClientFindTxtRecord/record_found
=== RUN   TestClientFindTxtRecord/record_not_found
--- PASS: TestClientFindTxtRecord (0.00s)
    --- PASS: TestClientFindTxtRecord/record_found (0.00s)
    --- PASS: TestClientFindTxtRecord/record_not_found (0.00s)
=== RUN   TestClientAddTxtRecord
=== RUN   TestClientAddTxtRecord/sub-zone
=== RUN   TestClientAddTxtRecord/main_zone
=== RUN   TestClientAddTxtRecord/invalid_status
--- PASS: TestClientAddTxtRecord (0.00s)
    --- PASS: TestClientAddTxtRecord/sub-zone (0.00s)
    --- PASS: TestClientAddTxtRecord/main_zone (0.00s)
    --- PASS: TestClientAddTxtRecord/invalid_status (0.00s)
PASS
coverage: 69.2% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/cloudns/internal	(cached)	coverage: 69.2% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_API_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    cloudxns_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    cloudxns_test.go:139: skipping live test
PASS
coverage: 48.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/cloudxns	(cached)	coverage: 48.3% of statements
=== RUN   TestClientGetDomainInformation
=== RUN   TestClientGetDomainInformation/domain_found
=== RUN   TestClientGetDomainInformation/domains_not_found
--- PASS: TestClientGetDomainInformation (1.02s)
    --- PASS: TestClientGetDomainInformation/domain_found (0.33s)
    --- PASS: TestClientGetDomainInformation/domains_not_found (0.69s)
=== RUN   TestClientFindTxtRecord
=== RUN   TestClientFindTxtRecord/record_found
=== RUN   TestClientFindTxtRecord/record_not_found
--- PASS: TestClientFindTxtRecord (0.00s)
    --- PASS: TestClientFindTxtRecord/record_found (0.00s)
    --- PASS: TestClientFindTxtRecord/record_not_found (0.00s)
=== RUN   TestClientAddTxtRecord
=== RUN   TestClientAddTxtRecord/sub-domain
=== RUN   TestClientAddTxtRecord/main_domain
--- PASS: TestClientAddTxtRecord (0.00s)
    --- PASS: TestClientAddTxtRecord/sub-domain (0.00s)
    --- PASS: TestClientAddTxtRecord/main_domain (0.00s)
PASS
coverage: 75.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/cloudxns/internal	(cached)	coverage: 75.0% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/complete_credentials,_but_login_failed
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_tenant_id
=== RUN   TestNewDNSProvider/missing_api_username
=== RUN   TestNewDNSProvider/missing_api_password
--- PASS: TestNewDNSProvider (1.71s)
    --- PASS: TestNewDNSProvider/complete_credentials,_but_login_failed (1.71s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_tenant_id (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_password (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/complete_credentials,_but_login_failed
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_tenant_id
=== RUN   TestNewDNSProviderConfig/missing_api_username
=== RUN   TestNewDNSProviderConfig/missing_api_password
--- PASS: TestNewDNSProviderConfig (0.50s)
    --- PASS: TestNewDNSProviderConfig/complete_credentials,_but_login_failed (0.50s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_tenant_id (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_username (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_password (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    conoha_test.go:152: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    conoha_test.go:165: skipping live test
PASS
coverage: 35.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/conoha	(cached)	coverage: 35.6% of statements
=== RUN   TestClient_GetDomainID
=== RUN   TestClient_GetDomainID/success
=== RUN   TestClient_GetDomainID/non_existing_domain
=== RUN   TestClient_GetDomainID/marshaling_error
--- PASS: TestClient_GetDomainID (0.02s)
    --- PASS: TestClient_GetDomainID/success (0.02s)
    --- PASS: TestClient_GetDomainID/non_existing_domain (0.00s)
    --- PASS: TestClient_GetDomainID/marshaling_error (0.00s)
=== RUN   TestClient_CreateRecord
=== RUN   TestClient_CreateRecord/success
=== RUN   TestClient_CreateRecord/bad_request
--- PASS: TestClient_CreateRecord (0.00s)
    --- PASS: TestClient_CreateRecord/success (0.00s)
    --- PASS: TestClient_CreateRecord/bad_request (0.00s)
PASS
coverage: 51.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/conoha/internal	(cached)	coverage: 51.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
2020/01/12 14:11:46 http: superfluous response.WriteHeader call from github.com/go-acme/lego/v3/providers/dns/designate.getServer.func1 (designate_test.go:212)
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_auth_url
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_password
=== RUN   TestNewDNSProvider/missing_region_name
=== RUN   TestNewDNSProvider/missing_tenant_name
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_auth_url (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_region_name (0.00s)
    --- PASS: TestNewDNSProvider/missing_tenant_name (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
2020/01/12 14:11:46 http: superfluous response.WriteHeader call from github.com/go-acme/lego/v3/providers/dns/designate.getServer.func1 (designate_test.go:212)
=== RUN   TestNewDNSProviderConfig/wrong_auth_url
2020/01/12 14:11:46 http: superfluous response.WriteHeader call from github.com/go-acme/lego/v3/providers/dns/designate.getServer.func1 (designate_test.go:212)
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/wrong_auth_url (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    designate_test.go:219: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    designate_test.go:232: skipping live test
PASS
coverage: 16.5% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/designate	(cached)	coverage: 16.5% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.19s)
=== RUN   TestDNSProvider_CleanUp
--- PASS: TestDNSProvider_CleanUp (0.05s)
PASS
coverage: 69.9% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/digitalocean	(cached)	coverage: 69.9% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/success:_base_url
=== RUN   TestNewDNSProvider/missing_oauth_token
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/success:_base_url (0.00s)
    --- PASS: TestNewDNSProvider/missing_oauth_token (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/success:_base_url
=== RUN   TestNewDNSProviderConfig/missing_oauth_token
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/success:_base_url (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_oauth_token (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    dnsimple_test.go:124: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    dnsimple_test.go:142: skipping live test
PASS
coverage: 16.2% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dnsimple	(cached)	coverage: 16.2% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestLivePresentAndCleanup
--- SKIP: TestLivePresentAndCleanup (0.00s)
    dnsmadeeasy_test.go:130: skipping live test
PASS
coverage: 38.9% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dnsmadeeasy	(cached)	coverage: 38.9% of statements
?   	github.com/go-acme/lego/v3/providers/dns/dnsmadeeasy/internal	[no test files]
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    dnspod_test.go:93: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    dnspod_test.go:106: skipping live test
PASS
coverage: 20.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dnspod	(cached)	coverage: 20.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    dode_test.go:91: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    dode_test.go:104: skipping live test
PASS
coverage: 26.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dode	(cached)	coverage: 26.8% of statements
=== RUN   TestDNSProvider_buildQuery
=== RUN   TestDNSProvider_buildQuery/success
=== PAUSE TestDNSProvider_buildQuery/success
=== RUN   TestDNSProvider_buildQuery/Invalid_base_URL
=== PAUSE TestDNSProvider_buildQuery/Invalid_base_URL
=== CONT  TestDNSProvider_buildQuery/success
=== CONT  TestDNSProvider_buildQuery/Invalid_base_URL
--- PASS: TestDNSProvider_buildQuery (0.00s)
    --- PASS: TestDNSProvider_buildQuery/success (0.00s)
    --- PASS: TestDNSProvider_buildQuery/Invalid_base_URL (0.00s)
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_API_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider_Present
2020/01/12 14:11:47 [INFO] dreamhost: record_added
--- PASS: TestDNSProvider_Present (0.00s)
=== RUN   TestDNSProvider_PresentFailed
--- PASS: TestDNSProvider_PresentFailed (0.00s)
=== RUN   TestDNSProvider_Cleanup
2020/01/12 14:11:47 [INFO] dreamhost: record_removed
--- PASS: TestDNSProvider_Cleanup (0.00s)
=== RUN   TestLivePresentAndCleanUp
--- SKIP: TestLivePresentAndCleanUp (0.00s)
    dreamhost_test.go:182: skipping live test
PASS
coverage: 84.1% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dreamhost	(cached)	coverage: 84.1% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   Test_getMainDomain
=== RUN   Test_getMainDomain/empty
=== PAUSE Test_getMainDomain/empty
=== RUN   Test_getMainDomain/missing_sub_domain
=== PAUSE Test_getMainDomain/missing_sub_domain
=== RUN   Test_getMainDomain/explicit_domain:_sub_domain
=== PAUSE Test_getMainDomain/explicit_domain:_sub_domain
=== RUN   Test_getMainDomain/explicit_domain:_subsub_domain
=== PAUSE Test_getMainDomain/explicit_domain:_subsub_domain
=== RUN   Test_getMainDomain/explicit_domain:_subsubsub_domain
=== PAUSE Test_getMainDomain/explicit_domain:_subsubsub_domain
=== RUN   Test_getMainDomain/only_subname:_sub_domain
=== PAUSE Test_getMainDomain/only_subname:_sub_domain
=== RUN   Test_getMainDomain/only_subname:_subsub_domain
=== PAUSE Test_getMainDomain/only_subname:_subsub_domain
=== RUN   Test_getMainDomain/only_subname:_subsubsub_domain
=== PAUSE Test_getMainDomain/only_subname:_subsubsub_domain
=== CONT  Test_getMainDomain/empty
=== CONT  Test_getMainDomain/only_subname:_subsubsub_domain
=== CONT  Test_getMainDomain/only_subname:_subsub_domain
=== CONT  Test_getMainDomain/only_subname:_sub_domain
=== CONT  Test_getMainDomain/explicit_domain:_subsubsub_domain
=== CONT  Test_getMainDomain/explicit_domain:_subsub_domain
=== CONT  Test_getMainDomain/explicit_domain:_sub_domain
=== CONT  Test_getMainDomain/missing_sub_domain
--- PASS: Test_getMainDomain (0.00s)
    --- PASS: Test_getMainDomain/empty (0.00s)
    --- PASS: Test_getMainDomain/only_subname:_subsubsub_domain (0.00s)
    --- PASS: Test_getMainDomain/only_subname:_subsub_domain (0.00s)
    --- PASS: Test_getMainDomain/only_subname:_sub_domain (0.00s)
    --- PASS: Test_getMainDomain/explicit_domain:_subsubsub_domain (0.00s)
    --- PASS: Test_getMainDomain/explicit_domain:_subsub_domain (0.00s)
    --- PASS: Test_getMainDomain/explicit_domain:_sub_domain (0.00s)
    --- PASS: Test_getMainDomain/missing_sub_domain (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    duckdns_test.go:151: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    duckdns_test.go:164: skipping live test
PASS
coverage: 41.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/duckdns	(cached)	coverage: 41.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_customer_name
=== RUN   TestNewDNSProvider/missing_password
=== RUN   TestNewDNSProvider/missing_username
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_customer_name (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_customer_name
=== RUN   TestNewDNSProviderConfig/missing_password
=== RUN   TestNewDNSProviderConfig/missing_username
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_customer_name (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_password (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    dyn_test.go:152: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    dyn_test.go:165: skipping live test
PASS
coverage: 11.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/dyn	(cached)	coverage: 11.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_token
=== RUN   TestNewDNSProvider/missing_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_token (0.00s)
    --- PASS: TestNewDNSProvider/missing_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/nil_config
=== RUN   TestNewDNSProviderConfig/missing_token
=== RUN   TestNewDNSProviderConfig/missing_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/nil_config (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_key (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.00s)
=== RUN   TestDNSProvider_Cleanup_WhenRecordIdNotSet_NoOp
--- PASS: TestDNSProvider_Cleanup_WhenRecordIdNotSet_NoOp (0.00s)
=== RUN   TestDNSProvider_Cleanup_WhenRecordIdSet_DeletesTxtRecord
--- PASS: TestDNSProvider_Cleanup_WhenRecordIdSet_DeletesTxtRecord (0.00s)
=== RUN   TestDNSProvider_Cleanup_WhenHttpError_ReturnsError
--- PASS: TestDNSProvider_Cleanup_WhenHttpError_ReturnsError (0.00s)
=== RUN   TestSplitFqdn
=== RUN   TestSplitFqdn/domain_only
=== RUN   TestSplitFqdn/single-part_host
=== RUN   TestSplitFqdn/multi-part_host
--- PASS: TestSplitFqdn (0.00s)
    --- PASS: TestSplitFqdn/domain_only (0.00s)
    --- PASS: TestSplitFqdn/single-part_host (0.00s)
    --- PASS: TestSplitFqdn/multi-part_host (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    easydns_test.go:291: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    easydns_test.go:304: skipping live test
PASS
coverage: 88.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/easydns	(cached)	coverage: 88.4% of statements
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/Standard_mode
XXX present _acme-challenge.domain. pW9ZKG0xz_PCriK-nCMOjADy9eJcgGWIzkkj2fN4uZM

=== RUN   TestDNSProvider_Present/program_error
=== RUN   TestDNSProvider_Present/Raw_mode
XXX present -- domain token keyAuth

--- PASS: TestDNSProvider_Present (0.02s)
    --- PASS: TestDNSProvider_Present/Standard_mode (0.01s)
    --- PASS: TestDNSProvider_Present/program_error (0.00s)
    --- PASS: TestDNSProvider_Present/Raw_mode (0.01s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/Standard_mode
XXX cleanup _acme-challenge.domain. pW9ZKG0xz_PCriK-nCMOjADy9eJcgGWIzkkj2fN4uZM

=== RUN   TestDNSProvider_CleanUp/program_error
=== RUN   TestDNSProvider_CleanUp/Raw_mode
XXX cleanup -- domain token keyAuth

--- PASS: TestDNSProvider_CleanUp (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Standard_mode (0.00s)
    --- PASS: TestDNSProvider_CleanUp/program_error (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Raw_mode (0.00s)
PASS
coverage: 66.7% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/exec	(cached)	coverage: 66.7% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestDNSProvider_FindZoneAndRecordName
=== RUN   TestDNSProvider_FindZoneAndRecordName/Extract_root_record_name
=== PAUSE TestDNSProvider_FindZoneAndRecordName/Extract_root_record_name
=== RUN   TestDNSProvider_FindZoneAndRecordName/Extract_sub_record_name
=== PAUSE TestDNSProvider_FindZoneAndRecordName/Extract_sub_record_name
=== CONT  TestDNSProvider_FindZoneAndRecordName/Extract_root_record_name
=== CONT  TestDNSProvider_FindZoneAndRecordName/Extract_sub_record_name
--- PASS: TestDNSProvider_FindZoneAndRecordName (0.00s)
    --- PASS: TestDNSProvider_FindZoneAndRecordName/Extract_root_record_name (0.08s)
    --- PASS: TestDNSProvider_FindZoneAndRecordName/Extract_sub_record_name (0.23s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    exoscale_test.go:179: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    exoscale_test.go:196: skipping live test
PASS
coverage: 35.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/exoscale	(cached)	coverage: 35.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_host
=== RUN   TestNewDNSProvider/missing_client_token
=== RUN   TestNewDNSProvider/missing_client_secret
=== RUN   TestNewDNSProvider/missing_access_token
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_host (0.00s)
    --- PASS: TestNewDNSProvider/missing_client_token (0.00s)
    --- PASS: TestNewDNSProvider/missing_client_secret (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_token (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_host
=== RUN   TestNewDNSProviderConfig/missing_client_token
=== RUN   TestNewDNSProviderConfig/missing_client_secret
=== RUN   TestNewDNSProviderConfig/missing_access_token
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_host (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_client_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_client_secret (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_access_token (0.00s)
=== RUN   TestDNSProvider_findZoneAndRecordName
=== RUN   TestDNSProvider_findZoneAndRecordName/Extract_root_record_name
=== PAUSE TestDNSProvider_findZoneAndRecordName/Extract_root_record_name
=== RUN   TestDNSProvider_findZoneAndRecordName/Extract_sub_record_name
=== PAUSE TestDNSProvider_findZoneAndRecordName/Extract_sub_record_name
=== CONT  TestDNSProvider_findZoneAndRecordName/Extract_root_record_name
=== CONT  TestDNSProvider_findZoneAndRecordName/Extract_sub_record_name
--- PASS: TestDNSProvider_findZoneAndRecordName (0.00s)
    --- PASS: TestDNSProvider_findZoneAndRecordName/Extract_root_record_name (0.08s)
    --- PASS: TestDNSProvider_findZoneAndRecordName/Extract_sub_record_name (0.25s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    fastdns_test.go:237: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    fastdns_test.go:254: skipping live test
PASS
coverage: 29.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/fastdns	(cached)	coverage: 29.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider
--- PASS: TestDNSProvider (0.00s)
PASS
coverage: 76.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/gandi	(cached)	coverage: 76.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider
2020/01/12 14:11:48 [INFO] request: GET /domains/example.com/records/_acme-challenge.abc.def/TXT
2020/01/12 14:11:48 [INFO] request: PUT /domains/example.com/records/_acme-challenge.abc.def/TXT
2020/01/12 14:11:48 [INFO] API response: Zone Record Created
2020/01/12 14:11:48 [INFO] request: DELETE /domains/example.com/records/_acme-challenge.abc.def/TXT
--- PASS: TestDNSProvider (0.00s)
PASS
coverage: 72.7% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/gandiv5	(cached)	coverage: 72.7% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/invalid_credentials
=== RUN   TestNewDNSProvider/missing_project
=== RUN   TestNewDNSProvider/success_key_file
=== RUN   TestNewDNSProvider/success_key
--- PASS: TestNewDNSProvider (0.01s)
    --- PASS: TestNewDNSProvider/invalid_credentials (0.01s)
    --- PASS: TestNewDNSProvider/missing_project (0.00s)
    --- PASS: TestNewDNSProvider/success_key_file (0.00s)
    --- PASS: TestNewDNSProvider/success_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/invalid_project
=== RUN   TestNewDNSProviderConfig/missing_project
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/invalid_project (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_project (0.00s)
=== RUN   TestPresentNoExistingRR
--- PASS: TestPresentNoExistingRR (0.12s)
=== RUN   TestPresentWithExistingRR
--- PASS: TestPresentWithExistingRR (0.00s)
=== RUN   TestPresentSkipExistingRR
2020/01/12 14:11:49 skip: the record already exists: 47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU
--- PASS: TestPresentSkipExistingRR (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.07s)
    googlecloud_test.go:379: skipping live test
=== RUN   TestLivePresentMultiple
--- SKIP: TestLivePresentMultiple (0.00s)
    googlecloud_test.go:393: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    googlecloud_test.go:411: skipping live test
PASS
coverage: 56.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/gcloud	(cached)	coverage: 56.0% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_api_user
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_user (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_user
=== RUN   TestNewDNSProviderConfig/missing_api_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_user (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    glesys_test.go:127: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    glesys_test.go:140: skipping live test
PASS
coverage: 20.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/glesys	(cached)	coverage: 20.0% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    godaddy_test.go:123: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    godaddy_test.go:136: skipping live test
PASS
coverage: 22.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/godaddy	(cached)	coverage: 22.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_zone_name
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_zone_name (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_zone_name
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_zone_name (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    hostingde_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    hostingde_test.go:139: skipping live test
PASS
coverage: 12.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/hostingde	(cached)	coverage: 12.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/invalid_URL
=== RUN   TestNewDNSProvider/missing_endpoint
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/invalid_URL (0.00s)
    --- PASS: TestNewDNSProvider/missing_endpoint (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_endpoint
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_endpoint (0.00s)
=== RUN   TestNewDNSProvider_Present
=== RUN   TestNewDNSProvider_Present/success
=== PAUSE TestNewDNSProvider_Present/success
=== RUN   TestNewDNSProvider_Present/success_with_path_prefix
=== PAUSE TestNewDNSProvider_Present/success_with_path_prefix
=== RUN   TestNewDNSProvider_Present/error
=== PAUSE TestNewDNSProvider_Present/error
=== RUN   TestNewDNSProvider_Present/success_raw_mode
=== PAUSE TestNewDNSProvider_Present/success_raw_mode
=== RUN   TestNewDNSProvider_Present/error_raw_mode
=== PAUSE TestNewDNSProvider_Present/error_raw_mode
=== RUN   TestNewDNSProvider_Present/basic_auth
=== PAUSE TestNewDNSProvider_Present/basic_auth
=== CONT  TestNewDNSProvider_Present/success
=== CONT  TestNewDNSProvider_Present/error_raw_mode
=== CONT  TestNewDNSProvider_Present/success_raw_mode
=== CONT  TestNewDNSProvider_Present/error
=== CONT  TestNewDNSProvider_Present/success_with_path_prefix
=== CONT  TestNewDNSProvider_Present/basic_auth
--- PASS: TestNewDNSProvider_Present (0.00s)
    --- PASS: TestNewDNSProvider_Present/success_with_path_prefix (0.01s)
    --- PASS: TestNewDNSProvider_Present/success (0.01s)
    --- PASS: TestNewDNSProvider_Present/basic_auth (0.02s)
    --- PASS: TestNewDNSProvider_Present/error_raw_mode (0.02s)
    --- PASS: TestNewDNSProvider_Present/error (0.02s)
    --- PASS: TestNewDNSProvider_Present/success_raw_mode (0.02s)
=== RUN   TestNewDNSProvider_Cleanup
=== RUN   TestNewDNSProvider_Cleanup/success
=== PAUSE TestNewDNSProvider_Cleanup/success
=== RUN   TestNewDNSProvider_Cleanup/error
=== PAUSE TestNewDNSProvider_Cleanup/error
=== RUN   TestNewDNSProvider_Cleanup/success_raw_mode
=== PAUSE TestNewDNSProvider_Cleanup/success_raw_mode
=== RUN   TestNewDNSProvider_Cleanup/error_raw_mode
=== PAUSE TestNewDNSProvider_Cleanup/error_raw_mode
=== RUN   TestNewDNSProvider_Cleanup/basic_auth
=== PAUSE TestNewDNSProvider_Cleanup/basic_auth
=== CONT  TestNewDNSProvider_Cleanup/success
=== CONT  TestNewDNSProvider_Cleanup/basic_auth
=== CONT  TestNewDNSProvider_Cleanup/error_raw_mode
=== CONT  TestNewDNSProvider_Cleanup/success_raw_mode
=== CONT  TestNewDNSProvider_Cleanup/error
--- PASS: TestNewDNSProvider_Cleanup (0.00s)
    --- PASS: TestNewDNSProvider_Cleanup/success (0.00s)
    --- PASS: TestNewDNSProvider_Cleanup/basic_auth (0.00s)
    --- PASS: TestNewDNSProvider_Cleanup/success_raw_mode (0.00s)
    --- PASS: TestNewDNSProvider_Cleanup/error_raw_mode (0.00s)
    --- PASS: TestNewDNSProvider_Cleanup/error (0.00s)
PASS
coverage: 89.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/httpreq	(cached)	coverage: 89.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_api_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
=== RUN   TestNewDNSProvider/missing_do_service_code
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_do_service_code (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_access_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
=== RUN   TestNewDNSProviderConfig/missing_do_service_code
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_access_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_do_service_code (0.00s)
=== RUN   TestSplitDomain
=== RUN   TestSplitDomain/domain_equals_zone
=== PAUSE TestSplitDomain/domain_equals_zone
=== RUN   TestSplitDomain/with_a_sub_domain
=== PAUSE TestSplitDomain/with_a_sub_domain
=== RUN   TestSplitDomain/with_a_sub_domain_in_a_zone
=== PAUSE TestSplitDomain/with_a_sub_domain_in_a_zone
=== RUN   TestSplitDomain/with_a_sub_sub_domain
=== PAUSE TestSplitDomain/with_a_sub_sub_domain
=== CONT  TestSplitDomain/domain_equals_zone
=== CONT  TestSplitDomain/with_a_sub_sub_domain
=== CONT  TestSplitDomain/with_a_sub_domain_in_a_zone
=== CONT  TestSplitDomain/with_a_sub_domain
--- PASS: TestSplitDomain (0.00s)
    --- PASS: TestSplitDomain/domain_equals_zone (0.00s)
    --- PASS: TestSplitDomain/with_a_sub_sub_domain (0.00s)
    --- PASS: TestSplitDomain/with_a_sub_domain_in_a_zone (0.00s)
    --- PASS: TestSplitDomain/with_a_sub_domain (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    iij_test.go:206: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    iij_test.go:219: skipping live test
PASS
coverage: 34.1% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/iij	(cached)	coverage: 34.1% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_password
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestLivePresentAndCleanup
--- SKIP: TestLivePresentAndCleanup (0.00s)
    inwx_test.go:118: skipping live test
PASS
coverage: 24.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/inwx	(cached)	coverage: 24.6% of statements
=== RUN   TestDNSProvider_login_api_key
=== RUN   TestDNSProvider_login_api_key/correct_key
=== RUN   TestDNSProvider_login_api_key/incorrect_key
=== RUN   TestDNSProvider_login_api_key/server_error
=== RUN   TestDNSProvider_login_api_key/non-ok_status_code
--- PASS: TestDNSProvider_login_api_key (0.00s)
    --- PASS: TestDNSProvider_login_api_key/correct_key (0.00s)
    --- PASS: TestDNSProvider_login_api_key/incorrect_key (0.00s)
    --- PASS: TestDNSProvider_login_api_key/server_error (0.00s)
    --- PASS: TestDNSProvider_login_api_key/non-ok_status_code (0.00s)
=== RUN   TestDNSProvider_login_username
=== RUN   TestDNSProvider_login_username/correct_username_and_password
=== RUN   TestDNSProvider_login_username/incorrect_username
=== RUN   TestDNSProvider_login_username/server_error
=== RUN   TestDNSProvider_login_username/non-ok_status_code
--- PASS: TestDNSProvider_login_username (0.00s)
    --- PASS: TestDNSProvider_login_username/correct_username_and_password (0.00s)
    --- PASS: TestDNSProvider_login_username/incorrect_username (0.00s)
    --- PASS: TestDNSProvider_login_username/server_error (0.00s)
    --- PASS: TestDNSProvider_login_username/non-ok_status_code (0.00s)
=== RUN   TestDNSProvider_logout
=== RUN   TestDNSProvider_logout/correct_auth-sid
=== RUN   TestDNSProvider_logout/incorrect_auth-sid
=== RUN   TestDNSProvider_logout/already_logged_out
=== RUN   TestDNSProvider_logout/server_error
--- PASS: TestDNSProvider_logout (0.00s)
    --- PASS: TestDNSProvider_logout/correct_auth-sid (0.00s)
    --- PASS: TestDNSProvider_logout/incorrect_auth-sid (0.00s)
    --- PASS: TestDNSProvider_logout/already_logged_out (0.00s)
    --- PASS: TestDNSProvider_logout/server_error (0.00s)
=== RUN   TestDNSProvider_getZone
=== RUN   TestDNSProvider_getZone/correct_auth-sid,_known_domain
=== RUN   TestDNSProvider_getZone/incorrect_auth-sid,_known_domain
=== RUN   TestDNSProvider_getZone/correct_auth-sid,_unknown_domain
=== RUN   TestDNSProvider_getZone/server_error
--- PASS: TestDNSProvider_getZone (0.00s)
    --- PASS: TestDNSProvider_getZone/correct_auth-sid,_known_domain (0.00s)
    --- PASS: TestDNSProvider_getZone/incorrect_auth-sid,_known_domain (0.00s)
    --- PASS: TestDNSProvider_getZone/correct_auth-sid,_unknown_domain (0.00s)
    --- PASS: TestDNSProvider_getZone/server_error (0.00s)
=== RUN   Test_parseResponse
=== RUN   Test_parseResponse/Empty_response
=== PAUSE Test_parseResponse/Empty_response
=== RUN   Test_parseResponse/No_headers,_just_body
=== PAUSE Test_parseResponse/No_headers,_just_body
=== RUN   Test_parseResponse/Headers_and_body
=== PAUSE Test_parseResponse/Headers_and_body
=== RUN   Test_parseResponse/Headers_and_body_+_Auth-Sid
=== PAUSE Test_parseResponse/Headers_and_body_+_Auth-Sid
=== RUN   Test_parseResponse/Headers_and_body_+_Status-Text
=== PAUSE Test_parseResponse/Headers_and_body_+_Status-Text
=== RUN   Test_parseResponse/Headers_and_body_+_Status-Code
=== PAUSE Test_parseResponse/Headers_and_body_+_Status-Code
=== CONT  Test_parseResponse/Empty_response
=== CONT  Test_parseResponse/Headers_and_body_+_Status-Code
=== CONT  Test_parseResponse/Headers_and_body_+_Status-Text
=== CONT  Test_parseResponse/Headers_and_body_+_Auth-Sid
=== CONT  Test_parseResponse/Headers_and_body
=== CONT  Test_parseResponse/No_headers,_just_body
--- PASS: Test_parseResponse (0.00s)
    --- PASS: Test_parseResponse/Empty_response (0.00s)
    --- PASS: Test_parseResponse/Headers_and_body_+_Status-Code (0.00s)
    --- PASS: Test_parseResponse/Headers_and_body_+_Status-Text (0.00s)
    --- PASS: Test_parseResponse/Headers_and_body_+_Auth-Sid (0.00s)
    --- PASS: Test_parseResponse/Headers_and_body (0.00s)
    --- PASS: Test_parseResponse/No_headers,_just_body (0.00s)
=== RUN   Test_removeTxtEntryFromZone
=== RUN   Test_removeTxtEntryFromZone/empty_zone
=== PAUSE Test_removeTxtEntryFromZone/empty_zone
=== RUN   Test_removeTxtEntryFromZone/zone_with_only_A_entry
=== PAUSE Test_removeTxtEntryFromZone/zone_with_only_A_entry
=== RUN   Test_removeTxtEntryFromZone/zone_with_only_clenup_entry
=== PAUSE Test_removeTxtEntryFromZone/zone_with_only_clenup_entry
=== RUN   Test_removeTxtEntryFromZone/zone_with_one_A_and_one_cleanup_entries
=== PAUSE Test_removeTxtEntryFromZone/zone_with_one_A_and_one_cleanup_entries
=== RUN   Test_removeTxtEntryFromZone/zone_with_one_A_and_multiple_cleanup_entries
=== PAUSE Test_removeTxtEntryFromZone/zone_with_one_A_and_multiple_cleanup_entries
=== CONT  Test_removeTxtEntryFromZone/empty_zone
=== CONT  Test_removeTxtEntryFromZone/zone_with_one_A_and_multiple_cleanup_entries
=== CONT  Test_removeTxtEntryFromZone/zone_with_one_A_and_one_cleanup_entries
=== CONT  Test_removeTxtEntryFromZone/zone_with_only_clenup_entry
=== CONT  Test_removeTxtEntryFromZone/zone_with_only_A_entry
--- PASS: Test_removeTxtEntryFromZone (0.00s)
    --- PASS: Test_removeTxtEntryFromZone/empty_zone (0.00s)
    --- PASS: Test_removeTxtEntryFromZone/zone_with_one_A_and_multiple_cleanup_entries (0.00s)
    --- PASS: Test_removeTxtEntryFromZone/zone_with_one_A_and_one_cleanup_entries (0.00s)
    --- PASS: Test_removeTxtEntryFromZone/zone_with_only_clenup_entry (0.00s)
    --- PASS: Test_removeTxtEntryFromZone/zone_with_only_A_entry (0.00s)
=== RUN   Test_addTxtEntryToZone
=== RUN   Test_addTxtEntryToZone/empty_zone
=== RUN   Test_addTxtEntryToZone/zone_with_A_entry
=== RUN   Test_addTxtEntryToZone/zone_with_required_cleanup_entry
--- PASS: Test_addTxtEntryToZone (0.00s)
    --- PASS: Test_addTxtEntryToZone/empty_zone (0.00s)
    --- PASS: Test_addTxtEntryToZone/zone_with_A_entry (0.00s)
    --- PASS: Test_addTxtEntryToZone/zone_with_required_cleanup_entry (0.00s)
=== RUN   Test_fixTxtLines
=== RUN   Test_fixTxtLines/clean-up
=== RUN   Test_fixTxtLines/already_cleaned
=== RUN   Test_fixTxtLines/special_DNS_entry
=== RUN   Test_fixTxtLines/SRV_entry
=== RUN   Test_fixTxtLines/MX_entry
--- PASS: Test_fixTxtLines (0.00s)
    --- PASS: Test_fixTxtLines/clean-up (0.00s)
    --- PASS: Test_fixTxtLines/already_cleaned (0.00s)
    --- PASS: Test_fixTxtLines/special_DNS_entry (0.00s)
    --- PASS: Test_fixTxtLines/SRV_entry (0.00s)
    --- PASS: Test_fixTxtLines/MX_entry (0.00s)
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success_API_key
=== RUN   TestNewDNSProvider/success_username_password
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_password
=== RUN   TestNewDNSProvider/missing_username
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success_API_key (0.00s)
    --- PASS: TestNewDNSProvider/success_username_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success_api_key
=== RUN   TestNewDNSProviderConfig/success_username_and_password
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_credentials:_username
=== RUN   TestNewDNSProviderConfig/missing_credentials:_password
=== RUN   TestNewDNSProviderConfig/Base_URL_should_ends_with_/
=== RUN   TestNewDNSProviderConfig/Base_URL_already_ends_with_/
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_username_and_password (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials:_username (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials:_password (0.00s)
    --- PASS: TestNewDNSProviderConfig/Base_URL_should_ends_with_/ (0.00s)
    --- PASS: TestNewDNSProviderConfig/Base_URL_already_ends_with_/ (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    joker_test.go:162: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    joker_test.go:175: skipping live test
PASS
coverage: 61.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/joker	(cached)	coverage: 61.6% of statements
=== RUN   TestLiveTTL
--- SKIP: TestLiveTTL (0.00s)
    lightsail_integration_test.go:14: skipping live test
=== RUN   TestCredentialsFromEnv
--- PASS: TestCredentialsFromEnv (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.11s)
PASS
coverage: 25.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/lightsail	(cached)	coverage: 25.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/success
=== RUN   TestDNSProvider_Present/NoDomain
=== RUN   TestDNSProvider_Present/CreateFailed
--- PASS: TestDNSProvider_Present (0.52s)
    --- PASS: TestDNSProvider_Present/success (0.31s)
    --- PASS: TestDNSProvider_Present/NoDomain (0.10s)
    --- PASS: TestDNSProvider_Present/CreateFailed (0.10s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/success
=== RUN   TestDNSProvider_CleanUp/NoDomain
=== RUN   TestDNSProvider_CleanUp/DeleteFailed
--- PASS: TestDNSProvider_CleanUp (0.30s)
    --- PASS: TestDNSProvider_CleanUp/success (0.10s)
    --- PASS: TestDNSProvider_CleanUp/NoDomain (0.10s)
    --- PASS: TestDNSProvider_CleanUp/DeleteFailed (0.10s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    linode_test.go:348: Skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    linode_test.go:355: Skipping live test
PASS
coverage: 81.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/linode	(cached)	coverage: 81.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/Success
=== RUN   TestDNSProvider_Present/NoDomain
=== RUN   TestDNSProvider_Present/CreateFailed
--- PASS: TestDNSProvider_Present (0.56s)
    --- PASS: TestDNSProvider_Present/Success (0.35s)
    --- PASS: TestDNSProvider_Present/NoDomain (0.10s)
    --- PASS: TestDNSProvider_Present/CreateFailed (0.10s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/Success
=== RUN   TestDNSProvider_CleanUp/NoDomain
=== RUN   TestDNSProvider_CleanUp/DeleteFailed
--- PASS: TestDNSProvider_CleanUp (0.30s)
    --- PASS: TestDNSProvider_CleanUp/Success (0.10s)
    --- PASS: TestDNSProvider_CleanUp/NoDomain (0.10s)
    --- PASS: TestDNSProvider_CleanUp/DeleteFailed (0.10s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    linodev4_test.go:345: Skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    linodev4_test.go:352: Skipping live test
PASS
coverage: 80.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/linodev4	(cached)	coverage: 80.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_password
=== RUN   TestNewDNSProvider/missing_zone
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_password (0.00s)
    --- PASS: TestNewDNSProvider/missing_zone (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_username
=== RUN   TestNewDNSProviderConfig/missing_password
=== RUN   TestNewDNSProviderConfig/missing_zone
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_password (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_zone (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.00s)
=== RUN   TestDNSProvider_CleanUp
--- PASS: TestDNSProvider_CleanUp (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    liquidweb_test.go:248: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    liquidweb_test.go:262: skipping live test
PASS
coverage: 85.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/liquidweb	(cached)	coverage: 85.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_email
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_email (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_email
=== RUN   TestNewDNSProviderConfig/missing_api_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_email (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    mydnsjp_test.go:121: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    mydnsjp_test.go:134: skipping live test
PASS
coverage: 25.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/mydnsjp	(cached)	coverage: 25.0% of statements
=== RUN   TestDNSProvider_getHosts
=== RUN   TestDNSProvider_getHosts/Test:Success:1
=== RUN   TestDNSProvider_getHosts/Test:Success:2
=== RUN   TestDNSProvider_getHosts/Test:Error:BadApiKey:1
--- PASS: TestDNSProvider_getHosts (0.02s)
    --- PASS: TestDNSProvider_getHosts/Test:Success:1 (0.00s)
    --- PASS: TestDNSProvider_getHosts/Test:Success:2 (0.02s)
    --- PASS: TestDNSProvider_getHosts/Test:Error:BadApiKey:1 (0.00s)
=== RUN   TestDNSProvider_setHosts
=== RUN   TestDNSProvider_setHosts/Test:Success:1
=== RUN   TestDNSProvider_setHosts/Test:Success:2
=== RUN   TestDNSProvider_setHosts/Test:Error:BadApiKey:1
--- PASS: TestDNSProvider_setHosts (0.00s)
    --- PASS: TestDNSProvider_setHosts/Test:Success:1 (0.00s)
    --- PASS: TestDNSProvider_setHosts/Test:Success:2 (0.00s)
    --- PASS: TestDNSProvider_setHosts/Test:Error:BadApiKey:1 (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/Test:Success:1
=== RUN   TestDNSProvider_Present/Test:Success:2
=== RUN   TestDNSProvider_Present/Test:Error:BadApiKey:1
--- PASS: TestDNSProvider_Present (0.00s)
    --- PASS: TestDNSProvider_Present/Test:Success:1 (0.00s)
    --- PASS: TestDNSProvider_Present/Test:Success:2 (0.00s)
    --- PASS: TestDNSProvider_Present/Test:Error:BadApiKey:1 (0.00s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/Test:Success:1
=== RUN   TestDNSProvider_CleanUp/Test:Success:2
=== RUN   TestDNSProvider_CleanUp/Test:Error:BadApiKey:1
--- PASS: TestDNSProvider_CleanUp (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Test:Success:1 (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Test:Success:2 (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Test:Error:BadApiKey:1 (0.00s)
=== RUN   TestDomainSplit
=== RUN   TestDomainSplit/a.b.c.test.co.uk
=== RUN   TestDomainSplit/test.co.uk
=== RUN   TestDomainSplit/test.com
=== RUN   TestDomainSplit/test.co.com
=== RUN   TestDomainSplit/www.test.com.au
=== RUN   TestDomainSplit/www.za.com
=== RUN   TestDomainSplit/#00
=== RUN   TestDomainSplit/a
=== RUN   TestDomainSplit/com
=== RUN   TestDomainSplit/co.com
=== RUN   TestDomainSplit/co.uk
=== RUN   TestDomainSplit/test.au
=== RUN   TestDomainSplit/za.com
=== RUN   TestDomainSplit/www.za
=== RUN   TestDomainSplit/www.test.au
=== RUN   TestDomainSplit/www.test.unk
--- PASS: TestDomainSplit (0.00s)
    --- PASS: TestDomainSplit/a.b.c.test.co.uk (0.00s)
    --- PASS: TestDomainSplit/test.co.uk (0.00s)
    --- PASS: TestDomainSplit/test.com (0.00s)
    --- PASS: TestDomainSplit/test.co.com (0.00s)
    --- PASS: TestDomainSplit/www.test.com.au (0.00s)
    --- PASS: TestDomainSplit/www.za.com (0.00s)
    --- PASS: TestDomainSplit/#00 (0.00s)
    --- PASS: TestDomainSplit/a (0.00s)
    --- PASS: TestDomainSplit/com (0.00s)
    --- PASS: TestDomainSplit/co.com (0.00s)
    --- PASS: TestDomainSplit/co.uk (0.00s)
    --- PASS: TestDomainSplit/test.au (0.00s)
    --- PASS: TestDomainSplit/za.com (0.00s)
    --- PASS: TestDomainSplit/www.za (0.00s)
    --- PASS: TestDomainSplit/www.test.au (0.00s)
    --- PASS: TestDomainSplit/www.test.unk (0.00s)
PASS
coverage: 66.7% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/namecheap	(cached)	coverage: 66.7% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_api_token
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_token (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_API_token
=== RUN   TestNewDNSProviderConfig/missing_username
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_API_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    namedotcom_test.go:128: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    namedotcom_test.go:141: skipping live test
PASS
coverage: 35.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/namedotcom	(cached)	coverage: 35.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_API_key
=== RUN   TestNewDNSProvider/unsupported_TTL
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_key (0.00s)
    --- PASS: TestNewDNSProvider/unsupported_TTL (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_API_key
=== RUN   TestNewDNSProviderConfig/unavailable_TTL
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_API_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/unavailable_TTL (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    namesilo_test.go:109: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    namesilo_test.go:123: skipping live test
PASS
coverage: 31.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/namesilo	(cached)	coverage: 31.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_customer_number
=== RUN   TestNewDNSProvider/missing_API_key
=== RUN   TestNewDNSProvider/missing_api_password
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_customer_number (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_password (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_customer
=== RUN   TestNewDNSProviderConfig/missing_key
=== RUN   TestNewDNSProviderConfig/missing_password
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_customer (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_password (0.00s)
=== RUN   TestLivePresentAndCleanup
--- SKIP: TestLivePresentAndCleanup (0.00s)
    netcup_test.go:155: skipping live test
PASS
coverage: 23.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/netcup	(cached)	coverage: 23.4% of statements
=== RUN   TestGetDNSRecordIdx
=== RUN   TestGetDNSRecordIdx/simple
=== PAUSE TestGetDNSRecordIdx/simple
=== RUN   TestGetDNSRecordIdx/wrong_Destination
=== PAUSE TestGetDNSRecordIdx/wrong_Destination
=== RUN   TestGetDNSRecordIdx/record_type_CNAME
=== PAUSE TestGetDNSRecordIdx/record_type_CNAME
=== CONT  TestGetDNSRecordIdx/simple
=== CONT  TestGetDNSRecordIdx/record_type_CNAME
=== CONT  TestGetDNSRecordIdx/wrong_Destination
--- PASS: TestGetDNSRecordIdx (0.00s)
    --- PASS: TestGetDNSRecordIdx/simple (0.00s)
    --- PASS: TestGetDNSRecordIdx/record_type_CNAME (0.00s)
    --- PASS: TestGetDNSRecordIdx/wrong_Destination (0.00s)
=== RUN   TestClient_Login
--- PASS: TestClient_Login (0.02s)
=== RUN   TestClient_Login_errors
=== RUN   TestClient_Login_errors/HTTP_error
=== PAUSE TestClient_Login_errors/HTTP_error
=== RUN   TestClient_Login_errors/API_error
=== PAUSE TestClient_Login_errors/API_error
=== RUN   TestClient_Login_errors/responsedata_marshaling_error
=== PAUSE TestClient_Login_errors/responsedata_marshaling_error
=== CONT  TestClient_Login_errors/HTTP_error
=== CONT  TestClient_Login_errors/responsedata_marshaling_error
=== CONT  TestClient_Login_errors/API_error
--- PASS: TestClient_Login_errors (0.00s)
    --- PASS: TestClient_Login_errors/HTTP_error (0.00s)
    --- PASS: TestClient_Login_errors/API_error (0.00s)
    --- PASS: TestClient_Login_errors/responsedata_marshaling_error (0.00s)
=== RUN   TestClient_Logout
--- PASS: TestClient_Logout (0.00s)
=== RUN   TestClient_Logout_errors
=== RUN   TestClient_Logout_errors/HTTP_error
=== PAUSE TestClient_Logout_errors/HTTP_error
=== RUN   TestClient_Logout_errors/API_error
=== PAUSE TestClient_Logout_errors/API_error
=== CONT  TestClient_Logout_errors/HTTP_error
=== CONT  TestClient_Logout_errors/API_error
--- PASS: TestClient_Logout_errors (0.00s)
    --- PASS: TestClient_Logout_errors/HTTP_error (0.00s)
    --- PASS: TestClient_Logout_errors/API_error (0.00s)
=== RUN   TestClient_GetDNSRecords
--- PASS: TestClient_GetDNSRecords (0.00s)
=== RUN   TestClient_GetDNSRecords_errors
=== RUN   TestClient_GetDNSRecords_errors/HTTP_error
=== PAUSE TestClient_GetDNSRecords_errors/HTTP_error
=== RUN   TestClient_GetDNSRecords_errors/API_error
=== PAUSE TestClient_GetDNSRecords_errors/API_error
=== RUN   TestClient_GetDNSRecords_errors/responsedata_marshaling_error
=== PAUSE TestClient_GetDNSRecords_errors/responsedata_marshaling_error
=== CONT  TestClient_GetDNSRecords_errors/HTTP_error
=== CONT  TestClient_GetDNSRecords_errors/responsedata_marshaling_error
=== CONT  TestClient_GetDNSRecords_errors/API_error
--- PASS: TestClient_GetDNSRecords_errors (0.00s)
    --- PASS: TestClient_GetDNSRecords_errors/HTTP_error (0.00s)
    --- PASS: TestClient_GetDNSRecords_errors/responsedata_marshaling_error (0.00s)
    --- PASS: TestClient_GetDNSRecords_errors/API_error (0.00s)
=== RUN   TestLiveClientAuth
--- SKIP: TestLiveClientAuth (0.00s)
    client_test.go:494: skipping live test
=== RUN   TestLiveClientGetDnsRecords
--- SKIP: TestLiveClientGetDnsRecords (0.00s)
    client_test.go:522: skipping live test
=== RUN   TestLiveClientUpdateDnsRecord
--- SKIP: TestLiveClientUpdateDnsRecord (0.00s)
    client_test.go:555: skipping live test
PASS
coverage: 79.5% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/netcup/internal	(cached)	coverage: 79.5% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_key
=== RUN   TestNewDNSProvider/missing_secret_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_secret_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_secret_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    nifcloud_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    nifcloud_test.go:139: skipping live test
PASS
coverage: 41.5% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/nifcloud	(cached)	coverage: 41.5% of statements
=== RUN   TestChangeResourceRecordSets
--- PASS: TestChangeResourceRecordSets (0.00s)
=== RUN   TestChangeResourceRecordSetsErrors
=== RUN   TestChangeResourceRecordSetsErrors/API_error
=== RUN   TestChangeResourceRecordSetsErrors/response_body_error
=== RUN   TestChangeResourceRecordSetsErrors/error_message_error
--- PASS: TestChangeResourceRecordSetsErrors (0.00s)
    --- PASS: TestChangeResourceRecordSetsErrors/API_error (0.00s)
    --- PASS: TestChangeResourceRecordSetsErrors/response_body_error (0.00s)
    --- PASS: TestChangeResourceRecordSetsErrors/error_message_error (0.00s)
=== RUN   TestGetChange
--- PASS: TestGetChange (0.00s)
=== RUN   TestGetChangeErrors
=== RUN   TestGetChangeErrors/API_error
=== RUN   TestGetChangeErrors/response_body_error
=== RUN   TestGetChangeErrors/error_message_error
--- PASS: TestGetChangeErrors (0.00s)
    --- PASS: TestGetChangeErrors/API_error (0.00s)
    --- PASS: TestGetChangeErrors/response_body_error (0.00s)
    --- PASS: TestGetChangeErrors/error_message_error (0.00s)
PASS
coverage: 82.2% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/nifcloud/internal	(cached)	coverage: 82.2% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   Test_getAuthZone
=== RUN   Test_getAuthZone/valid_fqdn
=== PAUSE Test_getAuthZone/valid_fqdn
=== RUN   Test_getAuthZone/invalid_fqdn
=== PAUSE Test_getAuthZone/invalid_fqdn
=== RUN   Test_getAuthZone/invalid_authority
=== PAUSE Test_getAuthZone/invalid_authority
=== CONT  Test_getAuthZone/valid_fqdn
=== CONT  Test_getAuthZone/invalid_authority
=== CONT  Test_getAuthZone/invalid_fqdn
--- PASS: Test_getAuthZone (0.00s)
    --- PASS: Test_getAuthZone/valid_fqdn (0.47s)
    --- PASS: Test_getAuthZone/invalid_authority (0.99s)
    --- PASS: Test_getAuthZone/invalid_fqdn (0.99s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    ns1_test.go:145: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    ns1_test.go:158: skipping live test
PASS
coverage: 28.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/ns1	(cached)	coverage: 28.6% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/success_file
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_CompartmentID
=== RUN   TestNewDNSProvider/missing_OCI_PRIVKEY
=== RUN   TestNewDNSProvider/missing_OCI_PRIVKEY_PASS
=== RUN   TestNewDNSProvider/missing_OCI_TENANCY_OCID
=== RUN   TestNewDNSProvider/missing_OCI_USER_OCID
=== RUN   TestNewDNSProvider/missing_OCI_PUBKEY_FINGERPRINT
=== RUN   TestNewDNSProvider/missing_OCI_REGION
=== RUN   TestNewDNSProvider/missing_OCI_REGION#01
--- PASS: TestNewDNSProvider (0.14s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/success_file (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_CompartmentID (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_PRIVKEY (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_PRIVKEY_PASS (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_TENANCY_OCID (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_USER_OCID (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_PUBKEY_FINGERPRINT (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_REGION (0.00s)
    --- PASS: TestNewDNSProvider/missing_OCI_REGION#01 (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/invalid_configuration
=== RUN   TestNewDNSProviderConfig/OCIConfigProvider_is_missing
=== RUN   TestNewDNSProviderConfig/missing_CompartmentID
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/invalid_configuration (0.00s)
    --- PASS: TestNewDNSProviderConfig/OCIConfigProvider_is_missing (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_CompartmentID (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    oraclecloud_test.go:244: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    oraclecloud_test.go:257: skipping live test
PASS
coverage: 54.9% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/oraclecloud	(cached)	coverage: 54.9% of statements
=== RUN   TestTestSuite
=== RUN   TestTestSuite/TestDNSProvider_CleanUp
=== RUN   TestTestSuite/TestDNSProvider_CleanUp_EmptyRecordset
=== RUN   TestTestSuite/TestDNSProvider_Present
=== RUN   TestTestSuite/TestDNSProvider_Present_EmptyZone
=== RUN   TestTestSuite/TestLogin
=== RUN   TestTestSuite/TestLoginEnv
=== RUN   TestTestSuite/TestLoginEnvEmpty
--- PASS: TestTestSuite (0.20s)
    --- PASS: TestTestSuite/TestDNSProvider_CleanUp (0.20s)
    --- PASS: TestTestSuite/TestDNSProvider_CleanUp_EmptyRecordset (0.00s)
    --- PASS: TestTestSuite/TestDNSProvider_Present (0.00s)
    --- PASS: TestTestSuite/TestDNSProvider_Present_EmptyZone (0.00s)
    --- PASS: TestTestSuite/TestLogin (0.00s)
    --- PASS: TestTestSuite/TestLoginEnv (0.00s)
    --- PASS: TestTestSuite/TestLoginEnvEmpty (0.00s)
PASS
coverage: 77.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/otc	(cached)	coverage: 77.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_endpoint
=== RUN   TestNewDNSProvider/missing_invalid_endpoint
=== RUN   TestNewDNSProvider/missing_application_key
=== RUN   TestNewDNSProvider/missing_application_secret
=== RUN   TestNewDNSProvider/missing_consumer_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_endpoint (0.00s)
    --- PASS: TestNewDNSProvider/missing_invalid_endpoint (0.00s)
    --- PASS: TestNewDNSProvider/missing_application_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_application_secret (0.00s)
    --- PASS: TestNewDNSProvider/missing_consumer_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_endpoint
=== RUN   TestNewDNSProviderConfig/missing_invalid_api_endpoint
=== RUN   TestNewDNSProviderConfig/missing_application_key
=== RUN   TestNewDNSProviderConfig/missing_application_secret
=== RUN   TestNewDNSProviderConfig/missing_consumer_key
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_endpoint (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_invalid_api_endpoint (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_application_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_application_secret (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_consumer_key (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    ovh_test.go:204: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    ovh_test.go:217: skipping live test
PASS
coverage: 27.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/ovh	(cached)	coverage: 27.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
2020/01/12 14:11:52 [WARN] pdns: failed to get API version unexpected HTTP status code 404 when fetching 'http://example.com/api'
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_api_key
=== RUN   TestNewDNSProvider/missing_API_URL
--- PASS: TestNewDNSProvider (0.29s)
    --- PASS: TestNewDNSProvider/success (0.29s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_URL (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
2020/01/12 14:11:53 [WARN] pdns: failed to get API version unexpected HTTP status code 404 when fetching 'http://example.com/api'
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_API_key
=== RUN   TestNewDNSProviderConfig/missing_host
--- PASS: TestNewDNSProviderConfig (0.25s)
    --- PASS: TestNewDNSProviderConfig/success (0.25s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_API_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_host (0.00s)
=== RUN   TestLivePresentAndCleanup
--- SKIP: TestLivePresentAndCleanup (0.00s)
    pdns_test.go:131: skipping live test
PASS
coverage: 27.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/pdns	(cached)	coverage: 27.0% of statements
=== RUN   TestNewDNSProviderConfig
--- PASS: TestNewDNSProviderConfig (0.00s)
=== RUN   TestNewDNSProviderConfig_MissingCredErr
--- PASS: TestNewDNSProviderConfig_MissingCredErr (0.00s)
=== RUN   TestDNSProvider_Present
--- PASS: TestDNSProvider_Present (0.22s)
=== RUN   TestDNSProvider_CleanUp
--- PASS: TestDNSProvider_CleanUp (0.00s)
=== RUN   TestLiveNewDNSProvider_ValidEnv
--- SKIP: TestLiveNewDNSProvider_ValidEnv (0.00s)
    rackspace_test.go:64: skipping live test
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    rackspace_test.go:76: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    rackspace_test.go:89: skipping live test
PASS
coverage: 68.2% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/rackspace	(cached)	coverage: 68.2% of statements
=== RUN   TestCanaryLocalTestServer
--- PASS: TestCanaryLocalTestServer (0.00s)
=== RUN   TestServerSuccess
--- PASS: TestServerSuccess (0.00s)
=== RUN   TestServerError
--- PASS: TestServerError (0.00s)
=== RUN   TestTsigClient
--- PASS: TestTsigClient (0.00s)
=== RUN   TestValidUpdatePacket
--- PASS: TestValidUpdatePacket (0.00s)
PASS
coverage: 55.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/rfc2136	(cached)	coverage: 55.0% of statements
=== RUN   TestLiveTTL
--- SKIP: TestLiveTTL (0.00s)
    route53_integration_test.go:14: skipping live test
=== RUN   Test_loadCredentials_FromEnv
--- PASS: Test_loadCredentials_FromEnv (0.00s)
=== RUN   Test_loadRegion_FromEnv
--- PASS: Test_loadRegion_FromEnv (0.00s)
=== RUN   Test_getHostedZoneID_FromEnv
--- PASS: Test_getHostedZoneID_FromEnv (0.00s)
=== RUN   TestNewDefaultConfig
=== RUN   TestNewDefaultConfig/default_configuration
=== RUN   TestNewDefaultConfig/#00
--- PASS: TestNewDefaultConfig (0.00s)
    --- PASS: TestNewDefaultConfig/default_configuration (0.00s)
    --- PASS: TestNewDefaultConfig/#00 (0.00s)
=== RUN   TestDNSProvider_Present
2020/01/12 14:11:53 [INFO] Wait for route53 [timeout: 2m0s, interval: 4s]
--- PASS: TestDNSProvider_Present (0.36s)
PASS
coverage: 60.6% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/route53	(cached)	coverage: 60.6% of statements
=== RUN   TestDNSProvider_addTXTRecord
--- PASS: TestDNSProvider_addTXTRecord (0.05s)
=== RUN   TestDNSProvider_cleanupTXTRecord
--- PASS: TestDNSProvider_cleanupTXTRecord (0.00s)
=== RUN   TestDNSProvider_addTXTRecord_concurrent
--- PASS: TestDNSProvider_addTXTRecord_concurrent (0.03s)
=== RUN   TestDNSProvider_cleanupTXTRecord_concurrent
--- PASS: TestDNSProvider_cleanupTXTRecord_concurrent (0.02s)
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_access_token
=== RUN   TestNewDNSProvider/missing_token_secret
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_access_token (0.00s)
    --- PASS: TestNewDNSProvider/missing_token_secret (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_token
=== RUN   TestNewDNSProviderConfig/missing_secret
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_secret (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    sakuracloud_test.go:126: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    sakuracloud_test.go:139: skipping live test
PASS
coverage: 77.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/sakuracloud	(cached)	coverage: 77.0% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/bad_TTL_value
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/bad_TTL_value (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    selectel_test.go:105: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    selectel_test.go:118: skipping live test
PASS
coverage: 35.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/selectel	(cached)	coverage: 35.0% of statements
?   	github.com/go-acme/lego/v3/providers/dns/selectel/internal	[no test files]
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_client_id
=== RUN   TestNewDNSProvider/missing_client_secret
=== RUN   TestNewDNSProvider/missing_stack_id
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_client_id (0.00s)
    --- PASS: TestNewDNSProvider/missing_client_secret (0.00s)
    --- PASS: TestNewDNSProvider/missing_stack_id (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/no_config
=== PAUSE TestNewDNSProviderConfig/no_config
=== RUN   TestNewDNSProviderConfig/no_client_id
=== PAUSE TestNewDNSProviderConfig/no_client_id
=== RUN   TestNewDNSProviderConfig/no_client_secret
=== PAUSE TestNewDNSProviderConfig/no_client_secret
=== RUN   TestNewDNSProviderConfig/no_stack_id
=== PAUSE TestNewDNSProviderConfig/no_stack_id
=== CONT  TestNewDNSProviderConfig/no_config
=== CONT  TestNewDNSProviderConfig/no_stack_id
=== CONT  TestNewDNSProviderConfig/no_client_secret
=== CONT  TestNewDNSProviderConfig/no_client_id
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/no_config (0.00s)
    --- PASS: TestNewDNSProviderConfig/no_stack_id (0.00s)
    --- PASS: TestNewDNSProviderConfig/no_client_secret (0.00s)
    --- PASS: TestNewDNSProviderConfig/no_client_id (0.00s)
=== RUN   TestDNSProvider_getZoneRecords
--- PASS: TestDNSProvider_getZoneRecords (0.00s)
=== RUN   TestDNSProvider_getZoneRecords_apiError
--- PASS: TestDNSProvider_getZoneRecords_apiError (0.00s)
=== RUN   TestDNSProvider_getZones
--- PASS: TestDNSProvider_getZones (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    stackpath_test.go:266: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    stackpath_test.go:279: skipping live test
PASS
coverage: 57.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/stackpath	(cached)	coverage: 57.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_all_credentials
=== RUN   TestNewDNSProvider/missing_account_name
=== RUN   TestNewDNSProvider/missing_private_key_path
=== RUN   TestNewDNSProvider/could_not_open_private_key_path
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_all_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_account_name (0.00s)
    --- PASS: TestNewDNSProvider/missing_private_key_path (0.00s)
    --- PASS: TestNewDNSProvider/could_not_open_private_key_path (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_all_credentials
=== RUN   TestNewDNSProviderConfig/missing_account_name
=== RUN   TestNewDNSProviderConfig/missing_private_key_path
=== RUN   TestNewDNSProviderConfig/could_not_open_private_key_path
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_all_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_account_name (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_private_key_path (0.00s)
    --- PASS: TestNewDNSProviderConfig/could_not_open_private_key_path (0.00s)
=== RUN   TestDNSProvider_concurrentGetInfo
2020/01/12 14:11:54 getInfo: []
2020/01/12 14:11:54 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:54 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:56 getInfo: [{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:56 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:56 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU} {Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:56 getInfo: [{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU} {Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:56 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:56 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:57 getInfo: [{Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:57 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:57 setDnsEntries dnsEntries: {Items:[]}
--- PASS: TestDNSProvider_concurrentGetInfo (4.00s)
=== RUN   TestDNSProvider_concurrentSetDNSEntries
2020/01/12 14:11:58 getInfo: []
2020/01/12 14:11:58 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:58 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:58 getInfo: [{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:58 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:58 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU} {Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:58 getInfo: [{Name:_acme-challenge.foo TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU} {Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:58 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:58 setDnsEntries dnsEntries: {Items:[{Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]}
2020/01/12 14:11:59 getInfo: [{Name:_acme-challenge.bar TTL:10 Type:TXT Content:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU}]
2020/01/12 14:11:59 setDnsEntries domainName: {DomainName:lego.wtf}
2020/01/12 14:11:59 setDnsEntries dnsEntries: {Items:[]}
--- PASS: TestDNSProvider_concurrentSetDNSEntries (1.05s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    transip_test.go:313: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    transip_test.go:326: skipping live test
PASS
coverage: 84.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/transip	(cached)	coverage: 84.0% of statements
=== RUN   TestNewDNSProvider_Fail
--- PASS: TestNewDNSProvider_Fail (0.00s)
=== RUN   TestDNSProvider_TimeoutSuccess
--- PASS: TestDNSProvider_TimeoutSuccess (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/Success
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 { 0 [{active example.com 1 0}]}
2020/01/12 14:11:54 Found zone: example.com
	Shortened to example.com
=== RUN   TestDNSProvider_Present/FailToFindZone
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 Unable to find hosted zone in vegadns
=== RUN   TestDNSProvider_Present/FailToCreateTXT
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 { 0 [{active example.com 1 0}]}
2020/01/12 14:11:54 Found zone: example.com
	Shortened to example.com
--- PASS: TestDNSProvider_Present (0.00s)
    --- PASS: TestDNSProvider_Present/Success (0.00s)
    --- PASS: TestDNSProvider_Present/FailToFindZone (0.00s)
    --- PASS: TestDNSProvider_Present/FailToCreateTXT (0.00s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/Success
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 { 0 [{active example.com 1 0}]}
2020/01/12 14:11:54 Found zone: example.com
	Shortened to example.com
=== RUN   TestDNSProvider_CleanUp/FailToFindZone
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 Unable to find hosted zone in vegadns
=== RUN   TestDNSProvider_CleanUp/FailToGetRecordID
2020/01/12 14:11:54 tmpHostname for i = 1: _acme-challenge.example.com
2020/01/12 14:11:54 tmpHostname for i = 2: example.com
2020/01/12 14:11:54 { 0 [{active example.com 1 0}]}
2020/01/12 14:11:54 Found zone: example.com
	Shortened to example.com
--- PASS: TestDNSProvider_CleanUp (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Success (0.00s)
    --- PASS: TestDNSProvider_CleanUp/FailToFindZone (0.00s)
    --- PASS: TestDNSProvider_CleanUp/FailToGetRecordID (0.00s)
PASS
coverage: 94.4% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/vegadns	(cached)	coverage: 94.4% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_token
=== RUN   TestNewDNSProvider/missing_key
=== RUN   TestNewDNSProvider/missing_credentials
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_token (0.00s)
    --- PASS: TestNewDNSProvider/missing_key (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/nil_config
=== RUN   TestNewDNSProviderConfig/missing_username
=== RUN   TestNewDNSProviderConfig/missing_password
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/nil_config (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_password (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/Success
=== RUN   TestDNSProvider_Present/FailToFindZone
=== RUN   TestDNSProvider_Present/FailToCreateTXT
--- PASS: TestDNSProvider_Present (0.21s)
    --- PASS: TestDNSProvider_Present/Success (0.20s)
    --- PASS: TestDNSProvider_Present/FailToFindZone (0.00s)
    --- PASS: TestDNSProvider_Present/FailToCreateTXT (0.01s)
=== RUN   TestDNSProvider_CleanUp
=== RUN   TestDNSProvider_CleanUp/Success
=== RUN   TestDNSProvider_CleanUp/FailToFindZone
--- PASS: TestDNSProvider_CleanUp (0.00s)
    --- PASS: TestDNSProvider_CleanUp/Success (0.00s)
    --- PASS: TestDNSProvider_CleanUp/FailToFindZone (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    versio_test.go:282: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    versio_test.go:295: skipping live test
PASS
coverage: 83.3% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/versio	(cached)	coverage: 83.3% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/bad_TTL_value
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/bad_TTL_value (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    vscale_test.go:105: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    vscale_test.go:118: skipping live test
PASS
coverage: 35.0% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/vscale	(cached)	coverage: 35.0% of statements
?   	github.com/go-acme/lego/v3/providers/dns/vscale/internal	[no test files]
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    vultr_test.go:93: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    vultr_test.go:106: skipping live test
PASS
coverage: 18.8% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/vultr	(cached)	coverage: 18.8% of statements
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_username
=== RUN   TestNewDNSProvider/missing_API_key
=== RUN   TestNewDNSProvider/invalid_URL
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_username (0.00s)
    --- PASS: TestNewDNSProvider/missing_API_key (0.00s)
    --- PASS: TestNewDNSProvider/invalid_URL (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_username
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_username (0.00s)
=== RUN   TestDNSProvider_Present
=== RUN   TestDNSProvider_Present/success
=== PAUSE TestDNSProvider_Present/success
=== RUN   TestDNSProvider_Present/invalid_auth
=== PAUSE TestDNSProvider_Present/invalid_auth
=== RUN   TestDNSProvider_Present/error
=== PAUSE TestDNSProvider_Present/error
=== CONT  TestDNSProvider_Present/success
=== CONT  TestDNSProvider_Present/error
=== CONT  TestDNSProvider_Present/invalid_auth
--- PASS: TestDNSProvider_Present (0.00s)
    --- PASS: TestDNSProvider_Present/invalid_auth (0.00s)
    --- PASS: TestDNSProvider_Present/error (0.00s)
    --- PASS: TestDNSProvider_Present/success (0.00s)
=== RUN   TestDNSProvider_Cleanup
=== RUN   TestDNSProvider_Cleanup/success
=== PAUSE TestDNSProvider_Cleanup/success
=== RUN   TestDNSProvider_Cleanup/no_txt_records
=== PAUSE TestDNSProvider_Cleanup/no_txt_records
=== RUN   TestDNSProvider_Cleanup/invalid_auth
=== PAUSE TestDNSProvider_Cleanup/invalid_auth
=== RUN   TestDNSProvider_Cleanup/error
=== PAUSE TestDNSProvider_Cleanup/error
=== CONT  TestDNSProvider_Cleanup/success
=== CONT  TestDNSProvider_Cleanup/error
=== CONT  TestDNSProvider_Cleanup/invalid_auth
=== CONT  TestDNSProvider_Cleanup/no_txt_records
--- PASS: TestDNSProvider_Cleanup (0.00s)
    --- PASS: TestDNSProvider_Cleanup/invalid_auth (0.00s)
    --- PASS: TestDNSProvider_Cleanup/error (0.00s)
    --- PASS: TestDNSProvider_Cleanup/no_txt_records (0.00s)
    --- PASS: TestDNSProvider_Cleanup/success (0.00s)
=== RUN   TestLivePresent
--- SKIP: TestLivePresent (0.00s)
    zoneee_test.go:296: skipping live test
=== RUN   TestLiveCleanUp
--- SKIP: TestLiveCleanUp (0.00s)
    zoneee_test.go:309: skipping live test
PASS
coverage: 84.5% of statements
ok  	github.com/go-acme/lego/v3/providers/dns/zoneee	(cached)	coverage: 84.5% of statements
=== RUN   TestNewMemcachedProviderEmpty
--- PASS: TestNewMemcachedProviderEmpty (0.00s)
=== RUN   TestNewMemcachedProviderValid
--- SKIP: TestNewMemcachedProviderValid (0.00s)
    memcached_test.go:39: Skipping memcached tests
=== RUN   TestMemcachedPresentSingleHost
--- SKIP: TestMemcachedPresentSingleHost (0.00s)
    memcached_test.go:47: Skipping memcached tests
=== RUN   TestMemcachedPresentMultiHost
--- SKIP: TestMemcachedPresentMultiHost (0.00s)
    memcached_test.go:65: Skipping memcached multi-host tests
=== RUN   TestMemcachedPresentPartialFailureMultiHost
--- SKIP: TestMemcachedPresentPartialFailureMultiHost (0.00s)
    memcached_test.go:85: Skipping memcached tests
=== RUN   TestMemcachedCleanup
--- SKIP: TestMemcachedCleanup (0.00s)
    memcached_test.go:106: Skipping memcached tests
PASS
coverage: 12.5% of statements
ok  	github.com/go-acme/lego/v3/providers/http/memcached	(cached)	coverage: 12.5% of statements
=== RUN   TestHTTPProvider
--- PASS: TestHTTPProvider (0.00s)
PASS
coverage: 75.0% of statements
ok  	github.com/go-acme/lego/v3/providers/http/webroot	(cached)	coverage: 75.0% of statements
=== RUN   TestRegistrar_ResolveAccountByKey
2020/01/12 14:20:27 [INFO] acme: Trying to resolve account by key
--- FAIL: TestRegistrar_ResolveAccountByKey (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6da655]

goroutine 7 [running]:
testing.tRunner.func1(0xc0000f4100)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:874 +0x3a3
panic(0x768040, 0xa8e8a0)
	/home/ldez/.gvm/gos/go1.13.6/src/runtime/panic.go:679 +0x1b2
time.(*Timer).Stop(...)
	/home/ldez/.gvm/gos/go1.13.6/src/time/sleep.go:74
github.com/cenkalti/backoff/v3.(*defaultTimer).Stop(0xc000112048)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/timer.go:32 +0x25
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer.func1(0x859d60, 0xc000112048)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:45 +0x31
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc000233958, 0x7f9dc45b0068, 0xc0001d81c0, 0x0, 0x859d60, 0xc000112048, 0x0, 0x0)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:53 +0x34d
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/home/ldez/sources/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.2.1/retry.go:25
github.com/go-acme/lego/v3/acme/api.(*Core).retrievablePost(0xc000252000, 0xc0001c80a0, 0x1e, 0xc0001c8240, 0x1b, 0x20, 0x73b4a0, 0xc0001dc240, 0xc0000e7a98, 0xc0001dc2a0, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:107 +0x210
github.com/go-acme/lego/v3/acme/api.(*Core).post(0xc000252000, 0xc0001c80a0, 0x1e, 0x7ac540, 0xc0001dc2a0, 0x73b4a0, 0xc0001dc240, 0xc0000e7ae0, 0x48b837, 0xc0000760c0)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/api.go:70 +0xf5
github.com/go-acme/lego/v3/acme/api.(*AccountService).New(0xc0002520c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, ...)
	/home/ldez/sources/go/src/github.com/go-acme/lego/acme/api/account.go:16 +0x150
github.com/go-acme/lego/v3/registration.(*Registrar).ResolveAccountByKey(0xc000233f28, 0xc0000e7f40, 0x85a1e0, 0xc0001d8100)
	/home/ldez/sources/go/src/github.com/go-acme/lego/registration/registar.go:159 +0x116
github.com/go-acme/lego/v3/registration.TestRegistrar_ResolveAccountByKey(0xc0000f4100)
	/home/ldez/sources/go/src/github.com/go-acme/lego/registration/registar_test.go:52 +0x3ac
testing.tRunner(0xc0000f4100, 0x7f3740)
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/home/ldez/.gvm/gos/go1.13.6/src/testing/testing.go:960 +0x350
FAIL	github.com/go-acme/lego/v3/registration	0.016s
FAIL
```

</details>
