### PR TITLE
Add a LEGO_NAMESERVER environment variable to set DNS servers during development

### DIFF
--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -3,6 +3,7 @@ package dns01
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -71,6 +72,12 @@ func AddRecursiveNameservers(nameservers []string) ChallengeOption {
 
 // getNameservers attempts to get systems nameservers before falling back to the defaults
 func getNameservers(path string, defaults []string) []string {
+	// The LEGO_NAMESERVER environment variable can be used to use a specific
+	// nameserver for testing purpose.
+	if server := os.Getenv("LEGO_NAMESERVER"); server != "" {
+		return []string{server}
+	}
+
 	config, err := dns.ClientConfigFromFile(path)
 	if err != nil || len(config.Servers) == 0 {
 		return defaults
@@ -95,6 +102,9 @@ func ParseNameservers(servers []string) []string {
 // lookupNameservers returns the authoritative nameservers for the given fqdn.
 func lookupNameservers(fqdn string) ([]string, error) {
 	var authoritativeNss []string
+	if server := os.Getenv("LEGO_NAMESERVER"); server != "" {
+		return []string{server}, nil
+	}
 
 	zone, err := FindZoneByFqdn(fqdn)
 	if err != nil {

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -95,7 +95,11 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 // checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
 func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, error) {
 	for _, ns := range nameservers {
-		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{net.JoinHostPort(ns, "53")}, false)
+		// If the address has a port, use it, otherwise default to 53
+		if _, _, err := net.SplitHostPort(ns); err != nil {
+			ns = net.JoinHostPort(ns, "53")
+		}
+		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{ns}, false)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
I'm using this to test https://github.com/remilapeyre/vault-acme.