### PR TITLE
dnsproviders: Implement NewConfigFromEnv()

### DIFF
--- a/providers/dns/cloudflare/cloudflare_test.go
+++ b/providers/dns/cloudflare/cloudflare_test.go
@@ -42,31 +42,6 @@ func TestNewDNSProvider(t *testing.T) {
 				"CLOUDFLARE_ZONE_API_TOKEN": "abcdef012345",
 			},
 		},
-		{
-			desc: "missing credentials",
-			envVars: map[string]string{
-				"CLOUDFLARE_EMAIL":         "",
-				"CLOUDFLARE_API_KEY":       "",
-				"CLOUDFLARE_DNS_API_TOKEN": "",
-			},
-			expected: "cloudflare: some credentials information are missing: CLOUDFLARE_EMAIL,CLOUDFLARE_API_KEY or some credentials information are missing: CLOUDFLARE_DNS_API_TOKEN,CLOUDFLARE_ZONE_API_TOKEN",
-		},
-		{
-			desc: "missing email",
-			envVars: map[string]string{
-				"CLOUDFLARE_EMAIL":   "",
-				"CLOUDFLARE_API_KEY": "key",
-			},
-			expected: "cloudflare: some credentials information are missing: CLOUDFLARE_EMAIL or some credentials information are missing: CLOUDFLARE_DNS_API_TOKEN,CLOUDFLARE_ZONE_API_TOKEN",
-		},
-		{
-			desc: "missing api key",
-			envVars: map[string]string{
-				"CLOUDFLARE_EMAIL":   "awesome@possum.com",
-				"CLOUDFLARE_API_KEY": "",
-			},
-			expected: "cloudflare: some credentials information are missing: CLOUDFLARE_API_KEY or some credentials information are missing: CLOUDFLARE_DNS_API_TOKEN,CLOUDFLARE_ZONE_API_TOKEN",
-		},
 	}
 
 	for _, test := range testCases {
@@ -128,15 +103,6 @@ func TestNewDNSProviderWithToken(t *testing.T) {
 				dnsToken:   "123",
 				zoneToken:  "123",
 				sameClient: true,
-			},
-		},
-		{
-			desc: "failure when only zone api given",
-			envVars: map[string]string{
-				"CLOUDFLARE_ZONE_API_TOKEN": "123",
-			},
-			expected: expected{
-				error: "cloudflare: some credentials information are missing: CLOUDFLARE_EMAIL,CLOUDFLARE_API_KEY or some credentials information are missing: CLOUDFLARE_DNS_API_TOKEN",
 			},
 		},
 		{

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -22,6 +22,13 @@ type Config struct {
 	HTTPClient         *http.Client
 }
 
+// NewConfigFromEnv returns a new config that is populated from environment variables.
+func NewConfigFromEnv() *Config {
+	config := NewDefaultConfig()
+	config.AuthToken = env.GetOrFile("DO_AUTH_TOKEN")
+	return config
+}
+
 // NewDefaultConfig returns a default configuration for the DNSProvider
 func NewDefaultConfig() *Config {
 	return &Config{
@@ -47,15 +54,7 @@ type DNSProvider struct {
 // Ocean. Credentials must be passed in the environment variable:
 // DO_AUTH_TOKEN.
 func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get("DO_AUTH_TOKEN")
-	if err != nil {
-		return nil, fmt.Errorf("digitalocean: %v", err)
-	}
-
-	config := NewDefaultConfig()
-	config.AuthToken = values["DO_AUTH_TOKEN"]
-
-	return NewDNSProviderConfig(config)
+	return NewDNSProviderConfig(NewConfigFromEnv())
 }
 
 // NewDNSProviderConfig return a DNSProvider instance configured for Digital Ocean.

--- a/providers/dns/digitalocean/digitalocean_test.go
+++ b/providers/dns/digitalocean/digitalocean_test.go
@@ -42,13 +42,6 @@ func TestNewDNSProvider(t *testing.T) {
 				"DO_AUTH_TOKEN": "123",
 			},
 		},
-		{
-			desc: "missing credentials",
-			envVars: map[string]string{
-				"DO_AUTH_TOKEN": "",
-			},
-			expected: "digitalocean: some credentials information are missing: DO_AUTH_TOKEN",
-		},
 	}
 
 	for _, test := range testCases {

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -24,6 +24,14 @@ type Config struct {
 	TTL                int
 }
 
+// NewConfigFromEnv returns a new config that is populated from environment variables.
+func NewConfigFromEnv() *Config {
+	config := NewDefaultConfig()
+	config.AccessToken = env.GetOrFile("DNSIMPLE_OAUTH_TOKEN")
+	config.BaseURL = env.GetOrFile("DNSIMPLE_BASE_URL")
+	return config
+}
+
 // NewDefaultConfig returns a default configuration for the DNSProvider
 func NewDefaultConfig() *Config {
 	return &Config{
@@ -44,11 +52,7 @@ type DNSProvider struct {
 //
 // See: https://developer.dnsimple.com/v2/#authentication
 func NewDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
-	config.AccessToken = env.GetOrFile("DNSIMPLE_OAUTH_TOKEN")
-	config.BaseURL = env.GetOrFile("DNSIMPLE_BASE_URL")
-
-	return NewDNSProviderConfig(config)
+	return NewDNSProviderConfig(NewConfigFromEnv())
 }
 
 // NewDNSProviderConfig return a DNSProvider instance configured for DNSimple.


### PR DESCRIPTION
This allows getting a config populated from env variables.
Without this, the only way to do this is to copy/duplicate all the env var logic.

`NewConfigFromEnv()` treats env variables as optional defaults.
Since the config struct is returned, its values can still be set/changed/read by the caller, which is immensely useful during application setup/config.

In practice, this allows us to keep credentials out of config files, while still being able to configure other elements of the DNS provider in code without relying on global env vars (which we can't do in Caddy 2, since we don't really have much/any global state -- so using a global value would lead to incorrect results).

Fixes #1054

I am just starting out with a few providers of my choice, but I am sure there will be more to follow!