### PR TITLE
zoneee: fix subdomains.

### DIFF
--- a/providers/dns/zoneee/client.go
+++ b/providers/dns/zoneee/client.go
@@ -92,7 +92,6 @@ func (d *DNSProvider) getHostedZone(domain string) (string, error) {
 	return zoneName, nil
 }
 
-
 func (d *DNSProvider) makeRequest(method, resource string, body io.Reader) (*http.Request, error) {
 	uri, err := d.config.Endpoint.Parse(resource)
 	if err != nil {

--- a/providers/dns/zoneee/client.go
+++ b/providers/dns/zoneee/client.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
-
-	"github.com/go-acme/lego/v3/challenge/dns01"
 )
 
 const defaultEndpoint = "https://api.zone.eu/v2/dns/"
@@ -35,12 +33,7 @@ func (d *DNSProvider) addTxtRecord(domain string, record txtRecord) ([]txtRecord
 		return nil, err
 	}
 
-	zoneName, err := d.getHostedZone(domain)
-	if err != nil {
-		return nil, fmt.Errorf("zoneee: %v", err)
-	}
-
-	req, err := d.makeRequest(http.MethodPost, path.Join(zoneName, "txt"), reqBody)
+	req, err := d.makeRequest(http.MethodPost, path.Join(domain, "txt"), reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -53,11 +46,7 @@ func (d *DNSProvider) addTxtRecord(domain string, record txtRecord) ([]txtRecord
 }
 
 func (d *DNSProvider) getTxtRecords(domain string) ([]txtRecord, error) {
-	zoneName, err := d.getHostedZone(domain)
-	if err != nil {
-		return nil, fmt.Errorf("zoneee: %v", err)
-	}
-	req, err := d.makeRequest(http.MethodGet, path.Join(zoneName, "txt"), nil)
+	req, err := d.makeRequest(http.MethodGet, path.Join(domain, "txt"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,26 +59,12 @@ func (d *DNSProvider) getTxtRecords(domain string) ([]txtRecord, error) {
 }
 
 func (d *DNSProvider) removeTxtRecord(domain, id string) error {
-	zoneName, err := d.getHostedZone(domain)
-	if err != nil {
-		return fmt.Errorf("zoneee: %v", err)
-	}
-	req, err := d.makeRequest(http.MethodDelete, path.Join(zoneName, "txt", id), nil)
+	req, err := d.makeRequest(http.MethodDelete, path.Join(domain, "txt", id), nil)
 	if err != nil {
 		return err
 	}
 
 	return d.sendRequest(req, nil)
-}
-
-func (d *DNSProvider) getHostedZone(domain string) (string, error) {
-	authZone, err := dns01.FindZoneByFqdn(dns01.ToFqdn(domain))
-	if err != nil {
-		return "", err
-	}
-
-	zoneName := dns01.UnFqdn(authZone)
-	return zoneName, nil
 }
 
 func (d *DNSProvider) makeRequest(method, resource string, body io.Reader) (*http.Request, error) {

--- a/providers/dns/zoneee/zoneee_test.go
+++ b/providers/dns/zoneee/zoneee_test.go
@@ -138,7 +138,8 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestDNSProvider_Present(t *testing.T) {
-	domain := "prefix.example.com"
+	hostedZone := "example.com"
+	domain := "prefix." + hostedZone
 
 	testCases := []struct {
 		desc          string
@@ -152,7 +153,10 @@ func TestDNSProvider_Present(t *testing.T) {
 			username: "bar",
 			apiKey:   "foo",
 			handlers: map[string]http.HandlerFunc{
-				"/" + domain + "/txt": mockHandlerCreateRecord,
+				"/": http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					fmt.Println(req.URL)
+				}),
+				"/" + hostedZone + "/txt": mockHandlerCreateRecord,
 			},
 		},
 		{
@@ -160,7 +164,7 @@ func TestDNSProvider_Present(t *testing.T) {
 			username: "nope",
 			apiKey:   "foo",
 			handlers: map[string]http.HandlerFunc{
-				"/" + domain + "/txt": mockHandlerCreateRecord,
+				"/" + hostedZone + "/txt": mockHandlerCreateRecord,
 			},
 			expectedError: "zoneee: status code=401: Unauthorized\n",
 		},
@@ -203,7 +207,8 @@ func TestDNSProvider_Present(t *testing.T) {
 }
 
 func TestDNSProvider_Cleanup(t *testing.T) {
-	domain := "prefix.example.com"
+	hostedZone := "example.com"
+	domain := "prefix." + hostedZone
 
 	testCases := []struct {
 		desc          string
@@ -217,14 +222,14 @@ func TestDNSProvider_Cleanup(t *testing.T) {
 			username: "bar",
 			apiKey:   "foo",
 			handlers: map[string]http.HandlerFunc{
-				"/" + domain + "/txt": mockHandlerGetRecords([]txtRecord{{
+				"/" + hostedZone + "/txt": mockHandlerGetRecords([]txtRecord{{
 					ID:          "1234",
 					Name:        domain,
 					Destination: "LHDhK3oGRvkiefQnx7OOczTY5Tic_xZ6HcMOc_gmtoM",
 					Delete:      true,
 					Modify:      true,
 				}}),
-				"/" + domain + "/txt/1234": mockHandlerDeleteRecord,
+				"/" + hostedZone + "/txt/1234": mockHandlerDeleteRecord,
 			},
 		},
 		{
@@ -232,8 +237,8 @@ func TestDNSProvider_Cleanup(t *testing.T) {
 			username: "bar",
 			apiKey:   "foo",
 			handlers: map[string]http.HandlerFunc{
-				"/" + domain + "/txt":      mockHandlerGetRecords([]txtRecord{}),
-				"/" + domain + "/txt/1234": mockHandlerDeleteRecord,
+				"/" + hostedZone + "/txt":      mockHandlerGetRecords([]txtRecord{}),
+				"/" + hostedZone + "/txt/1234": mockHandlerDeleteRecord,
 			},
 			expectedError: "zoneee: txt record does not exist for LHDhK3oGRvkiefQnx7OOczTY5Tic_xZ6HcMOc_gmtoM",
 		},
@@ -242,14 +247,14 @@ func TestDNSProvider_Cleanup(t *testing.T) {
 			username: "nope",
 			apiKey:   "foo",
 			handlers: map[string]http.HandlerFunc{
-				"/" + domain + "/txt": mockHandlerGetRecords([]txtRecord{{
+				"/" + hostedZone + "/txt": mockHandlerGetRecords([]txtRecord{{
 					ID:          "1234",
 					Name:        domain,
 					Destination: "LHDhK3oGRvkiefQnx7OOczTY5Tic_xZ6HcMOc_gmtoM",
 					Delete:      true,
 					Modify:      true,
 				}}),
-				"/" + domain + "/txt/1234": mockHandlerDeleteRecord,
+				"/" + hostedZone + "/txt/1234": mockHandlerDeleteRecord,
 			},
 			expectedError: "zoneee: status code=401: Unauthorized\n",
 		},


### PR DESCRIPTION
The zoneeee dns provider fails with any kind of subdomain, due to the API being based on the zone name rather than the subdomain. 

I put together a simple patch to fix this based on work from other providers.