### PR TITLE
designate: Don't clean up managed records like SOA and NS

### DIFF
--- a/providers/dns/designate/designate.go
+++ b/providers/dns/designate/designate.go
@@ -240,7 +240,7 @@ func (d *DNSProvider) getRecord(zoneID string, wanted string) (*recordsets.Recor
 	}
 
 	for _, record := range allRecords {
-		if record.Name == wanted {
+		if record.Name == wanted && record.Type == "TXT" {
 			return &record, nil
 		}
 	}


### PR DESCRIPTION
The Designate plugin tries to clean up managed recordsets like SOA and NS.
In most Designate installations this is not allowed.