### PR TITLE
route53: allow custom client to be provided

### DIFF
--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/platform/config/env"
 	"github.com/go-acme/lego/v3/platform/wait"
@@ -26,7 +25,7 @@ type Config struct {
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
 	HostedZoneID       string
-	Client             route53iface.Route53API
+	Client             *route53.Route53
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider
@@ -42,7 +41,7 @@ func NewDefaultConfig() *Config {
 
 // DNSProvider implements the challenge.Provider interface
 type DNSProvider struct {
-	client route53iface.Route53API
+	client *route53.Route53
 	config *Config
 }
 

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -87,20 +87,20 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("route53: the configuration of the Route53 DNS provider is nil")
 	}
 
-	cl := config.Client
-	if cl == nil {
-		retry := customRetryer{}
-		retry.NumMaxRetries = config.MaxRetries
-		sessionCfg := request.WithRetryer(aws.NewConfig(), retry)
-
-		sess, err := session.NewSessionWithOptions(session.Options{Config: *sessionCfg})
-		if err != nil {
-			return nil, err
-		}
-
-		cl = route53.New(sess)
+	if config.Client != nil {
+		return &DNSProvider{client: config.Client, config: config}, nil
 	}
-	
+
+	retry := customRetryer{}
+	retry.NumMaxRetries = config.MaxRetries
+	sessionCfg := request.WithRetryer(aws.NewConfig(), retry)
+
+	sess, err := session.NewSessionWithOptions(session.Options{Config: *sessionCfg})
+	if err != nil {
+		return nil, err
+	}
+
+	cl := route53.New(sess)
 	return &DNSProvider{client: cl, config: config}, nil
 }
 


### PR DESCRIPTION
This allows custom profiles, assumed roles, etc without modifying environment variables. Also instrumentation, custom proxies, etc.

Let me know if you want any changes made to suit project style, etc. Happy to make changes as desired!