### PR TITLE
Add "LEGO_PATH" environment variable

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -50,9 +50,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Usage: "(deprecated) Filename of the generated certificate.",
 		},
 		cli.StringFlag{
-			Name:  "path",
-			Usage: "Directory to use for storing the data.",
-			Value: defaultPath,
+			Name:   "path",
+			EnvVar: "LEGO_PATH",
+			Usage:  "Directory to use for storing the data.",
+			Value:  defaultPath,
 		},
 		cli.BoolFlag{
 			Name:  "http",

--- a/cmd/lego/main.go
+++ b/cmd/lego/main.go
@@ -29,20 +29,19 @@ func main() {
 		fmt.Printf("lego version %s %s/%s\n", c.App.Version, runtime.GOOS, runtime.GOARCH)
 	}
 
-	defaultPath := os.Getenv("LEGOPATH")
-	if defaultPath == "" {
-		cwd, err := os.Getwd()
-		if err == nil {
-			defaultPath = filepath.Join(cwd, ".lego")
-		}
+	var defaultPath string
+	cwd, err := os.Getwd()
+	if err == nil {
+		defaultPath = filepath.Join(cwd, ".lego")
 	}
+
 	app.Flags = cmd.CreateFlags(defaultPath)
 
 	app.Before = cmd.Before
 
 	app.Commands = cmd.CreateCommands()
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/lego/main.go
+++ b/cmd/lego/main.go
@@ -29,10 +29,12 @@ func main() {
 		fmt.Printf("lego version %s %s/%s\n", c.App.Version, runtime.GOOS, runtime.GOARCH)
 	}
 
-	defaultPath := ""
-	cwd, err := os.Getwd()
-	if err == nil {
-		defaultPath = filepath.Join(cwd, ".lego")
+	defaultPath := os.Getenv("LEGOPATH")
+	if defaultPath == "" {
+		cwd, err := os.Getwd()
+		if err == nil {
+			defaultPath = filepath.Join(cwd, ".lego")
+		}
 	}
 	app.Flags = cmd.CreateFlags(defaultPath)
 
@@ -40,7 +42,7 @@ func main() {
 
 	app.Commands = cmd.CreateCommands()
 
-	err = app.Run(os.Args)
+	err := app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Similar to [`CADDYPATH` in Caddy](https://caddyserver.com/v1/docs/cli) I think that lego should have an environment variable that allows setting the default path. This feature is especially useful in containers.