### PR TITLE
Wrap errors.

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -31,12 +31,12 @@ func (a *AccountService) New(req acme.Account) (acme.ExtendedAccount, error) {
 func (a *AccountService) NewEAB(accMsg acme.Account, kid string, hmacEncoded string) (acme.ExtendedAccount, error) {
 	hmac, err := base64.RawURLEncoding.DecodeString(hmacEncoded)
 	if err != nil {
-		return acme.ExtendedAccount{}, fmt.Errorf("acme: could not decode hmac key: %v", err)
+		return acme.ExtendedAccount{}, fmt.Errorf("acme: could not decode hmac key: %w", err)
 	}
 
 	eabJWS, err := a.core.signEABContent(a.core.GetDirectory().NewAccountURL, kid, hmac)
 	if err != nil {
-		return acme.ExtendedAccount{}, fmt.Errorf("acme: error signing eab content: %v", err)
+		return acme.ExtendedAccount{}, fmt.Errorf("acme: error signing eab content: %w", err)
 	}
 	accMsg.ExternalAccountBinding = eabJWS
 

--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -118,7 +118,7 @@ func (a *Core) retrievablePost(uri string, content []byte, response interface{})
 func (a *Core) signedPost(uri string, content []byte, response interface{}) (*http.Response, error) {
 	signedContent, err := a.jws.SignContent(uri, content)
 	if err != nil {
-		return nil, fmt.Errorf("failed to post JWS message -> failed to sign content -> %v", err)
+		return nil, fmt.Errorf("failed to post JWS message -> failed to sign content -> %w", err)
 	}
 
 	signedBody := bytes.NewBuffer([]byte(signedContent.FullSerialize()))
@@ -155,7 +155,7 @@ func (a *Core) GetDirectory() acme.Directory {
 func getDirectory(do *sender.Doer, caDirURL string) (acme.Directory, error) {
 	var dir acme.Directory
 	if _, err := do.Get(caDirURL, &dir); err != nil {
-		return dir, fmt.Errorf("get directory at '%s': %v", caDirURL, err)
+		return dir, fmt.Errorf("get directory at '%s': %w", caDirURL, err)
 	}
 
 	if dir.NewAccountURL == "" {

--- a/acme/api/internal/nonces/nonce_manager.go
+++ b/acme/api/internal/nonces/nonce_manager.go
@@ -57,7 +57,7 @@ func (n *Manager) Nonce() (string, error) {
 func (n *Manager) getNonce() (string, error) {
 	resp, err := n.do.Head(n.nonceURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce from HTTP HEAD -> %v", err)
+		return "", fmt.Errorf("failed to get nonce from HTTP HEAD -> %w", err)
 	}
 
 	return GetFromResponse(resp)
@@ -71,7 +71,7 @@ func GetFromResponse(resp *http.Response) (string, error) {
 
 	nonce := resp.Header.Get("Replay-Nonce")
 	if nonce == "" {
-		return "", fmt.Errorf("server did not respond with a proper nonce header")
+		return "", errors.New("server did not respond with a proper nonce header")
 	}
 
 	return nonce, nil

--- a/acme/api/internal/secure/jws.go
+++ b/acme/api/internal/secure/jws.go
@@ -65,12 +65,12 @@ func (j *JWS) SignContent(url string, content []byte) (*jose.JSONWebSignature, e
 
 	signer, err := jose.NewSigner(signKey, &options)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create jose signer -> %v", err)
+		return nil, fmt.Errorf("failed to create jose signer -> %w", err)
 	}
 
 	signed, err := signer.Sign(content)
 	if err != nil {
-		return nil, fmt.Errorf("failed to sign content -> %v", err)
+		return nil, fmt.Errorf("failed to sign content -> %w", err)
 	}
 	return signed, nil
 }
@@ -80,7 +80,7 @@ func (j *JWS) SignEABContent(url, kid string, hmac []byte) (*jose.JSONWebSignatu
 	jwk := jose.JSONWebKey{Key: j.privKey}
 	jwkJSON, err := jwk.Public().MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("acme: error encoding eab jwk key: %v", err)
+		return nil, fmt.Errorf("acme: error encoding eab jwk key: %w", err)
 	}
 
 	signer, err := jose.NewSigner(
@@ -94,12 +94,12 @@ func (j *JWS) SignEABContent(url, kid string, hmac []byte) (*jose.JSONWebSignatu
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create External Account Binding jose signer -> %v", err)
+		return nil, fmt.Errorf("failed to create External Account Binding jose signer -> %w", err)
 	}
 
 	signed, err := signer.Sign(jwkJSON)
 	if err != nil {
-		return nil, fmt.Errorf("failed to External Account Binding sign content -> %v", err)
+		return nil, fmt.Errorf("failed to External Account Binding sign content -> %w", err)
 	}
 
 	return signed, nil

--- a/acme/api/internal/sender/sender.go
+++ b/acme/api/internal/sender/sender.go
@@ -70,7 +70,7 @@ func (d *Doer) Post(url string, body io.Reader, bodyType string, response interf
 func (d *Doer) newRequest(method, uri string, body io.Reader, opts ...RequestOption) (*http.Request, error) {
 	req, err := http.NewRequest(method, uri, body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("User-Agent", d.formatUserAgent())
@@ -78,7 +78,7 @@ func (d *Doer) newRequest(method, uri string, body io.Reader, opts ...RequestOpt
 	for _, opt := range opts {
 		err = opt(req)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %v", err)
+			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (d *Doer) do(req *http.Request, response interface{}) (*http.Response, erro
 
 		err = json.Unmarshal(raw, response)
 		if err != nil {
-			return resp, fmt.Errorf("failed to unmarshal %q to type %T: %v", raw, response, err)
+			return resp, fmt.Errorf("failed to unmarshal %q to type %T: %w", raw, response, err)
 		}
 	}
 
@@ -122,13 +122,13 @@ func checkError(req *http.Request, resp *http.Response) error {
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("%d :: %s :: %s :: %v", resp.StatusCode, req.Method, req.URL, err)
+			return fmt.Errorf("%d :: %s :: %s :: %w", resp.StatusCode, req.Method, req.URL, err)
 		}
 
 		var errorDetails *acme.ProblemDetails
 		err = json.Unmarshal(body, &errorDetails)
 		if err != nil {
-			return fmt.Errorf("%d ::%s :: %s :: %v :: %s", resp.StatusCode, req.Method, req.URL, err, string(body))
+			return fmt.Errorf("%d ::%s :: %s :: %w :: %s", resp.StatusCode, req.Method, req.URL, err, string(body))
 		}
 
 		errorDetails.Method = req.Method

--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -167,7 +167,7 @@ func PEMBlock(data interface{}) *pem.Block {
 func pemDecode(data []byte) (*pem.Block, error) {
 	pemBlock, _ := pem.Decode(data)
 	if pemBlock == nil {
-		return nil, fmt.Errorf("PEM decode did not yield a valid block. Is the certificate in the right format?")
+		return nil, errors.New("PEM decode did not yield a valid block. Is the certificate in the right format?")
 	}
 
 	return pemBlock, nil
@@ -180,7 +180,7 @@ func PemDecodeTox509CSR(pem []byte) (*x509.CertificateRequest, error) {
 	}
 
 	if pemBlock.Type != "CERTIFICATE REQUEST" {
-		return nil, fmt.Errorf("PEM block is not a certificate request")
+		return nil, errors.New("PEM block is not a certificate request")
 	}
 
 	return x509.ParseCertificateRequest(pemBlock.Bytes)

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -317,7 +317,7 @@ func (c *Certifier) Revoke(cert []byte) error {
 
 	x509Cert := certificates[0]
 	if x509Cert.IsCA {
-		return fmt.Errorf("certificate bundle starts with a CA certificate")
+		return errors.New("certificate bundle starts with a CA certificate")
 	}
 
 	revokeMsg := acme.RevokeCertMessage{

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -93,7 +93,7 @@ func (c *Challenge) PreSolve(authz acme.Authorization) error {
 
 	err = c.provider.Present(authz.Identifier.Value, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] acme: error presenting token: %s", domain, err)
+		return fmt.Errorf("[%s] acme: error presenting token: %w", domain, err)
 	}
 
 	return nil

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -1,6 +1,7 @@
 package dns01
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -98,7 +99,7 @@ func lookupNameservers(fqdn string) ([]string, error) {
 
 	zone, err := FindZoneByFqdn(fqdn)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine the zone: %v", err)
+		return nil, fmt.Errorf("could not determine the zone: %w", err)
 	}
 
 	r, err := dnsQuery(zone, dns.TypeNS, recursiveNameservers, true)
@@ -115,7 +116,7 @@ func lookupNameservers(fqdn string) ([]string, error) {
 	if len(authoritativeNss) > 0 {
 		return authoritativeNss, nil
 	}
-	return nil, fmt.Errorf("could not determine authoritative nameservers")
+	return nil, errors.New("could not determine authoritative nameservers")
 }
 
 // FindPrimaryNsByFqdn determines the primary nameserver of the zone apex for the given fqdn

--- a/challenge/http01/http_challenge.go
+++ b/challenge/http01/http_challenge.go
@@ -51,7 +51,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 	err = c.provider.Present(authz.Identifier.Value, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] acme: error presenting token: %v", domain, err)
+		return fmt.Errorf("[%s] acme: error presenting token: %w", domain, err)
 	}
 	defer func() {
 		err := c.provider.CleanUp(authz.Identifier.Value, chlng.Token, keyAuth)

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -37,7 +37,7 @@ func (s *ProviderServer) Present(domain, token, keyAuth string) error {
 	var err error
 	s.listener, err = net.Listen("tcp", s.GetAddress())
 	if err != nil {
-		return fmt.Errorf("could not start HTTP server for challenge -> %v", err)
+		return fmt.Errorf("could not start HTTP server for challenge -> %w", err)
 	}
 
 	s.done = make(chan bool)

--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -79,7 +79,7 @@ func (c *SolverManager) chooseSolver(authz acme.Authorization) solver {
 func validate(core *api.Core, domain string, chlg acme.Challenge) error {
 	chlng, err := core.Challenges.New(chlg.URL)
 	if err != nil {
-		return fmt.Errorf("failed to initiate challenge: %v", err)
+		return fmt.Errorf("failed to initiate challenge: %w", err)
 	}
 
 	valid, err := checkChallengeStatus(chlng)

--- a/challenge/tlsalpn01/tls_alpn_challenge.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge.go
@@ -57,7 +57,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 	err = c.provider.Present(domain, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] acme: error presenting token: %v", challenge.GetTargetedDomain(authz), err)
+		return fmt.Errorf("[%s] acme: error presenting token: %w", challenge.GetTargetedDomain(authz), err)
 	}
 	defer func() {
 		err := c.provider.CleanUp(domain, chlng.Token, keyAuth)

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -66,7 +66,7 @@ func (s *ProviderServer) Present(domain, token, keyAuth string) error {
 	// Create the listener with the created tls.Config.
 	s.listener, err = tls.Listen("tcp", s.GetAddress(), tlsConf)
 	if err != nil {
-		return fmt.Errorf("could not start HTTPS server for challenge -> %v", err)
+		return fmt.Errorf("could not start HTTPS server for challenge -> %w", err)
 	}
 
 	// Shut the server down when we're finished.

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1480,7 +1480,7 @@ func displayDNSHelp(name string) error {
 	}
 
 	if ew.err != nil {
-		return fmt.Errorf("error: %v", ew.err)
+		return fmt.Errorf("error: %w", ew.err)
 	}
 
 	return w.Flush()

--- a/e2e/loader/loader.go
+++ b/e2e/loader/loader.go
@@ -288,7 +288,7 @@ func goTool() (string, error) {
 
 	goBin, err := exec.LookPath("go" + exeSuffix)
 	if err != nil {
-		return "", fmt.Errorf("cannot find go tool: %v", err)
+		return "", fmt.Errorf("cannot find go tool: %w", err)
 	}
 
 	return goBin, nil

--- a/internal/dnsdocs/dns.go.tmpl
+++ b/internal/dnsdocs/dns.go.tmpl
@@ -56,7 +56,7 @@ func displayDNSHelp(name string) error {
 	}
 
 	if ew.err != nil {
-		return fmt.Errorf("error: %v", ew.err)
+		return fmt.Errorf("error: %w", ew.err)
 	}
 
 	return w.Flush()

--- a/platform/wait/wait.go
+++ b/platform/wait/wait.go
@@ -11,12 +11,12 @@ import (
 func For(msg string, timeout, interval time.Duration, f func() (bool, error)) error {
 	log.Infof("Wait for %s [timeout: %s, interval: %s]", msg, timeout, interval)
 
-	var lastErr string
+	var lastErr error
 	timeUp := time.After(timeout)
 	for {
 		select {
 		case <-timeUp:
-			return fmt.Errorf("time limit exceeded: last error: %s", lastErr)
+			return fmt.Errorf("time limit exceeded: last error: %w", lastErr)
 		default:
 		}
 
@@ -25,7 +25,7 @@ func For(msg string, timeout, interval time.Duration, f func() (bool, error)) er
 			return nil
 		}
 		if err != nil {
-			lastErr = err.Error()
+			lastErr = err
 		}
 
 		time.Sleep(interval)

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -45,7 +45,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(apiBaseEnvVar, storagePathEnvVar)
 	if err != nil {
-		return nil, fmt.Errorf("acme-dns: %v", err)
+		return nil, fmt.Errorf("acme-dns: %w", err)
 	}
 
 	client := goacmedns.NewClient(values[apiBaseEnvVar])

--- a/providers/dns/alidns/alidns.go
+++ b/providers/dns/alidns/alidns.go
@@ -49,7 +49,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("ALICLOUD_ACCESS_KEY", "ALICLOUD_SECRET_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("alicloud: %v", err)
+		return nil, fmt.Errorf("alicloud: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -79,7 +79,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := alidns.NewClientWithOptions(config.RegionID, conf, credential)
 	if err != nil {
-		return nil, fmt.Errorf("alicloud: credentials failed: %v", err)
+		return nil, fmt.Errorf("alicloud: credentials failed: %w", err)
 	}
 
 	return &DNSProvider{config: config, client: client}, nil
@@ -97,14 +97,14 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zoneName, err := d.getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("alicloud: %v", err)
+		return fmt.Errorf("alicloud: %w", err)
 	}
 
 	recordAttributes := d.newTxtRecord(zoneName, fqdn, value)
 
 	_, err = d.client.AddDomainRecord(recordAttributes)
 	if err != nil {
-		return fmt.Errorf("alicloud: API call failed: %v", err)
+		return fmt.Errorf("alicloud: API call failed: %w", err)
 	}
 	return nil
 }
@@ -115,12 +115,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	records, err := d.findTxtRecords(domain, fqdn)
 	if err != nil {
-		return fmt.Errorf("alicloud: %v", err)
+		return fmt.Errorf("alicloud: %w", err)
 	}
 
 	_, err = d.getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("alicloud: %v", err)
+		return fmt.Errorf("alicloud: %w", err)
 	}
 
 	for _, rec := range records {
@@ -128,7 +128,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		request.RecordId = rec.RecordId
 		_, err = d.client.DeleteDomainRecord(request)
 		if err != nil {
-			return fmt.Errorf("alicloud: %v", err)
+			return fmt.Errorf("alicloud: %w", err)
 		}
 	}
 	return nil
@@ -145,7 +145,7 @@ func (d *DNSProvider) getHostedZone(domain string) (string, error) {
 
 		response, err := d.client.DescribeDomains(request)
 		if err != nil {
-			return "", fmt.Errorf("API call failed: %v", err)
+			return "", fmt.Errorf("API call failed: %w", err)
 		}
 
 		domains = append(domains, response.Domains.Domain...)
@@ -200,7 +200,7 @@ func (d *DNSProvider) findTxtRecords(domain, fqdn string) ([]alidns.Record, erro
 
 	result, err := d.client.DescribeDomainRecords(request)
 	if err != nil {
-		return records, fmt.Errorf("API call has failed: %v", err)
+		return records, fmt.Errorf("API call has failed: %w", err)
 	}
 
 	recordName := d.extractRecordName(fqdn, zoneName)

--- a/providers/dns/autodns/autodns.go
+++ b/providers/dns/autodns/autodns.go
@@ -1,6 +1,7 @@
 package autodns
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -63,7 +64,7 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(envAPIUser, envAPIPassword)
 	if err != nil {
-		return nil, fmt.Errorf("autodns: %v", err)
+		return nil, fmt.Errorf("autodns: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -75,15 +76,15 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config == nil {
-		return nil, fmt.Errorf("autodns: config is nil")
+		return nil, errors.New("autodns: config is nil")
 	}
 
 	if config.Username == "" {
-		return nil, fmt.Errorf("autodns: missing user")
+		return nil, errors.New("autodns: missing user")
 	}
 
 	if config.Password == "" {
-		return nil, fmt.Errorf("autodns: missing password")
+		return nil, errors.New("autodns: missing password")
 	}
 
 	return &DNSProvider{config: config}, nil
@@ -102,7 +103,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, err := d.addTxtRecord(domain, records)
 	if err != nil {
-		return fmt.Errorf("autodns: %v", err)
+		return fmt.Errorf("autodns: %w", err)
 	}
 
 	return nil
@@ -120,7 +121,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}}
 
 	if err := d.removeTXTRecord(domain, records); err != nil {
-		return fmt.Errorf("autodns: %v", err)
+		return fmt.Errorf("autodns: %w", err)
 	}
 
 	return nil

--- a/providers/dns/autodns/client.go
+++ b/providers/dns/autodns/client.go
@@ -139,7 +139,7 @@ func (d *DNSProvider) sendRequest(req *http.Request, result interface{}) error {
 
 	err = json.Unmarshal(raw, result)
 	if err != nil {
-		return fmt.Errorf("unmarshaling %T error [status code=%d]: %v: %s", result, resp.StatusCode, err, string(raw))
+		return fmt.Errorf("unmarshaling %T error [status code=%d]: %w: %s", result, resp.StatusCode, err, string(raw))
 	}
 	return err
 }
@@ -157,7 +157,7 @@ func checkResponse(resp *http.Response) error {
 
 	raw, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("unable to read body: status code=%d, error=%v", resp.StatusCode, err)
+		return fmt.Errorf("unable to read body: status code=%d, error=%w", resp.StatusCode, err)
 	}
 
 	return fmt.Errorf("status code=%d: %s", resp.StatusCode, string(raw))

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -89,7 +89,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config.SubscriptionID == "" {
 		subsID, err := getMetadata(config, "subscriptionId")
 		if err != nil {
-			return nil, fmt.Errorf("azure: %v", err)
+			return nil, fmt.Errorf("azure: %w", err)
 		}
 
 		if subsID == "" {
@@ -101,7 +101,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config.ResourceGroup == "" {
 		resGroup, err := getMetadata(config, "resourceGroupName")
 		if err != nil {
-			return nil, fmt.Errorf("azure: %v", err)
+			return nil, fmt.Errorf("azure: %w", err)
 		}
 
 		if resGroup == "" {
@@ -126,7 +126,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return fmt.Errorf("azure: %v", err)
+		return fmt.Errorf("azure: %w", err)
 	}
 
 	rsc := dns.NewRecordSetsClient(d.config.SubscriptionID)
@@ -139,7 +139,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	if err != nil {
 		detailedError, ok := err.(autorest.DetailedError)
 		if !ok || detailedError.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("azure: %v", err)
+			return fmt.Errorf("azure: %w", err)
 		}
 	}
 
@@ -169,7 +169,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, err = rsc.CreateOrUpdate(ctx, d.config.ResourceGroup, zone, relative, dns.TXT, rec, "", "")
 	if err != nil {
-		return fmt.Errorf("azure: %v", err)
+		return fmt.Errorf("azure: %w", err)
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return fmt.Errorf("azure: %v", err)
+		return fmt.Errorf("azure: %w", err)
 	}
 
 	relative := toRelativeRecord(fqdn, dns01.ToFqdn(zone))
@@ -190,7 +190,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	_, err = rsc.Delete(ctx, d.config.ResourceGroup, zone, relative, dns.TXT, "")
 	if err != nil {
-		return fmt.Errorf("azure: %v", err)
+		return fmt.Errorf("azure: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/bindman/bindman.go
+++ b/providers/dns/bindman/bindman.go
@@ -43,7 +43,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("BINDMAN_MANAGER_ADDRESS")
 	if err != nil {
-		return nil, fmt.Errorf("bindman: %v", err)
+		return nil, fmt.Errorf("bindman: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -59,12 +59,12 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.BaseURL == "" {
-		return nil, fmt.Errorf("bindman: bindman manager address missing")
+		return nil, errors.New("bindman: bindman manager address missing")
 	}
 
 	bClient, err := client.New(config.BaseURL, config.HTTPClient)
 	if err != nil {
-		return nil, fmt.Errorf("bindman: %v", err)
+		return nil, fmt.Errorf("bindman: %w", err)
 	}
 
 	return &DNSProvider{config: config, client: bClient}, nil
@@ -77,7 +77,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
 
 	if err := d.client.AddRecord(fqdn, "TXT", value); err != nil {
-		return fmt.Errorf("bindman: %v", err)
+		return fmt.Errorf("bindman: %w", err)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _ := dns01.GetRecord(domain, keyAuth)
 
 	if err := d.client.RemoveRecord(fqdn, "TXT"); err != nil {
-		return fmt.Errorf("bindman: %v", err)
+		return fmt.Errorf("bindman: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/bluecat/bluecat.go
+++ b/providers/dns/bluecat/bluecat.go
@@ -61,7 +61,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("BLUECAT_SERVER_URL", "BLUECAT_USER_NAME", "BLUECAT_PASSWORD", "BLUECAT_CONFIG_NAME", "BLUECAT_DNS_VIEW")
 	if err != nil {
-		return nil, fmt.Errorf("bluecat: %v", err)
+		return nil, fmt.Errorf("bluecat: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -81,7 +81,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.BaseURL == "" || config.UserName == "" || config.Password == "" || config.ConfigName == "" || config.DNSView == "" {
-		return nil, fmt.Errorf("bluecat: credentials missing")
+		return nil, errors.New("bluecat: credentials missing")
 	}
 
 	return &DNSProvider{config: config}, nil
@@ -174,7 +174,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	var txtRec entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&txtRec)
 	if err != nil {
-		return fmt.Errorf("bluecat: %v", err)
+		return fmt.Errorf("bluecat: %w", err)
 	}
 	queryArgs = map[string]string{
 		"objectId": strconv.FormatUint(uint64(txtRec.ID), 10),

--- a/providers/dns/bluecat/client.go
+++ b/providers/dns/bluecat/client.go
@@ -42,7 +42,7 @@ func (d *DNSProvider) login() error {
 
 	authBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("bluecat: %v", err)
+		return fmt.Errorf("bluecat: %w", err)
 	}
 	authResp := string(authBytes)
 
@@ -106,7 +106,7 @@ func (d *DNSProvider) lookupConfID() (uint, error) {
 	var conf entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&conf)
 	if err != nil {
-		return 0, fmt.Errorf("bluecat: %v", err)
+		return 0, fmt.Errorf("bluecat: %w", err)
 	}
 	return conf.ID, nil
 }
@@ -133,7 +133,7 @@ func (d *DNSProvider) lookupViewID(viewName string) (uint, error) {
 	var view entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&view)
 	if err != nil {
-		return 0, fmt.Errorf("bluecat: %v", err)
+		return 0, fmt.Errorf("bluecat: %w", err)
 	}
 
 	return view.ID, nil
@@ -187,7 +187,7 @@ func (d *DNSProvider) getZone(parentID uint, name string) (uint, error) {
 	var zone entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&zone)
 	if err != nil {
-		return 0, fmt.Errorf("bluecat: %v", err)
+		return 0, fmt.Errorf("bluecat: %w", err)
 	}
 
 	return zone.ID, nil
@@ -215,12 +215,12 @@ func (d *DNSProvider) sendRequest(method, resource string, payload interface{}, 
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("bluecat: %v", err)
+		return nil, fmt.Errorf("bluecat: %w", err)
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("bluecat: %v", err)
+		return nil, fmt.Errorf("bluecat: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if len(d.token) > 0 {
@@ -235,7 +235,7 @@ func (d *DNSProvider) sendRequest(method, resource string, payload interface{}, 
 	req.URL.RawQuery = q.Encode()
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("bluecat: %v", err)
+		return nil, fmt.Errorf("bluecat: %w", err)
 	}
 
 	if resp.StatusCode >= 400 {

--- a/providers/dns/checkdomain/checkdomain.go
+++ b/providers/dns/checkdomain/checkdomain.go
@@ -1,6 +1,7 @@
 package checkdomain
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -59,7 +60,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(envToken)
 	if err != nil {
-		return nil, fmt.Errorf("checkdomain: %v", err)
+		return nil, fmt.Errorf("checkdomain: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -67,7 +68,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 	endpoint, err := url.Parse(env.GetOrDefaultString(envEndpoint, defaultEndpoint))
 	if err != nil {
-		return nil, fmt.Errorf("checkdomain: invalid %s: %v", envEndpoint, err)
+		return nil, fmt.Errorf("checkdomain: invalid %s: %w", envEndpoint, err)
 	}
 	config.Endpoint = endpoint
 
@@ -76,11 +77,11 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config.Endpoint == nil {
-		return nil, fmt.Errorf("checkdomain: invalid endpoint")
+		return nil, errors.New("checkdomain: invalid endpoint")
 	}
 
 	if config.Token == "" {
-		return nil, fmt.Errorf("checkdomain: missing token")
+		return nil, errors.New("checkdomain: missing token")
 	}
 
 	if config.HTTPClient == nil {
@@ -97,12 +98,12 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	domainID, err := d.getDomainIDByName(domain)
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	err = d.checkNameservers(domainID)
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	name, value := dns01.GetRecord(domain, keyAuth)
@@ -115,7 +116,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	return nil
@@ -125,19 +126,19 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	domainID, err := d.getDomainIDByName(domain)
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	err = d.checkNameservers(domainID)
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	name, value := dns01.GetRecord(domain, keyAuth)
 
 	err = d.deleteTXTRecord(domainID, name, value)
 	if err != nil {
-		return fmt.Errorf("checkdomain: %v", err)
+		return fmt.Errorf("checkdomain: %w", err)
 	}
 
 	d.domainIDMu.Lock()

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -102,7 +102,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := newClient(config)
 	if err != nil {
-		return nil, fmt.Errorf("cloudflare: %v", err)
+		return nil, fmt.Errorf("cloudflare: %w", err)
 	}
 
 	return &DNSProvider{
@@ -124,12 +124,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("cloudflare: %v", err)
+		return fmt.Errorf("cloudflare: %w", err)
 	}
 
 	zoneID, err := d.client.ZoneIDByName(authZone)
 	if err != nil {
-		return fmt.Errorf("cloudflare: failed to find zone %s: %v", authZone, err)
+		return fmt.Errorf("cloudflare: failed to find zone %s: %w", authZone, err)
 	}
 
 	dnsRecord := cloudflare.DNSRecord{
@@ -141,7 +141,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	response, err := d.client.CreateDNSRecord(zoneID, dnsRecord)
 	if err != nil {
-		return fmt.Errorf("cloudflare: failed to create TXT record: %v", err)
+		return fmt.Errorf("cloudflare: failed to create TXT record: %w", err)
 	}
 
 	if !response.Success {
@@ -163,12 +163,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("cloudflare: %v", err)
+		return fmt.Errorf("cloudflare: %w", err)
 	}
 
 	zoneID, err := d.client.ZoneIDByName(authZone)
 	if err != nil {
-		return fmt.Errorf("cloudflare: failed to find zone %s: %v", authZone, err)
+		return fmt.Errorf("cloudflare: failed to find zone %s: %w", authZone, err)
 	}
 
 	// get the record's unique ID from when we created it
@@ -181,7 +181,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.client.DeleteDNSRecord(zoneID, recordID)
 	if err != nil {
-		log.Printf("cloudflare: failed to delete TXT record: %v", err)
+		log.Printf("cloudflare: failed to delete TXT record: %w", err)
 	}
 
 	// Delete record ID from map

--- a/providers/dns/cloudns/cloudns.go
+++ b/providers/dns/cloudns/cloudns.go
@@ -46,7 +46,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("CLOUDNS_AUTH_ID", "CLOUDNS_AUTH_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("ClouDNS: %v", err)
+		return nil, fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -64,7 +64,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := internal.NewClient(config.AuthID, config.AuthPassword)
 	if err != nil {
-		return nil, fmt.Errorf("ClouDNS: %v", err)
+		return nil, fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	client.HTTPClient = config.HTTPClient
@@ -78,12 +78,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zone, err := d.client.GetZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("ClouDNS: %v", err)
+		return fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	err = d.client.AddTxtRecord(zone.Name, fqdn, value, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("ClouDNS: %v", err)
+		return fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	return nil
@@ -95,12 +95,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := d.client.GetZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("ClouDNS: %v", err)
+		return fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	record, err := d.client.FindTxtRecord(zone.Name, fqdn)
 	if err != nil {
-		return fmt.Errorf("ClouDNS: %v", err)
+		return fmt.Errorf("ClouDNS: %w", err)
 	}
 
 	if record == nil {
@@ -109,7 +109,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.client.RemoveTxtRecord(record.ID, zone.Name)
 	if err != nil {
-		return fmt.Errorf("ClouDNS: %v", err)
+		return fmt.Errorf("ClouDNS: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/cloudns/internal/client.go
+++ b/providers/dns/cloudns/internal/client.go
@@ -43,11 +43,11 @@ type TXTRecords map[string]TXTRecord
 // NewClient creates a ClouDNS client
 func NewClient(authID string, authPassword string) (*Client, error) {
 	if authID == "" {
-		return nil, fmt.Errorf("credentials missing: authID")
+		return nil, errors.New("credentials missing: authID")
 	}
 
 	if authPassword == "" {
-		return nil, fmt.Errorf("credentials missing: authPassword")
+		return nil, errors.New("credentials missing: authPassword")
 	}
 
 	baseURL, err := url.Parse(defaultBaseURL)
@@ -96,7 +96,7 @@ func (c *Client) GetZone(authFQDN string) (*Zone, error) {
 
 	if len(result) > 0 {
 		if err = json.Unmarshal(result, &zone); err != nil {
-			return nil, fmt.Errorf("zone unmarshaling error: %v", err)
+			return nil, fmt.Errorf("zone unmarshaling error: %w", err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func (c *Client) FindTxtRecord(zoneName, fqdn string) (*TXTRecord, error) {
 
 	var records TXTRecords
 	if err = json.Unmarshal(result, &records); err != nil {
-		return nil, fmt.Errorf("TXT record unmarshaling error: %v: %s", err, string(result))
+		return nil, fmt.Errorf("TXT record unmarshaling error: %w: %s", err, string(result))
 	}
 
 	for _, record := range records {
@@ -166,7 +166,7 @@ func (c *Client) AddTxtRecord(zoneName string, fqdn, value string, ttl int) erro
 
 	resp := apiResponse{}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return fmt.Errorf("apiResponse unmarshaling error: %v: %s", err, string(raw))
+		return fmt.Errorf("apiResponse unmarshaling error: %w: %s", err, string(raw))
 	}
 
 	if resp.Status != "Success" {
@@ -193,7 +193,7 @@ func (c *Client) RemoveTxtRecord(recordID int, zoneName string) error {
 
 	resp := apiResponse{}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return fmt.Errorf("apiResponse unmarshaling error: %v: %s", err, string(raw))
+		return fmt.Errorf("apiResponse unmarshaling error: %w: %s", err, string(raw))
 	}
 
 	if resp.Status != "Success" {
@@ -235,7 +235,7 @@ func (c *Client) buildRequest(method string, url *url.URL) (*http.Request, error
 
 	req, err := http.NewRequest(method, url.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("invalid request: %v", err)
+		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
 	return req, nil

--- a/providers/dns/cloudxns/cloudxns.go
+++ b/providers/dns/cloudxns/cloudxns.go
@@ -46,7 +46,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("CLOUDXNS_API_KEY", "CLOUDXNS_SECRET_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("CloudXNS: %v", err)
+		return nil, fmt.Errorf("CloudXNS: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/conoha/conoha.go
+++ b/providers/dns/conoha/conoha.go
@@ -48,7 +48,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("CONOHA_TENANT_ID", "CONOHA_API_USERNAME", "CONOHA_API_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("conoha: %v", err)
+		return nil, fmt.Errorf("conoha: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -79,7 +79,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := internal.NewClient(config.Region, auth, config.HTTPClient)
 	if err != nil {
-		return nil, fmt.Errorf("conoha: failed to create client: %v", err)
+		return nil, fmt.Errorf("conoha: failed to create client: %w", err)
 	}
 
 	return &DNSProvider{config: config, client: client}, nil
@@ -96,7 +96,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	id, err := d.client.GetDomainID(authZone)
 	if err != nil {
-		return fmt.Errorf("conoha: failed to get domain ID: %v", err)
+		return fmt.Errorf("conoha: failed to get domain ID: %w", err)
 	}
 
 	record := internal.Record{
@@ -108,7 +108,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err = d.client.CreateRecord(id, record)
 	if err != nil {
-		return fmt.Errorf("conoha: failed to create record: %v", err)
+		return fmt.Errorf("conoha: failed to create record: %w", err)
 	}
 
 	return nil
@@ -125,17 +125,17 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	domID, err := d.client.GetDomainID(authZone)
 	if err != nil {
-		return fmt.Errorf("conoha: failed to get domain ID: %v", err)
+		return fmt.Errorf("conoha: failed to get domain ID: %w", err)
 	}
 
 	recID, err := d.client.GetRecordID(domID, fqdn, "TXT", value)
 	if err != nil {
-		return fmt.Errorf("conoha: failed to get record ID: %v", err)
+		return fmt.Errorf("conoha: failed to get record ID: %w", err)
 	}
 
 	err = d.client.DeleteRecord(domID, recID)
 	if err != nil {
-		return fmt.Errorf("conoha: failed to delete record: %v", err)
+		return fmt.Errorf("conoha: failed to delete record: %w", err)
 	}
 
 	return nil

--- a/providers/dns/conoha/internal/client.go
+++ b/providers/dns/conoha/internal/client.go
@@ -90,7 +90,7 @@ func NewClient(region string, auth Auth, httpClient *http.Client) (*Client, erro
 
 	identity, err := c.getIdentity(auth)
 	if err != nil {
-		return nil, fmt.Errorf("failed to login: %v", err)
+		return nil, fmt.Errorf("failed to login: %w", err)
 	}
 
 	c.token = identity.Access.Token.ID

--- a/providers/dns/constellix/internal/auth.go
+++ b/providers/dns/constellix/internal/auth.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -25,10 +26,10 @@ type TokenTransport struct {
 // NewTokenTransport Creates a HTTP transport for API authentication.
 func NewTokenTransport(apiKey, secretKey string) (*TokenTransport, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("credentials missing: API key")
+		return nil, errors.New("credentials missing: API key")
 	}
 	if secretKey == "" {
-		return nil, fmt.Errorf("credentials missing: secret key")
+		return nil, errors.New("credentials missing: secret key")
 	}
 
 	return &TokenTransport{apiKey: apiKey, secretKey: secretKey}, nil

--- a/providers/dns/digitalocean/client.go
+++ b/providers/dns/digitalocean/client.go
@@ -35,7 +35,7 @@ type apiError struct {
 func (d *DNSProvider) removeTxtRecord(domain string, recordID int) error {
 	authZone, err := dns01.FindZoneByFqdn(dns01.ToFqdn(domain))
 	if err != nil {
-		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("could not determine zone for domain %q: %w", domain, err)
 	}
 
 	reqURL := fmt.Sprintf("%s/v2/domains/%s/records/%d", d.config.BaseURL, dns01.UnFqdn(authZone), recordID)
@@ -60,7 +60,7 @@ func (d *DNSProvider) removeTxtRecord(domain string, recordID int) error {
 func (d *DNSProvider) addTxtRecord(fqdn, value string) (*txtRecordResponse, error) {
 	authZone, err := dns01.FindZoneByFqdn(dns01.ToFqdn(fqdn))
 	if err != nil {
-		return nil, fmt.Errorf("could not determine zone for domain: '%s'. %s", fqdn, err)
+		return nil, fmt.Errorf("could not determine zone for domain %q: %w", fqdn, err)
 	}
 
 	reqData := record{Type: "TXT", Name: fqdn, Data: value, TTL: d.config.TTL}
@@ -94,7 +94,7 @@ func (d *DNSProvider) addTxtRecord(fqdn, value string) (*txtRecordResponse, erro
 	respData := &txtRecordResponse{}
 	err = json.Unmarshal(content, respData)
 	if err != nil {
-		return nil, fmt.Errorf("%v: %s", err, toUnreadableBodyMessage(req, content))
+		return nil, fmt.Errorf("%w: %s", err, toUnreadableBodyMessage(req, content))
 	}
 
 	return respData, nil
@@ -121,7 +121,7 @@ func readError(req *http.Request, resp *http.Response) error {
 	var errInfo apiError
 	err = json.Unmarshal(content, &errInfo)
 	if err != nil {
-		return fmt.Errorf("apiError unmarshaling error: %v: %s", err, toUnreadableBodyMessage(req, content))
+		return fmt.Errorf("apiError unmarshaling error: %w: %s", err, toUnreadableBodyMessage(req, content))
 	}
 
 	return fmt.Errorf("HTTP %d: %s: %s", resp.StatusCode, errInfo.ID, errInfo.Message)

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -49,7 +49,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DO_AUTH_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("digitalocean: %v", err)
+		return nil, fmt.Errorf("digitalocean: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -65,7 +65,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.AuthToken == "" {
-		return nil, fmt.Errorf("digitalocean: credentials missing")
+		return nil, errors.New("digitalocean: credentials missing")
 	}
 
 	if config.BaseURL == "" {
@@ -90,7 +90,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	respData, err := d.addTxtRecord(fqdn, value)
 	if err != nil {
-		return fmt.Errorf("digitalocean: %v", err)
+		return fmt.Errorf("digitalocean: %w", err)
 	}
 
 	d.recordIDsMu.Lock()
@@ -106,7 +106,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("digitalocean: %v", err)
+		return fmt.Errorf("digitalocean: %w", err)
 	}
 
 	// get the record's unique ID from when we created it
@@ -119,7 +119,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.removeTxtRecord(authZone, recordID)
 	if err != nil {
-		return fmt.Errorf("digitalocean: %v", err)
+		return fmt.Errorf("digitalocean: %w", err)
 	}
 
 	// Delete record ID from map

--- a/providers/dns/dnsmadeeasy/dnsmadeeasy.go
+++ b/providers/dns/dnsmadeeasy/dnsmadeeasy.go
@@ -54,7 +54,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DNSMADEEASY_API_KEY", "DNSMADEEASY_API_SECRET")
 	if err != nil {
-		return nil, fmt.Errorf("dnsmadeeasy: %v", err)
+		return nil, fmt.Errorf("dnsmadeeasy: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -84,7 +84,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := internal.NewClient(config.APIKey, config.APISecret)
 	if err != nil {
-		return nil, fmt.Errorf("dnsmadeeasy: %v", err)
+		return nil, fmt.Errorf("dnsmadeeasy: %w", err)
 	}
 
 	client.HTTPClient = config.HTTPClient
@@ -102,13 +102,13 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %v", fqdn, err)
+		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %w", fqdn, err)
 	}
 
 	// fetch the domain details
 	domain, err := d.client.GetDomain(authZone)
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %v", authZone, err)
+		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %w", authZone, err)
 	}
 
 	// create the TXT record
@@ -117,7 +117,7 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	err = d.client.CreateRecord(domain, record)
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to create record for %s: %v", name, err)
+		return fmt.Errorf("dnsmadeeasy: unable to create record for %s: %w", name, err)
 	}
 	return nil
 }
@@ -128,20 +128,20 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %v", fqdn, err)
+		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %w", fqdn, err)
 	}
 
 	// fetch the domain details
 	domain, err := d.client.GetDomain(authZone)
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %v", authZone, err)
+		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %w", authZone, err)
 	}
 
 	// find matching records
 	name := strings.Replace(fqdn, "."+authZone, "", 1)
 	records, err := d.client.GetRecords(domain, name, "TXT")
 	if err != nil {
-		return fmt.Errorf("dnsmadeeasy: unable to get records for domain %s: %v", domain.Name, err)
+		return fmt.Errorf("dnsmadeeasy: unable to get records for domain %s: %w", domain.Name, err)
 	}
 
 	// delete records
@@ -149,7 +149,7 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 	for _, record := range *records {
 		err = d.client.DeleteRecord(record)
 		if err != nil {
-			lastError = fmt.Errorf("dnsmadeeasy: unable to delete record [id=%d, name=%s]: %v", record.ID, record.Name, err)
+			lastError = fmt.Errorf("dnsmadeeasy: unable to delete record [id=%d, name=%s]: %w", record.ID, record.Name, err)
 		}
 	}
 

--- a/providers/dns/dnsmadeeasy/internal/client.go
+++ b/providers/dns/dnsmadeeasy/internal/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -43,11 +44,11 @@ type Client struct {
 // NewClient creates a DNSMadeEasy client
 func NewClient(apiKey string, apiSecret string) (*Client, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("credentials missing: API key")
+		return nil, errors.New("credentials missing: API key")
 	}
 
 	if apiSecret == "" {
-		return nil, fmt.Errorf("credentials missing: API secret")
+		return nil, errors.New("credentials missing: API secret")
 	}
 
 	return &Client{

--- a/providers/dns/dnspod/dnspod.go
+++ b/providers/dns/dnspod/dnspod.go
@@ -46,7 +46,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DNSPOD_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("dnspod: %v", err)
+		return nil, fmt.Errorf("dnspod: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -62,7 +62,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.LoginToken == "" {
-		return nil, fmt.Errorf("dnspod: credentials missing")
+		return nil, errors.New("dnspod: credentials missing")
 	}
 
 	params := dnspod.CommonParams{LoginToken: config.LoginToken, Format: "json"}
@@ -84,7 +84,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	recordAttributes := d.newTxtRecord(zoneName, fqdn, value, d.config.TTL)
 	_, _, err = d.client.Records.Create(zoneID, *recordAttributes)
 	if err != nil {
-		return fmt.Errorf("API call failed: %v", err)
+		return fmt.Errorf("API call failed: %w", err)
 	}
 
 	return nil
@@ -122,7 +122,7 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func (d *DNSProvider) getHostedZone(domain string) (string, string, error) {
 	zones, _, err := d.client.Domains.List()
 	if err != nil {
-		return "", "", fmt.Errorf("API call failed: %v", err)
+		return "", "", fmt.Errorf("API call failed: %w", err)
 	}
 
 	authZone, err := dns01.FindZoneByFqdn(dns01.ToFqdn(domain))
@@ -165,7 +165,7 @@ func (d *DNSProvider) findTxtRecords(domain, fqdn string) ([]dnspod.Record, erro
 	var records []dnspod.Record
 	result, _, err := d.client.Records.List(zoneID, "")
 	if err != nil {
-		return records, fmt.Errorf("API call has failed: %v", err)
+		return records, fmt.Errorf("API call has failed: %w", err)
 	}
 
 	recordName := d.extractRecordName(fqdn, zoneName)

--- a/providers/dns/dode/dode.go
+++ b/providers/dns/dode/dode.go
@@ -42,7 +42,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DODE_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("do.de: %v", err)
+		return nil, fmt.Errorf("do.de: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/dreamhost/client.go
+++ b/providers/dns/dreamhost/client.go
@@ -55,13 +55,13 @@ func (d *DNSProvider) updateTxtRecord(u fmt.Stringer) error {
 
 	raw, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read body: %v", err)
+		return fmt.Errorf("failed to read body: %w", err)
 	}
 
 	var response apiResponse
 	err = json.Unmarshal(raw, &response)
 	if err != nil {
-		return fmt.Errorf("unable to decode API server response: %v: %s", err, string(raw))
+		return fmt.Errorf("unable to decode API server response: %w: %s", err, string(raw))
 	}
 
 	if response.Result == "error" {

--- a/providers/dns/dreamhost/dreamhost.go
+++ b/providers/dns/dreamhost/dreamhost.go
@@ -44,7 +44,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DREAMHOST_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("dreamhost: %v", err)
+		return nil, fmt.Errorf("dreamhost: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -77,12 +77,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	u, err := d.buildQuery(cmdAddRecord, record, value)
 	if err != nil {
-		return fmt.Errorf("dreamhost: %v", err)
+		return fmt.Errorf("dreamhost: %w", err)
 	}
 
 	err = d.updateTxtRecord(u)
 	if err != nil {
-		return fmt.Errorf("dreamhost: %v", err)
+		return fmt.Errorf("dreamhost: %w", err)
 	}
 	return nil
 }
@@ -94,12 +94,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	u, err := d.buildQuery(cmdRemoveRecord, record, value)
 	if err != nil {
-		return fmt.Errorf("dreamhost: %v", err)
+		return fmt.Errorf("dreamhost: %w", err)
 	}
 
 	err = d.updateTxtRecord(u)
 	if err != nil {
-		return fmt.Errorf("dreamhost: %v", err)
+		return fmt.Errorf("dreamhost: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/duckdns/duckdns.go
+++ b/providers/dns/duckdns/duckdns.go
@@ -43,7 +43,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DUCKDNS_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("duckdns: %v", err)
+		return nil, fmt.Errorf("duckdns: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/dyn/client.go
+++ b/providers/dns/dyn/client.go
@@ -3,6 +3,7 @@ package dyn
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -134,7 +135,7 @@ func (d *DNSProvider) sendRequest(method, resource string, payload interface{}) 
 		return nil, fmt.Errorf("API request failed with HTTP status code %d: %s", resp.StatusCode, dynRes.Messages)
 	} else if resp.StatusCode == 307 {
 		// TODO add support for HTTP 307 response and long running jobs
-		return nil, fmt.Errorf("API request returned HTTP 307. This is currently unsupported")
+		return nil, errors.New("API request returned HTTP 307. This is currently unsupported")
 	}
 
 	if dynRes.Status == "failure" {

--- a/providers/dns/easydns/client.go
+++ b/providers/dns/easydns/client.go
@@ -83,7 +83,7 @@ func (d *DNSProvider) doRequest(method, path string, requestMsg, responseMsg int
 	if response.StatusCode >= http.StatusBadRequest {
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return fmt.Errorf("%d: failed to read response body: %v", response.StatusCode, err)
+			return fmt.Errorf("%d: failed to read response body: %w", response.StatusCode, err)
 		}
 
 		return fmt.Errorf("%d: request failed: %v", response.StatusCode, string(body))

--- a/providers/dns/easydns/easydns.go
+++ b/providers/dns/easydns/easydns.go
@@ -54,13 +54,13 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 	endpoint, err := url.Parse(env.GetOrDefaultString("EASYDNS_ENDPOINT", defaultEndpoint))
 	if err != nil {
-		return nil, fmt.Errorf("easydns: %v", err)
+		return nil, fmt.Errorf("easydns: %w", err)
 	}
 	config.Endpoint = endpoint
 
 	values, err := env.Get("EASYDNS_TOKEN", "EASYDNS_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("easydns: %v", err)
+		return nil, fmt.Errorf("easydns: %w", err)
 	}
 
 	config.Token = values["EASYDNS_TOKEN"]
@@ -102,7 +102,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	recordID, err := d.addRecord(apiDomain, record)
 	if err != nil {
-		return fmt.Errorf("easydns: error adding zone record: %v", err)
+		return fmt.Errorf("easydns: error adding zone record: %w", err)
 	}
 
 	key := getMapKey(fqdn, value)
@@ -132,7 +132,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	d.recordIDsMu.Unlock()
 
 	if err != nil {
-		return fmt.Errorf("easydns: %v", err)
+		return fmt.Errorf("easydns: %w", err)
 	}
 
 	return nil

--- a/providers/dns/exec/exec.go
+++ b/providers/dns/exec/exec.go
@@ -40,7 +40,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("EXEC_PATH")
 	if err != nil {
-		return nil, fmt.Errorf("exec: %v", err)
+		return nil, fmt.Errorf("exec: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -49,7 +49,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("EXOSCALE_API_KEY", "EXOSCALE_API_SECRET")
 	if err != nil {
-		return nil, fmt.Errorf("exoscale: %v", err)
+		return nil, fmt.Errorf("exoscale: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -67,7 +67,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIKey == "" || config.APISecret == "" {
-		return nil, fmt.Errorf("exoscale: credentials missing")
+		return nil, errors.New("exoscale: credentials missing")
 	}
 
 	if config.Endpoint == "" {

--- a/providers/dns/fastdns/fastdns.go
+++ b/providers/dns/fastdns/fastdns.go
@@ -40,7 +40,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("AKAMAI_HOST", "AKAMAI_CLIENT_TOKEN", "AKAMAI_CLIENT_SECRET", "AKAMAI_ACCESS_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("fastdns: %v", err)
+		return nil, fmt.Errorf("fastdns: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -62,7 +62,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.ClientToken == "" || config.ClientSecret == "" || config.AccessToken == "" || config.Host == "" {
-		return nil, fmt.Errorf("fastdns: credentials are missing")
+		return nil, errors.New("fastdns: credentials are missing")
 	}
 
 	return &DNSProvider{config: config}, nil
@@ -73,14 +73,14 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
 	zoneName, recordName, err := d.findZoneAndRecordName(fqdn, domain)
 	if err != nil {
-		return fmt.Errorf("fastdns: %v", err)
+		return fmt.Errorf("fastdns: %w", err)
 	}
 
 	configdns.Init(d.config.Config)
 
 	zone, err := configdns.GetZone(zoneName)
 	if err != nil {
-		return fmt.Errorf("fastdns: %v", err)
+		return fmt.Errorf("fastdns: %w", err)
 	}
 
 	record := configdns.NewTxtRecord()
@@ -103,21 +103,21 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _ := dns01.GetRecord(domain, keyAuth)
 	zoneName, recordName, err := d.findZoneAndRecordName(fqdn, domain)
 	if err != nil {
-		return fmt.Errorf("fastdns: %v", err)
+		return fmt.Errorf("fastdns: %w", err)
 	}
 
 	configdns.Init(d.config.Config)
 
 	zone, err := configdns.GetZone(zoneName)
 	if err != nil {
-		return fmt.Errorf("fastdns: %v", err)
+		return fmt.Errorf("fastdns: %w", err)
 	}
 
 	var removed bool
 	for _, r := range zone.Zone.Txt {
 		if r != nil && r.Name == recordName {
 			if zone.RemoveRecord(r) != nil {
-				return fmt.Errorf("fastdns: %v", err)
+				return fmt.Errorf("fastdns: %w", err)
 			}
 			removed = true
 		}

--- a/providers/dns/gandi/client.go
+++ b/providers/dns/gandi/client.go
@@ -3,6 +3,7 @@ package gandi
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -102,7 +103,7 @@ func (d *DNSProvider) rpcCall(call *methodCall, resp response) error {
 	// marshal
 	b, err := xml.MarshalIndent(call, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal error: %v", err)
+		return fmt.Errorf("marshal error: %w", err)
 	}
 
 	// post
@@ -115,7 +116,7 @@ func (d *DNSProvider) rpcCall(call *methodCall, resp response) error {
 	// unmarshal
 	err = xml.Unmarshal(respBody, resp)
 	if err != nil {
-		return fmt.Errorf("unmarshal error: %v", err)
+		return fmt.Errorf("unmarshal error: %w", err)
 	}
 	if resp.faultCode() != 0 {
 		return rpcError{
@@ -181,7 +182,7 @@ func (d *DNSProvider) cloneZone(zoneID int, name string) (int, error) {
 	}
 
 	if newZoneID == 0 {
-		return 0, fmt.Errorf("could not determine cloned zone_id")
+		return 0, errors.New("could not determine cloned zone_id")
 	}
 	return newZoneID, nil
 }
@@ -200,7 +201,7 @@ func (d *DNSProvider) newZoneVersion(zoneID int) (int, error) {
 	}
 
 	if resp.Value == 0 {
-		return 0, fmt.Errorf("could not create new zone version")
+		return 0, errors.New("could not create new zone version")
 	}
 	return resp.Value, nil
 }
@@ -249,7 +250,7 @@ func (d *DNSProvider) setZoneVersion(zoneID int, version int) error {
 	}
 
 	if !resp.Value {
-		return fmt.Errorf("could not set zone version")
+		return errors.New("could not set zone version")
 	}
 	return nil
 }
@@ -295,7 +296,7 @@ func (d *DNSProvider) deleteZone(zoneID int) error {
 	}
 
 	if !resp.Value {
-		return fmt.Errorf("could not delete zone_id")
+		return errors.New("could not delete zone_id")
 	}
 	return nil
 }
@@ -303,13 +304,13 @@ func (d *DNSProvider) deleteZone(zoneID int) error {
 func (d *DNSProvider) httpPost(url string, bodyType string, body io.Reader) ([]byte, error) {
 	resp, err := d.config.HTTPClient.Post(url, bodyType, body)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP Post Error: %v", err)
+		return nil, fmt.Errorf("HTTP Post Error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP Post Error: %v", err)
+		return nil, fmt.Errorf("HTTP Post Error: %w", err)
 	}
 
 	return b, nil

--- a/providers/dns/gandi/gandi.go
+++ b/providers/dns/gandi/gandi.go
@@ -68,7 +68,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GANDI_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("gandi: %v", err)
+		return nil, fmt.Errorf("gandi: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -84,7 +84,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIKey == "" {
-		return nil, fmt.Errorf("gandi: no API Key given")
+		return nil, errors.New("gandi: no API Key given")
 	}
 
 	if config.BaseURL == "" {
@@ -112,12 +112,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// find authZone and Gandi zone_id for fqdn
 	authZone, err := d.findZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("gandi: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("gandi: findZoneByFqdn failure: %w", err)
 	}
 
 	zoneID, err := d.getZoneID(authZone)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	// determine name of TXT record
@@ -147,22 +147,22 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	newZoneVersion, err := d.newZoneVersion(newZoneID)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	err = d.addTXTRecord(newZoneID, newZoneVersion, name, value, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	err = d.setZoneVersion(newZoneID, newZoneVersion)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	err = d.setZone(authZone, newZoneID)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	// save data necessary for CleanUp
@@ -200,7 +200,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// perform API actions to restore old gandi zone for authZone
 	err := d.setZone(authZone, zoneID)
 	if err != nil {
-		return fmt.Errorf("gandi: %v", err)
+		return fmt.Errorf("gandi: %w", err)
 	}
 
 	return d.deleteZone(newZoneID)

--- a/providers/dns/gandiv5/gandiv5.go
+++ b/providers/dns/gandiv5/gandiv5.go
@@ -65,7 +65,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GANDIV5_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("gandi: %v", err)
+		return nil, fmt.Errorf("gandi: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -81,7 +81,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIKey == "" {
-		return nil, fmt.Errorf("gandiv5: no API Key given")
+		return nil, errors.New("gandiv5: no API Key given")
 	}
 
 	if config.BaseURL == "" {
@@ -106,7 +106,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// find authZone
 	authZone, err := d.findZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("gandiv5: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("gandiv5: findZoneByFqdn failure: %w", err)
 	}
 
 	// determine name of TXT record
@@ -154,7 +154,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// delete TXT record from authZone
 	err := d.deleteTXTRecord(dns01.UnFqdn(authZone), fieldName)
 	if err != nil {
-		return fmt.Errorf("gandiv5: %v", err)
+		return fmt.Errorf("gandiv5: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/glesys/glesys.go
+++ b/providers/dns/glesys/glesys.go
@@ -56,7 +56,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GLESYS_API_USER", "GLESYS_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("glesys: %v", err)
+		return nil, fmt.Errorf("glesys: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -73,7 +73,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIUser == "" || config.APIKey == "" {
-		return nil, fmt.Errorf("glesys: incomplete credentials provided")
+		return nil, errors.New("glesys: incomplete credentials provided")
 	}
 
 	if config.TTL < minTTL {
@@ -93,7 +93,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// find authZone
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("glesys: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("glesys: findZoneByFqdn failure: %w", err)
 	}
 
 	// determine name of TXT record

--- a/providers/dns/godaddy/godaddy.go
+++ b/providers/dns/godaddy/godaddy.go
@@ -53,7 +53,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GODADDY_API_KEY", "GODADDY_API_SECRET")
 	if err != nil {
-		return nil, fmt.Errorf("godaddy: %v", err)
+		return nil, fmt.Errorf("godaddy: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -70,7 +70,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIKey == "" || config.APISecret == "" {
-		return nil, fmt.Errorf("godaddy: credentials missing")
+		return nil, errors.New("godaddy: credentials missing")
 	}
 
 	if config.TTL < minTTL {

--- a/providers/dns/hostingde/client.go
+++ b/providers/dns/hostingde/client.go
@@ -27,7 +27,7 @@ func (d *DNSProvider) listZoneConfigs(findRequest ZoneConfigsFindRequest) (*Zone
 	}
 
 	if len(findResponse.Response.Data) == 0 {
-		return nil, fmt.Errorf("%v: %s", err, toUnreadableBodyMessage(uri, rawResp))
+		return nil, fmt.Errorf("%w: %s", err, toUnreadableBodyMessage(uri, rawResp))
 	}
 
 	if findResponse.Status != "success" && findResponse.Status != "pending" {
@@ -104,7 +104,7 @@ func (d *DNSProvider) post(uri string, request interface{}, response interface{}
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error querying API: %v", err)
+		return nil, fmt.Errorf("error querying API: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -116,7 +116,7 @@ func (d *DNSProvider) post(uri string, request interface{}, response interface{}
 
 	err = json.Unmarshal(content, response)
 	if err != nil {
-		return nil, fmt.Errorf("%v: %s", err, toUnreadableBodyMessage(uri, content))
+		return nil, fmt.Errorf("%w: %s", err, toUnreadableBodyMessage(uri, content))
 	}
 
 	return content, nil

--- a/providers/dns/hostingde/hostingde.go
+++ b/providers/dns/hostingde/hostingde.go
@@ -47,7 +47,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("HOSTINGDE_API_KEY", "HOSTINGDE_ZONE_NAME")
 	if err != nil {
-		return nil, fmt.Errorf("hostingde: %v", err)
+		return nil, fmt.Errorf("hostingde: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -100,7 +100,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zoneConfig, err := d.getZone(zonesFind)
 	if err != nil {
-		return fmt.Errorf("hostingde: %v", err)
+		return fmt.Errorf("hostingde: %w", err)
 	}
 	zoneConfig.Name = d.config.ZoneName
 
@@ -119,7 +119,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	resp, err := d.updateZone(req)
 	if err != nil {
-		return fmt.Errorf("hostingde: %v", err)
+		return fmt.Errorf("hostingde: %w", err)
 	}
 
 	for _, record := range resp.Response.Records {
@@ -160,7 +160,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zoneConfig, err := d.getZone(zonesFind)
 	if err != nil {
-		return fmt.Errorf("hostingde: %v", err)
+		return fmt.Errorf("hostingde: %w", err)
 	}
 	zoneConfig.Name = d.config.ZoneName
 
@@ -177,7 +177,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	_, err = d.updateZone(req)
 	if err != nil {
-		return fmt.Errorf("hostingde: %v", err)
+		return fmt.Errorf("hostingde: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/httpreq/httpreq.go
+++ b/providers/dns/httpreq/httpreq.go
@@ -58,12 +58,12 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("HTTPREQ_ENDPOINT")
 	if err != nil {
-		return nil, fmt.Errorf("httpreq: %v", err)
+		return nil, fmt.Errorf("httpreq: %w", err)
 	}
 
 	endpoint, err := url.Parse(values["HTTPREQ_ENDPOINT"])
 	if err != nil {
-		return nil, fmt.Errorf("httpreq: %v", err)
+		return nil, fmt.Errorf("httpreq: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -104,7 +104,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 		err := d.doPost("/present", msg)
 		if err != nil {
-			return fmt.Errorf("httpreq: %v", err)
+			return fmt.Errorf("httpreq: %w", err)
 		}
 		return nil
 	}
@@ -117,7 +117,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err := d.doPost("/present", msg)
 	if err != nil {
-		return fmt.Errorf("httpreq: %v", err)
+		return fmt.Errorf("httpreq: %w", err)
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 		err := d.doPost("/cleanup", msg)
 		if err != nil {
-			return fmt.Errorf("httpreq: %v", err)
+			return fmt.Errorf("httpreq: %w", err)
 		}
 		return nil
 	}
@@ -146,7 +146,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err := d.doPost("/cleanup", msg)
 	if err != nil {
-		return fmt.Errorf("httpreq: %v", err)
+		return fmt.Errorf("httpreq: %w", err)
 	}
 	return nil
 }
@@ -184,7 +184,7 @@ func (d *DNSProvider) doPost(uri string, msg interface{}) error {
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("%d: failed to read response body: %v", resp.StatusCode, err)
+			return fmt.Errorf("%d: failed to read response body: %w", resp.StatusCode, err)
 		}
 
 		return fmt.Errorf("%d: request failed: %v", resp.StatusCode, string(body))

--- a/providers/dns/iij/iij.go
+++ b/providers/dns/iij/iij.go
@@ -2,6 +2,7 @@
 package iij
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -42,7 +43,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("IIJ_API_ACCESS_KEY", "IIJ_API_SECRET_KEY", "IIJ_DO_SERVICE_CODE")
 	if err != nil {
-		return nil, fmt.Errorf("iij: %v", err)
+		return nil, fmt.Errorf("iij: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -57,7 +58,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 // and returns a custom configured DNSProvider instance
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config.SecretKey == "" || config.AccessKey == "" || config.DoServiceCode == "" {
-		return nil, fmt.Errorf("iij: credentials missing")
+		return nil, errors.New("iij: credentials missing")
 	}
 
 	return &DNSProvider{
@@ -77,7 +78,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err := d.addTxtRecord(domain, value)
 	if err != nil {
-		return fmt.Errorf("iij: %v", err)
+		return fmt.Errorf("iij: %w", err)
 	}
 	return nil
 }
@@ -88,7 +89,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err := d.deleteTxtRecord(domain, value)
 	if err != nil {
-		return fmt.Errorf("iij: %v", err)
+		return fmt.Errorf("iij: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -44,7 +44,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("INWX_USERNAME", "INWX_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("inwx: %v", err)
+		return nil, fmt.Errorf("inwx: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -61,7 +61,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.Username == "" || config.Password == "" {
-		return nil, fmt.Errorf("inwx: credentials missing")
+		return nil, errors.New("inwx: credentials missing")
 	}
 
 	if config.Sandbox {
@@ -79,12 +79,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("inwx: %v", err)
+		return fmt.Errorf("inwx: %w", err)
 	}
 
 	err = d.client.Account.Login()
 	if err != nil {
-		return fmt.Errorf("inwx: %v", err)
+		return fmt.Errorf("inwx: %w", err)
 	}
 
 	defer func() {
@@ -109,9 +109,9 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 			if er.Message == "Object exists" {
 				return nil
 			}
-			return fmt.Errorf("inwx: %v", err)
+			return fmt.Errorf("inwx: %w", err)
 		default:
-			return fmt.Errorf("inwx: %v", err)
+			return fmt.Errorf("inwx: %w", err)
 		}
 	}
 
@@ -124,12 +124,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("inwx: %v", err)
+		return fmt.Errorf("inwx: %w", err)
 	}
 
 	err = d.client.Account.Login()
 	if err != nil {
-		return fmt.Errorf("inwx: %v", err)
+		return fmt.Errorf("inwx: %w", err)
 	}
 
 	defer func() {
@@ -145,14 +145,14 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		Type:   "TXT",
 	})
 	if err != nil {
-		return fmt.Errorf("inwx: %v", err)
+		return fmt.Errorf("inwx: %w", err)
 	}
 
 	var lastErr error
 	for _, record := range response.Records {
 		err = d.client.Nameservers.DeleteRecord(record.ID)
 		if err != nil {
-			lastErr = fmt.Errorf("inwx: %v", err)
+			lastErr = fmt.Errorf("inwx: %w", err)
 		}
 	}
 

--- a/providers/dns/joker/client.go
+++ b/providers/dns/joker/client.go
@@ -1,6 +1,7 @@
 package joker
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -80,7 +81,7 @@ func (d *DNSProvider) login() (*response, error) {
 	case d.config.APIKey != "":
 		values = url.Values{"api-key": {d.config.APIKey}}
 	default:
-		return nil, fmt.Errorf("no username and password or api-key")
+		return nil, errors.New("no username and password or api-key")
 	}
 
 	response, err := d.postRequest("login", values)
@@ -89,11 +90,11 @@ func (d *DNSProvider) login() (*response, error) {
 	}
 
 	if response == nil {
-		return nil, fmt.Errorf("login returned nil response")
+		return nil, errors.New("login returned nil response")
 	}
 
 	if response.AuthSid == "" {
-		return response, fmt.Errorf("login did not return valid Auth-Sid")
+		return response, errors.New("login did not return valid Auth-Sid")
 	}
 
 	d.config.AuthSid = response.AuthSid
@@ -104,7 +105,7 @@ func (d *DNSProvider) login() (*response, error) {
 // logout closes authenticated session with Joker's DMAPI
 func (d *DNSProvider) logout() (*response, error) {
 	if d.config.AuthSid == "" {
-		return nil, fmt.Errorf("already logged out")
+		return nil, errors.New("already logged out")
 	}
 
 	response, err := d.postRequest("logout", url.Values{})
@@ -117,7 +118,7 @@ func (d *DNSProvider) logout() (*response, error) {
 // getZone returns content of DNS zone for domain
 func (d *DNSProvider) getZone(domain string) (*response, error) {
 	if d.config.AuthSid == "" {
-		return nil, fmt.Errorf("must be logged in to get zone")
+		return nil, errors.New("must be logged in to get zone")
 	}
 
 	return d.postRequest("dns-zone-get", url.Values{"domain": {dns01.UnFqdn(domain)}})
@@ -126,7 +127,7 @@ func (d *DNSProvider) getZone(domain string) (*response, error) {
 // putZone uploads DNS zone to Joker DMAPI
 func (d *DNSProvider) putZone(domain, zone string) (*response, error) {
 	if d.config.AuthSid == "" {
-		return nil, fmt.Errorf("must be logged in to put zone")
+		return nil, errors.New("must be logged in to put zone")
 	}
 
 	return d.postRequest("dns-zone-put", url.Values{"domain": {dns01.UnFqdn(domain)}, "zone": {strings.TrimSpace(zone)}})

--- a/providers/dns/joker/joker.go
+++ b/providers/dns/joker/joker.go
@@ -75,7 +75,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	if config.APIKey == "" {
 		if config.Username == "" || config.Password == "" {
-			return nil, fmt.Errorf("joker: credentials missing")
+			return nil, errors.New("joker: credentials missing")
 		}
 	}
 
@@ -97,7 +97,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("joker: %v", err)
+		return fmt.Errorf("joker: %w", err)
 	}
 
 	relative := getRelative(fqdn, zone)
@@ -132,7 +132,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("joker: %v", err)
+		return fmt.Errorf("joker: %w", err)
 	}
 
 	relative := getRelative(fqdn, zone)
@@ -178,7 +178,7 @@ func getRelative(fqdn, zone string) string {
 // formatResponseError formats error with optional details from DMAPI response
 func formatResponseError(response *response, err error) error {
 	if response != nil {
-		return fmt.Errorf("joker: DMAPI error: %v Response: %v", err, response.Headers)
+		return fmt.Errorf("joker: DMAPI error: %w Response: %v", err, response.Headers)
 	}
-	return fmt.Errorf("joker: DMAPI error: %v", err)
+	return fmt.Errorf("joker: DMAPI error: %w", err)
 }

--- a/providers/dns/lightsail/lightsail.go
+++ b/providers/dns/lightsail/lightsail.go
@@ -108,7 +108,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err := d.newTxtRecord(fqdn, `"`+value+`"`)
 	if err != nil {
-		return fmt.Errorf("lightsail: %v", err)
+		return fmt.Errorf("lightsail: %w", err)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	_, err := d.client.DeleteDomainEntry(params)
 	if err != nil {
-		return fmt.Errorf("lightsail: %v", err)
+		return fmt.Errorf("lightsail: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/linode/linode.go
+++ b/providers/dns/linode/linode.go
@@ -49,7 +49,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("LINODE_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("linode: %v", err)
+		return nil, fmt.Errorf("linode: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/linodev4/linodev4.go
+++ b/providers/dns/linodev4/linodev4.go
@@ -57,7 +57,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("LINODE_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("linodev4: %v", err)
+		return nil, fmt.Errorf("linodev4: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -185,7 +185,7 @@ func (d *DNSProvider) getHostedZoneInfo(fqdn string) (*hostedZoneInfo, error) {
 	}
 
 	if len(domains) == 0 {
-		return nil, fmt.Errorf("domain not found")
+		return nil, errors.New("domain not found")
 	}
 
 	return &hostedZoneInfo{

--- a/providers/dns/liquidweb/liquidweb.go
+++ b/providers/dns/liquidweb/liquidweb.go
@@ -54,7 +54,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("LIQUID_WEB_USERNAME", "LIQUID_WEB_PASSWORD", "LIQUID_WEB_ZONE")
 	if err != nil {
-		return nil, fmt.Errorf("liquidweb: %v", err)
+		return nil, fmt.Errorf("liquidweb: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -77,21 +77,21 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.Zone == "" {
-		return nil, fmt.Errorf("liquidweb: zone is missing")
+		return nil, errors.New("liquidweb: zone is missing")
 	}
 
 	if config.Username == "" {
-		return nil, fmt.Errorf("liquidweb: username is missing")
+		return nil, errors.New("liquidweb: username is missing")
 	}
 
 	if config.Password == "" {
-		return nil, fmt.Errorf("liquidweb: password is missing")
+		return nil, errors.New("liquidweb: password is missing")
 	}
 
 	// Initialize LW client.
 	client, err := lw.NewAPI(config.Username, config.Password, config.BaseURL, int(config.HTTPTimeout.Seconds()))
 	if err != nil {
-		return nil, fmt.Errorf("liquidweb: could not create Liquid Web API client: %v", err)
+		return nil, fmt.Errorf("liquidweb: could not create Liquid Web API client: %w", err)
 	}
 
 	return &DNSProvider{
@@ -121,7 +121,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	dnsEntry, err := d.client.NetworkDNS.Create(params)
 	if err != nil {
-		return fmt.Errorf("liquidweb: could not create TXT record: %v", err)
+		return fmt.Errorf("liquidweb: could not create TXT record: %w", err)
 	}
 
 	d.recordIDsMu.Lock()
@@ -144,7 +144,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	params := &network.DNSRecordParams{ID: recordID}
 	_, err := d.client.NetworkDNS.Delete(params)
 	if err != nil {
-		return fmt.Errorf("liquidweb: could not remove TXT record: %v", err)
+		return fmt.Errorf("liquidweb: could not remove TXT record: %w", err)
 	}
 
 	d.recordIDsMu.Lock()

--- a/providers/dns/mydnsjp/client.go
+++ b/providers/dns/mydnsjp/client.go
@@ -16,7 +16,7 @@ func (d *DNSProvider) doRequest(domain, value string, cmd string) error {
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error querying API: %v", err)
+		return fmt.Errorf("error querying API: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -42,7 +42,7 @@ func (d *DNSProvider) buildRequest(domain, value string, cmd string) (*http.Requ
 
 	req, err := http.NewRequest(http.MethodPost, defaultBaseURL, strings.NewReader(params.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("invalid request: %v", err)
+		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/providers/dns/mydnsjp/mydnsjp.go
+++ b/providers/dns/mydnsjp/mydnsjp.go
@@ -43,7 +43,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("MYDNSJP_MASTER_ID", "MYDNSJP_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("mydnsjp: %v", err)
+		return nil, fmt.Errorf("mydnsjp: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -77,7 +77,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	_, value := dns01.GetRecord(domain, keyAuth)
 	err := d.doRequest(domain, value, "REGIST")
 	if err != nil {
-		return fmt.Errorf("mydnsjp: %v", err)
+		return fmt.Errorf("mydnsjp: %w", err)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	_, value := dns01.GetRecord(domain, keyAuth)
 	err := d.doRequest(domain, value, "DELETE")
 	if err != nil {
-		return fmt.Errorf("mydnsjp: %v", err)
+		return fmt.Errorf("mydnsjp: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/namecheap/client.go
+++ b/providers/dns/namecheap/client.go
@@ -2,6 +2,7 @@ package namecheap
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -97,7 +98,7 @@ func (d *DNSProvider) setHosts(sld, tld string, hosts []Record) error {
 		return fmt.Errorf("%s [%d]", shr.Errors[0].Description, shr.Errors[0].Number)
 	}
 	if shr.Result.IsSuccess != "true" {
-		return fmt.Errorf("setHosts failed")
+		return errors.New("setHosts failed")
 	}
 
 	return nil
@@ -113,7 +114,7 @@ func (d *DNSProvider) do(req *http.Request, out interface{}) error {
 		var body []byte
 		body, err = readBody(resp)
 		if err != nil {
-			return fmt.Errorf("HTTP error %d [%s]: %v", resp.StatusCode, http.StatusText(resp.StatusCode), err)
+			return fmt.Errorf("HTTP error %d [%s]: %w", resp.StatusCode, http.StatusText(resp.StatusCode), err)
 		}
 		return fmt.Errorf("HTTP error %d [%s]: %s", resp.StatusCode, http.StatusText(resp.StatusCode), string(body))
 	}
@@ -178,7 +179,7 @@ func addParam(key, value string) func(url.Values) {
 
 func readBody(resp *http.Response) ([]byte, error) {
 	if resp.Body == nil {
-		return nil, fmt.Errorf("response body is nil")
+		return nil, errors.New("response body is nil")
 	}
 
 	defer resp.Body.Close()

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -91,7 +91,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NAMECHEAP_API_USER", "NAMECHEAP_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("namecheap: %v", err)
+		return nil, fmt.Errorf("namecheap: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -108,13 +108,13 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIUser == "" || config.APIKey == "" {
-		return nil, fmt.Errorf("namecheap: credentials missing")
+		return nil, errors.New("namecheap: credentials missing")
 	}
 
 	if len(config.ClientIP) == 0 {
 		clientIP, err := getClientIP(config.HTTPClient, config.Debug)
 		if err != nil {
-			return nil, fmt.Errorf("namecheap: %v", err)
+			return nil, fmt.Errorf("namecheap: %w", err)
 		}
 		config.ClientIP = clientIP
 	}
@@ -132,12 +132,12 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	ch, err := newChallenge(domain, keyAuth)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 
 	records, err := d.getHosts(ch.sld, ch.tld)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 
 	record := Record{
@@ -158,7 +158,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err = d.setHosts(ch.sld, ch.tld, records)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 	return nil
 }
@@ -167,12 +167,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	ch, err := newChallenge(domain, keyAuth)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 
 	records, err := d.getHosts(ch.sld, ch.tld)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 
 	// Find the challenge TXT record and remove it if found.
@@ -192,7 +192,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.setHosts(ch.sld, ch.tld, newRecords)
 	if err != nil {
-		return fmt.Errorf("namecheap: %v", err)
+		return fmt.Errorf("namecheap: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/namedotcom/namedotcom.go
+++ b/providers/dns/namedotcom/namedotcom.go
@@ -51,7 +51,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NAMECOM_USERNAME", "NAMECOM_API_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("namedotcom: %v", err)
+		return nil, fmt.Errorf("namedotcom: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -69,11 +69,11 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.Username == "" {
-		return nil, fmt.Errorf("namedotcom: username is required")
+		return nil, errors.New("namedotcom: username is required")
 	}
 
 	if config.APIToken == "" {
-		return nil, fmt.Errorf("namedotcom: API token is required")
+		return nil, errors.New("namedotcom: API token is required")
 	}
 
 	if config.TTL < minTTL {
@@ -104,7 +104,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, err := d.client.CreateRecord(request)
 	if err != nil {
-		return fmt.Errorf("namedotcom: API call failed: %v", err)
+		return fmt.Errorf("namedotcom: API call failed: %w", err)
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	records, err := d.getRecords(domain)
 	if err != nil {
-		return fmt.Errorf("namedotcom: %v", err)
+		return fmt.Errorf("namedotcom: %w", err)
 	}
 
 	for _, rec := range records {
@@ -127,7 +127,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 			}
 			_, err := d.client.DeleteRecord(request)
 			if err != nil {
-				return fmt.Errorf("namedotcom: %v", err)
+				return fmt.Errorf("namedotcom: %w", err)
 			}
 		}
 	}

--- a/providers/dns/namesilo/namesilo.go
+++ b/providers/dns/namesilo/namesilo.go
@@ -47,7 +47,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NAMESILO_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("namesilo: %v", err)
+		return nil, fmt.Errorf("namesilo: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -68,7 +68,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	transport, err := namesilo.NewTokenTransport(config.APIKey)
 	if err != nil {
-		return nil, fmt.Errorf("namesilo: %v", err)
+		return nil, fmt.Errorf("namesilo: %w", err)
 	}
 
 	return &DNSProvider{client: namesilo.NewClient(transport.Client()), config: config}, nil
@@ -80,7 +80,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zoneName, err := getZoneNameByDomain(domain)
 	if err != nil {
-		return fmt.Errorf("namesilo: %v", err)
+		return fmt.Errorf("namesilo: %w", err)
 	}
 
 	_, err = d.client.DnsAddRecord(&namesilo.DnsAddRecordParams{
@@ -91,7 +91,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		TTL:    d.config.TTL,
 	})
 	if err != nil {
-		return fmt.Errorf("namesilo: failed to add record %v", err)
+		return fmt.Errorf("namesilo: failed to add record %w", err)
 	}
 	return nil
 }
@@ -102,12 +102,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zoneName, err := getZoneNameByDomain(domain)
 	if err != nil {
-		return fmt.Errorf("namesilo: %v", err)
+		return fmt.Errorf("namesilo: %w", err)
 	}
 
 	resp, err := d.client.DnsListRecords(&namesilo.DnsListRecordsParams{Domain: zoneName})
 	if err != nil {
-		return fmt.Errorf("namesilo: %v", err)
+		return fmt.Errorf("namesilo: %w", err)
 	}
 
 	var lastErr error
@@ -116,7 +116,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		if r.Type == "TXT" && r.Host == name {
 			_, err := d.client.DnsDeleteRecord(&namesilo.DnsDeleteRecordParams{Domain: zoneName, ID: r.RecordID})
 			if err != nil {
-				lastErr = fmt.Errorf("namesilo: %v", err)
+				lastErr = fmt.Errorf("namesilo: %w", err)
 			}
 		}
 	}
@@ -132,7 +132,7 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func getZoneNameByDomain(domain string) (string, error) {
 	zone, err := dns01.FindZoneByFqdn(dns01.ToFqdn(domain))
 	if err != nil {
-		return "", fmt.Errorf("failed to find zone for domain: %s, %v", domain, err)
+		return "", fmt.Errorf("failed to find zone for domain: %s, %w", domain, err)
 	}
 	return dns01.UnFqdn(zone), nil
 }

--- a/providers/dns/netcup/internal/client_test.go
+++ b/providers/dns/netcup/internal/client_test.go
@@ -570,7 +570,7 @@ func TestLiveClientUpdateDnsRecord(t *testing.T) {
 	fqdn, _ := dns01.GetRecord(envTest.GetDomain(), "123d==")
 
 	zone, err := dns01.FindZoneByFqdn(fqdn)
-	require.NoError(t, err, fmt.Errorf("error finding DNSZone, %v", err))
+	require.NoError(t, err, fmt.Errorf("error finding DNSZone, %w", err))
 
 	hostname := strings.Replace(fqdn, "."+zone, "", 1)
 

--- a/providers/dns/netcup/netcup.go
+++ b/providers/dns/netcup/netcup.go
@@ -50,7 +50,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NETCUP_CUSTOMER_NUMBER", "NETCUP_API_KEY", "NETCUP_API_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("netcup: %v", err)
+		return nil, fmt.Errorf("netcup: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -69,7 +69,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := internal.NewClient(config.Customer, config.Key, config.Password)
 	if err != nil {
-		return nil, fmt.Errorf("netcup: %v", err)
+		return nil, fmt.Errorf("netcup: %w", err)
 	}
 
 	client.HTTPClient = config.HTTPClient
@@ -83,12 +83,12 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	zone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("netcup: failed to find DNSZone, %v", err)
+		return fmt.Errorf("netcup: failed to find DNSZone, %w", err)
 	}
 
 	sessionID, err := d.client.Login()
 	if err != nil {
-		return fmt.Errorf("netcup: %v", err)
+		return fmt.Errorf("netcup: %w", err)
 	}
 
 	defer func() {
@@ -118,7 +118,7 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	err = d.client.UpdateDNSRecord(sessionID, zone, records)
 	if err != nil {
-		return fmt.Errorf("netcup: failed to add TXT-Record: %v", err)
+		return fmt.Errorf("netcup: failed to add TXT-Record: %w", err)
 	}
 
 	return nil
@@ -130,12 +130,12 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 
 	zone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("netcup: failed to find DNSZone, %v", err)
+		return fmt.Errorf("netcup: failed to find DNSZone, %w", err)
 	}
 
 	sessionID, err := d.client.Login()
 	if err != nil {
-		return fmt.Errorf("netcup: %v", err)
+		return fmt.Errorf("netcup: %w", err)
 	}
 
 	defer func() {
@@ -151,7 +151,7 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 
 	records, err := d.client.GetDNSRecords(zone, sessionID)
 	if err != nil {
-		return fmt.Errorf("netcup: %v", err)
+		return fmt.Errorf("netcup: %w", err)
 	}
 
 	record := internal.DNSRecord{
@@ -162,14 +162,14 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 
 	idx, err := internal.GetDNSRecordIdx(records, record)
 	if err != nil {
-		return fmt.Errorf("netcup: %v", err)
+		return fmt.Errorf("netcup: %w", err)
 	}
 
 	records[idx].DeleteRecord = true
 
 	err = d.client.UpdateDNSRecord(sessionID, zone, []internal.DNSRecord{records[idx]})
 	if err != nil {
-		return fmt.Errorf("netcup: %v", err)
+		return fmt.Errorf("netcup: %w", err)
 	}
 
 	return nil

--- a/providers/dns/nifcloud/internal/client.go
+++ b/providers/dns/nifcloud/internal/client.go
@@ -129,7 +129,7 @@ func (c *Client) ChangeResourceRecordSets(hostedZoneID string, input ChangeResou
 
 	err = c.sign(req)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred during the creation of the signature: %v", err)
+		return nil, fmt.Errorf("an error occurred during the creation of the signature: %w", err)
 	}
 
 	res, err := c.HTTPClient.Do(req)
@@ -146,7 +146,7 @@ func (c *Client) ChangeResourceRecordSets(hostedZoneID string, input ChangeResou
 		errResp := &ErrorResponse{}
 		err = xml.NewDecoder(res.Body).Decode(errResp)
 		if err != nil {
-			return nil, fmt.Errorf("an error occurred while unmarshaling the error body to XML: %v", err)
+			return nil, fmt.Errorf("an error occurred while unmarshaling the error body to XML: %w", err)
 		}
 
 		return nil, fmt.Errorf("an error occurred: %s", errResp.Error.Message)
@@ -155,7 +155,7 @@ func (c *Client) ChangeResourceRecordSets(hostedZoneID string, input ChangeResou
 	output := &ChangeResourceRecordSetsResponse{}
 	err = xml.NewDecoder(res.Body).Decode(output)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while unmarshaling the response body to XML: %v", err)
+		return nil, fmt.Errorf("an error occurred while unmarshaling the response body to XML: %w", err)
 	}
 
 	return output, err
@@ -172,7 +172,7 @@ func (c *Client) GetChange(statusID string) (*GetChangeResponse, error) {
 
 	err = c.sign(req)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred during the creation of the signature: %v", err)
+		return nil, fmt.Errorf("an error occurred during the creation of the signature: %w", err)
 	}
 
 	res, err := c.HTTPClient.Do(req)
@@ -189,7 +189,7 @@ func (c *Client) GetChange(statusID string) (*GetChangeResponse, error) {
 		errResp := &ErrorResponse{}
 		err = xml.NewDecoder(res.Body).Decode(errResp)
 		if err != nil {
-			return nil, fmt.Errorf("an error occurred while unmarshaling the error body to XML: %v", err)
+			return nil, fmt.Errorf("an error occurred while unmarshaling the error body to XML: %w", err)
 		}
 
 		return nil, fmt.Errorf("an error occurred: %s", errResp.Error.Message)
@@ -198,7 +198,7 @@ func (c *Client) GetChange(statusID string) (*GetChangeResponse, error) {
 	output := &GetChangeResponse{}
 	err = xml.NewDecoder(res.Body).Decode(output)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while unmarshaling the response body to XML: %v", err)
+		return nil, fmt.Errorf("an error occurred while unmarshaling the response body to XML: %w", err)
 	}
 
 	return output, nil

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -49,7 +49,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NIFCLOUD_ACCESS_KEY_ID", "NIFCLOUD_SECRET_ACCESS_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("nifcloud: %v", err)
+		return nil, fmt.Errorf("nifcloud: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -68,7 +68,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := internal.NewClient(config.AccessKey, config.SecretKey)
 	if err != nil {
-		return nil, fmt.Errorf("nifcloud: %v", err)
+		return nil, fmt.Errorf("nifcloud: %w", err)
 	}
 
 	if config.HTTPClient != nil {
@@ -88,7 +88,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err := d.changeRecord("CREATE", fqdn, value, domain, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("nifcloud: %v", err)
+		return fmt.Errorf("nifcloud: %w", err)
 	}
 	return err
 }
@@ -99,7 +99,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err := d.changeRecord("DELETE", fqdn, value, domain, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("nifcloud: %v", err)
+		return fmt.Errorf("nifcloud: %w", err)
 	}
 	return err
 }
@@ -141,7 +141,7 @@ func (d *DNSProvider) changeRecord(action, fqdn, value, domain string, ttl int) 
 
 	resp, err := d.client.ChangeResourceRecordSets(domain, reqParams)
 	if err != nil {
-		return fmt.Errorf("failed to change NIFCLOUD record set: %v", err)
+		return fmt.Errorf("failed to change NIFCLOUD record set: %w", err)
 	}
 
 	statusID := resp.ChangeInfo.ID
@@ -149,7 +149,7 @@ func (d *DNSProvider) changeRecord(action, fqdn, value, domain string, ttl int) 
 	return wait.For("nifcloud", 120*time.Second, 4*time.Second, func() (bool, error) {
 		resp, err := d.client.GetChange(statusID)
 		if err != nil {
-			return false, fmt.Errorf("failed to query NIFCLOUD DNS change status: %v", err)
+			return false, fmt.Errorf("failed to query NIFCLOUD DNS change status: %w", err)
 		}
 		return resp.ChangeInfo.Status == "INSYNC", nil
 	})

--- a/providers/dns/oraclecloud/configprovider.go
+++ b/providers/dns/oraclecloud/configprovider.go
@@ -81,7 +81,7 @@ func getPrivateKey(envVar string) ([]byte, error) {
 	if envVarValue != "" {
 		bytes, err := base64.StdEncoding.DecodeString(envVarValue)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read base64 value %s (defined by env var %s): %s", envVarValue, envVar, err)
+			return nil, fmt.Errorf("failed to read base64 value %s (defined by env var %s): %w", envVarValue, envVar, err)
 		}
 		return bytes, nil
 	}
@@ -94,7 +94,7 @@ func getPrivateKey(envVar string) ([]byte, error) {
 
 	fileContents, err := ioutil.ReadFile(fileVarValue)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read the file %s (defined by env var %s): %s", fileVarValue, fileVar, err)
+		return nil, fmt.Errorf("failed to read the file %s (defined by env var %s): %w", fileVarValue, fileVar, err)
 	}
 
 	return fileContents, nil

--- a/providers/dns/oraclecloud/oraclecloud.go
+++ b/providers/dns/oraclecloud/oraclecloud.go
@@ -45,7 +45,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(ociPrivkey, ociTenancyOCID, ociUserOCID, ociPubkeyFingerprint, ociRegion, "OCI_COMPARTMENT_OCID")
 	if err != nil {
-		return nil, fmt.Errorf("oraclecloud: %v", err)
+		return nil, fmt.Errorf("oraclecloud: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -71,7 +71,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client, err := dns.NewDnsClientWithConfigurationProvider(config.OCIConfigProvider)
 	if err != nil {
-		return nil, fmt.Errorf("oraclecloud: %v", err)
+		return nil, fmt.Errorf("oraclecloud: %w", err)
 	}
 
 	if config.HTTPClient != nil {
@@ -105,7 +105,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, err := d.client.PatchDomainRecords(context.Background(), request)
 	if err != nil {
-		return fmt.Errorf("oraclecloud: %v", err)
+		return fmt.Errorf("oraclecloud: %w", err)
 	}
 
 	return nil
@@ -127,11 +127,11 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	domainRecords, err := d.client.GetDomainRecords(ctx, getRequest)
 	if err != nil {
-		return fmt.Errorf("oraclecloud: %v", err)
+		return fmt.Errorf("oraclecloud: %w", err)
 	}
 
 	if *domainRecords.OpcTotalItems == 0 {
-		return fmt.Errorf("oraclecloud: no record to CleanUp")
+		return errors.New("oraclecloud: no record to CleanUp")
 	}
 
 	var deleteHash *string
@@ -143,7 +143,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}
 
 	if deleteHash == nil {
-		return fmt.Errorf("oraclecloud: no record to CleanUp")
+		return errors.New("oraclecloud: no record to CleanUp")
 	}
 
 	recordOperation := dns.RecordOperation{
@@ -162,7 +162,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	_, err = d.client.PatchDomainRecords(ctx, patchRequest)
 	if err != nil {
-		return fmt.Errorf("oraclecloud: %v", err)
+		return fmt.Errorf("oraclecloud: %w", err)
 	}
 
 	return nil

--- a/providers/dns/otc/client.go
+++ b/providers/dns/otc/client.go
@@ -3,6 +3,7 @@ package otc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -138,7 +139,7 @@ func (d *DNSProvider) loginRequest() error {
 	d.token = resp.Header.Get("X-Subject-Token")
 
 	if d.token == "" {
-		return fmt.Errorf("unable to get auth token")
+		return errors.New("unable to get auth token")
 	}
 
 	var endpointResp endpointResponse
@@ -158,7 +159,7 @@ func (d *DNSProvider) loginRequest() error {
 	if len(endpoints) > 0 {
 		d.baseURL = fmt.Sprintf("%s/v2", endpoints[0].URL)
 	} else {
-		return fmt.Errorf("unable to get dns endpoint")
+		return errors.New("unable to get dns endpoint")
 	}
 
 	return nil
@@ -182,11 +183,11 @@ func (d *DNSProvider) getZoneID(zone string) (string, error) {
 	}
 
 	if len(zonesRes.Zones) > 1 {
-		return "", fmt.Errorf("to many zones found")
+		return "", errors.New("to many zones found")
 	}
 
 	if zonesRes.Zones[0].ID == "" {
-		return "", fmt.Errorf("id not found")
+		return "", errors.New("id not found")
 	}
 
 	return zonesRes.Zones[0].ID, nil
@@ -206,15 +207,15 @@ func (d *DNSProvider) getRecordSetID(zoneID string, fqdn string) (string, error)
 	}
 
 	if len(recordSetsRes.RecordSets) < 1 {
-		return "", fmt.Errorf("record not found")
+		return "", errors.New("record not found")
 	}
 
 	if len(recordSetsRes.RecordSets) > 1 {
-		return "", fmt.Errorf("to many records found")
+		return "", errors.New("to many records found")
 	}
 
 	if recordSetsRes.RecordSets[0].ID == "" {
-		return "", fmt.Errorf("id not found")
+		return "", errors.New("id not found")
 	}
 
 	return recordSetsRes.RecordSets[0].ID, nil

--- a/providers/dns/otc/otc.go
+++ b/providers/dns/otc/otc.go
@@ -72,7 +72,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("OTC_DOMAIN_NAME", "OTC_USER_NAME", "OTC_PASSWORD", "OTC_PROJECT_NAME")
 	if err != nil {
-		return nil, fmt.Errorf("otc: %v", err)
+		return nil, fmt.Errorf("otc: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -91,7 +91,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.DomainName == "" || config.UserName == "" || config.Password == "" || config.ProjectName == "" {
-		return nil, fmt.Errorf("otc: credentials missing")
+		return nil, errors.New("otc: credentials missing")
 	}
 
 	if config.TTL < minTTL {
@@ -111,17 +111,17 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 
 	err = d.login()
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 
 	zoneID, err := d.getZoneID(authZone)
 	if err != nil {
-		return fmt.Errorf("otc: unable to get zone: %s", err)
+		return fmt.Errorf("otc: unable to get zone: %w", err)
 	}
 
 	resource := fmt.Sprintf("zones/%s/recordsets", zoneID)
@@ -136,7 +136,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, err = d.sendRequest(http.MethodPost, resource, r1)
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 	return nil
 }
@@ -147,27 +147,27 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 
 	err = d.login()
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 
 	zoneID, err := d.getZoneID(authZone)
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 
 	recordID, err := d.getRecordSetID(zoneID, fqdn)
 	if err != nil {
-		return fmt.Errorf("otc: unable go get record %s for zone %s: %s", fqdn, domain, err)
+		return fmt.Errorf("otc: unable go get record %s for zone %s: %w", fqdn, domain, err)
 	}
 
 	err = d.deleteRecordSet(zoneID, recordID)
 	if err != nil {
-		return fmt.Errorf("otc: %v", err)
+		return fmt.Errorf("otc: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -160,7 +160,7 @@ func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawM
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error talking to PDNS API -> %v", err)
+		return nil, fmt.Errorf("error talking to PDNS API -> %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -188,7 +188,7 @@ func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawM
 			return nil, err
 		}
 		if errInfo.ShortMsg != "" {
-			return nil, fmt.Errorf("error talking to PDNS API -> %v", errInfo)
+			return nil, fmt.Errorf("error talking to PDNS API -> %w", errInfo)
 		}
 	}
 	return msg, nil

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -49,12 +49,12 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("PDNS_API_KEY", "PDNS_API_URL")
 	if err != nil {
-		return nil, fmt.Errorf("pdns: %v", err)
+		return nil, fmt.Errorf("pdns: %w", err)
 	}
 
 	hostURL, err := url.Parse(values["PDNS_API_URL"])
 	if err != nil {
-		return nil, fmt.Errorf("pdns: %v", err)
+		return nil, fmt.Errorf("pdns: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -71,11 +71,11 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.APIKey == "" {
-		return nil, fmt.Errorf("pdns: API key missing")
+		return nil, errors.New("pdns: API key missing")
 	}
 
 	if config.Host == nil || config.Host.Host == "" {
-		return nil, fmt.Errorf("pdns: API URL missing")
+		return nil, errors.New("pdns: API URL missing")
 	}
 
 	d := &DNSProvider{config: config}
@@ -101,7 +101,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 
 	name := fqdn
@@ -124,7 +124,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// Look for existing records.
 	existingRrSet, err := d.findTxtRecord(fqdn)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 
 	// merge the existing and new records
@@ -149,12 +149,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	body, err := json.Marshal(rrsets)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 
 	_, err = d.sendRequest(http.MethodPatch, zone.URL, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 	return nil
 }
@@ -165,12 +165,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 
 	set, err := d.findTxtRecord(fqdn)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 	if set == nil {
 		return fmt.Errorf("pdns: no existing record found for %s", fqdn)
@@ -187,12 +187,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}
 	body, err := json.Marshal(rrsets)
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 
 	_, err = d.sendRequest(http.MethodPatch, zone.URL, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("pdns: %v", err)
+		return fmt.Errorf("pdns: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/rackspace/client.go
+++ b/providers/dns/rackspace/client.go
@@ -145,7 +145,7 @@ func (d *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error querying DNS API: %v", err)
+		return nil, fmt.Errorf("error querying DNS API: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -187,7 +187,7 @@ func login(config *Config) (*Identity, error) {
 
 	resp, err := config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error querying Identity API: %v", err)
+		return nil, fmt.Errorf("error querying Identity API: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/providers/dns/rfc2136/rfc2136.go
+++ b/providers/dns/rfc2136/rfc2136.go
@@ -56,7 +56,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("RFC2136_NAMESERVER")
 	if err != nil {
-		return nil, fmt.Errorf("rfc2136: %v", err)
+		return nil, fmt.Errorf("rfc2136: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -74,7 +74,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.Nameserver == "" {
-		return nil, fmt.Errorf("rfc2136: nameserver missing")
+		return nil, errors.New("rfc2136: nameserver missing")
 	}
 
 	if config.TSIGAlgorithm == "" {
@@ -86,7 +86,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		if strings.Contains(err.Error(), "missing port") {
 			config.Nameserver = net.JoinHostPort(config.Nameserver, "53")
 		} else {
-			return nil, fmt.Errorf("rfc2136: %v", err)
+			return nil, fmt.Errorf("rfc2136: %w", err)
 		}
 	}
 
@@ -117,7 +117,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err := d.changeRecord("INSERT", fqdn, value, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("rfc2136: failed to insert: %v", err)
+		return fmt.Errorf("rfc2136: failed to insert: %w", err)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err := d.changeRecord("REMOVE", fqdn, value, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("rfc2136: failed to remove: %v", err)
+		return fmt.Errorf("rfc2136: failed to remove: %w", err)
 	}
 	return nil
 }
@@ -173,7 +173,7 @@ func (d *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 	// Send the query
 	reply, _, err := c.Exchange(m, d.config.Nameserver)
 	if err != nil {
-		return fmt.Errorf("DNS update failed: %v", err)
+		return fmt.Errorf("DNS update failed: %w", err)
 	}
 	if reply != nil && reply.Rcode != dns.RcodeSuccess {
 		return fmt.Errorf("DNS update failed: server replied: %s", dns.RcodeToString[reply.Rcode])

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -116,12 +116,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	hostedZoneID, err := d.getHostedZoneID(fqdn)
 	if err != nil {
-		return fmt.Errorf("route53: failed to determine hosted zone ID: %v", err)
+		return fmt.Errorf("route53: failed to determine hosted zone ID: %w", err)
 	}
 
 	records, err := d.getExistingRecordSets(hostedZoneID, fqdn)
 	if err != nil {
-		return fmt.Errorf("route53: %v", err)
+		return fmt.Errorf("route53: %w", err)
 	}
 
 	realValue := `"` + value + `"`
@@ -146,7 +146,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err = d.changeRecord(route53.ChangeActionUpsert, hostedZoneID, recordSet)
 	if err != nil {
-		return fmt.Errorf("route53: %v", err)
+		return fmt.Errorf("route53: %w", err)
 	}
 	return nil
 }
@@ -157,12 +157,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	hostedZoneID, err := d.getHostedZoneID(fqdn)
 	if err != nil {
-		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %v", err)
+		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %w", err)
 	}
 
 	records, err := d.getExistingRecordSets(hostedZoneID, fqdn)
 	if err != nil {
-		return fmt.Errorf("route53: %v", err)
+		return fmt.Errorf("route53: %w", err)
 	}
 
 	if len(records) == 0 {
@@ -178,7 +178,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.changeRecord(route53.ChangeActionDelete, hostedZoneID, recordSet)
 	if err != nil {
-		return fmt.Errorf("route53: %v", err)
+		return fmt.Errorf("route53: %w", err)
 	}
 	return nil
 }
@@ -197,7 +197,7 @@ func (d *DNSProvider) changeRecord(action, hostedZoneID string, recordSet *route
 
 	resp, err := d.client.ChangeResourceRecordSets(recordSetInput)
 	if err != nil {
-		return fmt.Errorf("failed to change record set: %v", err)
+		return fmt.Errorf("failed to change record set: %w", err)
 	}
 
 	changeID := resp.ChangeInfo.Id
@@ -207,7 +207,7 @@ func (d *DNSProvider) changeRecord(action, hostedZoneID string, recordSet *route
 
 		resp, err := d.client.GetChange(reqParams)
 		if err != nil {
-			return false, fmt.Errorf("failed to query change status: %v", err)
+			return false, fmt.Errorf("failed to query change status: %w", err)
 		}
 
 		if aws.StringValue(resp.ChangeInfo.Status) == route53.ChangeStatusInsync {

--- a/providers/dns/sakuracloud/client.go
+++ b/providers/dns/sakuracloud/client.go
@@ -18,7 +18,7 @@ func (d *DNSProvider) addTXTRecord(fqdn, domain, value string, ttl int) error {
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("sakuracloud: %v", err)
+		return fmt.Errorf("sakuracloud: %w", err)
 	}
 
 	name := d.extractRecordName(fqdn, zone.Name)
@@ -26,7 +26,7 @@ func (d *DNSProvider) addTXTRecord(fqdn, domain, value string, ttl int) error {
 	zone.AddRecord(zone.CreateNewRecord(name, "TXT", value, ttl))
 	_, err = d.client.Update(zone.ID, zone)
 	if err != nil {
-		return fmt.Errorf("sakuracloud: API call failed: %v", err)
+		return fmt.Errorf("sakuracloud: API call failed: %w", err)
 	}
 
 	return nil
@@ -38,7 +38,7 @@ func (d *DNSProvider) cleanupTXTRecord(fqdn, domain string) error {
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("sakuracloud: %v", err)
+		return fmt.Errorf("sakuracloud: %w", err)
 	}
 
 	records := d.findTxtRecords(fqdn, zone)
@@ -55,7 +55,7 @@ func (d *DNSProvider) cleanupTXTRecord(fqdn, domain string) error {
 
 	_, err = d.client.Update(zone.ID, zone)
 	if err != nil {
-		return fmt.Errorf("sakuracloud: API call failed: %v", err)
+		return fmt.Errorf("sakuracloud: API call failed: %w", err)
 	}
 	return nil
 }
@@ -71,9 +71,9 @@ func (d *DNSProvider) getHostedZone(domain string) (*sacloud.DNS, error) {
 	res, err := d.client.Reset().WithNameLike(zoneName).Find()
 	if err != nil {
 		if notFound, ok := err.(api.Error); ok && notFound.ResponseCode() == http.StatusNotFound {
-			return nil, fmt.Errorf("zone %s not found on SakuraCloud DNS: %v", zoneName, err)
+			return nil, fmt.Errorf("zone %s not found on SakuraCloud DNS: %w", zoneName, err)
 		}
-		return nil, fmt.Errorf("API call failed: %v", err)
+		return nil, fmt.Errorf("API call failed: %w", err)
 	}
 
 	for _, zone := range res.CommonServiceDNSItems {

--- a/providers/dns/sakuracloud/sakuracloud.go
+++ b/providers/dns/sakuracloud/sakuracloud.go
@@ -45,7 +45,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")
 	if err != nil {
-		return nil, fmt.Errorf("sakuracloud: %v", err)
+		return nil, fmt.Errorf("sakuracloud: %w", err)
 	}
 
 	config := NewDefaultConfig()

--- a/providers/dns/selectel/internal/client.go
+++ b/providers/dns/selectel/internal/client.go
@@ -32,7 +32,7 @@ type APIError struct {
 	Field       string `json:"field"`
 }
 
-func (a *APIError) Error() string {
+func (a APIError) Error() string {
 	return fmt.Sprintf("API error: %d - %s - %s", a.Code, a.Description, a.Field)
 }
 
@@ -143,13 +143,13 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 	if body != nil {
 		err := json.NewEncoder(buf).Encode(body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode request body with error: %v", err)
+			return nil, fmt.Errorf("failed to encode request body with error: %w", err)
 		}
 	}
 
 	req, err := http.NewRequest(method, c.baseURL+uri, buf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new http request with error: %v", err)
+		return nil, fmt.Errorf("failed to create new http request with error: %w", err)
 	}
 
 	req.Header.Add("X-Token", c.token)
@@ -162,7 +162,7 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 func (c *Client) do(req *http.Request, to interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed with error: %v", err)
+		return nil, fmt.Errorf("request failed with error: %w", err)
 	}
 
 	err = checkResponse(resp)
@@ -197,7 +197,7 @@ func checkResponse(resp *http.Response) error {
 			return fmt.Errorf("request failed with status code %d, response body: %s", resp.StatusCode, string(body))
 		}
 
-		return fmt.Errorf("request failed with status code %d: %v", resp.StatusCode, apiError)
+		return fmt.Errorf("request failed with status code %d: %w", resp.StatusCode, apiError)
 	}
 
 	return nil
@@ -212,7 +212,7 @@ func unmarshalBody(resp *http.Response, to interface{}) error {
 
 	err = json.Unmarshal(body, to)
 	if err != nil {
-		return fmt.Errorf("unmarshaling error: %v: %s", err, string(body))
+		return fmt.Errorf("unmarshaling error: %w: %s", err, string(body))
 	}
 
 	return nil

--- a/providers/dns/selectel/selectel.go
+++ b/providers/dns/selectel/selectel.go
@@ -63,7 +63,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(apiTokenEnvVar)
 	if err != nil {
-		return nil, fmt.Errorf("selectel: %v", err)
+		return nil, fmt.Errorf("selectel: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -107,7 +107,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	domainObj, err := d.client.GetDomainByName(domain)
 	if err != nil {
-		return fmt.Errorf("selectel: %v", err)
+		return fmt.Errorf("selectel: %w", err)
 	}
 
 	txtRecord := internal.Record{
@@ -118,7 +118,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 	_, err = d.client.AddRecord(domainObj.ID, txtRecord)
 	if err != nil {
-		return fmt.Errorf("selectel: %v", err)
+		return fmt.Errorf("selectel: %w", err)
 	}
 
 	return nil
@@ -131,12 +131,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	domainObj, err := d.client.GetDomainByName(domain)
 	if err != nil {
-		return fmt.Errorf("selectel: %v", err)
+		return fmt.Errorf("selectel: %w", err)
 	}
 
 	records, err := d.client.ListRecords(domainObj.ID)
 	if err != nil {
-		return fmt.Errorf("selectel: %v", err)
+		return fmt.Errorf("selectel: %w", err)
 	}
 
 	// Delete records with specific FQDN
@@ -145,7 +145,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		if record.Name == recordName {
 			err = d.client.DeleteRecord(domainObj.ID, record.ID)
 			if err != nil {
-				lastErr = fmt.Errorf("selectel: %v", err)
+				lastErr = fmt.Errorf("selectel: %w", err)
 			}
 		}
 	}

--- a/providers/dns/servercow/servercow.go
+++ b/providers/dns/servercow/servercow.go
@@ -2,6 +2,7 @@
 package servercow
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -59,7 +60,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 // NewDNSProviderConfig return a DNSProvider instance configured for Servercow.
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config.Username == "" || config.Password == "" {
-		return nil, fmt.Errorf("servercow: incomplete credentials, missing username and/or password")
+		return nil, errors.New("servercow: incomplete credentials, missing username and/or password")
 	}
 
 	if config.HTTPClient == nil {

--- a/providers/dns/stackpath/client.go
+++ b/providers/dns/stackpath/client.go
@@ -3,6 +3,7 @@ package stackpath
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -172,12 +173,12 @@ func (d *DNSProvider) do(req *http.Request, v interface{}) error {
 
 	raw, err := readBody(resp)
 	if err != nil {
-		return fmt.Errorf("failed to read body: %v", err)
+		return fmt.Errorf("failed to read body: %w", err)
 	}
 
 	err = json.Unmarshal(raw, v)
 	if err != nil {
-		return fmt.Errorf("unmarshaling error: %v: %s", err, string(raw))
+		return fmt.Errorf("unmarshaling error: %w: %s", err, string(raw))
 	}
 
 	return nil
@@ -203,7 +204,7 @@ func checkResponse(resp *http.Response) error {
 
 func readBody(resp *http.Response) ([]byte, error) {
 	if resp.Body == nil {
-		return nil, fmt.Errorf("response body is nil")
+		return nil, errors.New("response body is nil")
 	}
 
 	defer resp.Body.Close()

--- a/providers/dns/stackpath/stackpath.go
+++ b/providers/dns/stackpath/stackpath.go
@@ -54,7 +54,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("STACKPATH_CLIENT_ID", "STACKPATH_CLIENT_SECRET", "STACKPATH_STACK_ID")
 	if err != nil {
-		return nil, fmt.Errorf("stackpath: %v", err)
+		return nil, fmt.Errorf("stackpath: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -102,7 +102,7 @@ func getOathClient(config *Config) *http.Client {
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	zone, err := d.getZones(domain)
 	if err != nil {
-		return fmt.Errorf("stackpath: %v", err)
+		return fmt.Errorf("stackpath: %w", err)
 	}
 
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
@@ -122,7 +122,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	zone, err := d.getZones(domain)
 	if err != nil {
-		return fmt.Errorf("stackpath: %v", err)
+		return fmt.Errorf("stackpath: %w", err)
 	}
 
 	fqdn, _ := dns01.GetRecord(domain, keyAuth)

--- a/providers/dns/transip/transip.go
+++ b/providers/dns/transip/transip.go
@@ -45,7 +45,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("TRANSIP_ACCOUNT_NAME", "TRANSIP_PRIVATE_KEY_PATH")
 	if err != nil {
-		return nil, fmt.Errorf("transip: %v", err)
+		return nil, fmt.Errorf("transip: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -66,7 +66,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		PrivateKeyPath: config.PrivateKeyPath,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("transip: %v", err)
+		return nil, fmt.Errorf("transip: %w", err)
 	}
 
 	return &DNSProvider{client: client, config: config}, nil
@@ -99,7 +99,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// get all DNS entries
 	info, err := transipdomain.GetInfo(d.client, domainName)
 	if err != nil {
-		return fmt.Errorf("transip: error for %s in Present: %v", domain, err)
+		return fmt.Errorf("transip: error for %s in Present: %w", domain, err)
 	}
 
 	// include the new DNS entry
@@ -113,7 +113,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// set the updated DNS entries
 	err = transipdomain.SetDNSEntries(d.client, domainName, dnsEntries)
 	if err != nil {
-		return fmt.Errorf("transip: %v", err)
+		return fmt.Errorf("transip: %w", err)
 	}
 	return nil
 }
@@ -139,7 +139,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// get all DNS entries
 	info, err := transipdomain.GetInfo(d.client, domainName)
 	if err != nil {
-		return fmt.Errorf("transip: error for %s in CleanUp: %v", fqdn, err)
+		return fmt.Errorf("transip: error for %s in CleanUp: %w", fqdn, err)
 	}
 
 	// loop through the existing entries and remove the specific record
@@ -153,7 +153,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// set the updated DNS entries
 	err = transipdomain.SetDNSEntries(d.client, domainName, updatedEntries)
 	if err != nil {
-		return fmt.Errorf("transip: couldn't get Record ID in CleanUp: %sv", err)
+		return fmt.Errorf("transip: couldn't get Record ID in CleanUp: %w", err)
 	}
 
 	return nil

--- a/providers/dns/vegadns/vegadns.go
+++ b/providers/dns/vegadns/vegadns.go
@@ -43,7 +43,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("VEGADNS_URL")
 	if err != nil {
-		return nil, fmt.Errorf("vegadns: %v", err)
+		return nil, fmt.Errorf("vegadns: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -79,12 +79,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	_, domainID, err := d.client.GetAuthZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("vegadns: can't find Authoritative Zone for %s in Present: %v", fqdn, err)
+		return fmt.Errorf("vegadns: can't find Authoritative Zone for %s in Present: %w", fqdn, err)
 	}
 
 	err = d.client.CreateTXT(domainID, fqdn, value, d.config.TTL)
 	if err != nil {
-		return fmt.Errorf("vegadns: %v", err)
+		return fmt.Errorf("vegadns: %w", err)
 	}
 	return nil
 }
@@ -95,19 +95,19 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	_, domainID, err := d.client.GetAuthZone(fqdn)
 	if err != nil {
-		return fmt.Errorf("vegadns: can't find Authoritative Zone for %s in CleanUp: %v", fqdn, err)
+		return fmt.Errorf("vegadns: can't find Authoritative Zone for %s in CleanUp: %w", fqdn, err)
 	}
 
 	txt := strings.TrimSuffix(fqdn, ".")
 
 	recordID, err := d.client.GetRecordID(domainID, txt, "TXT")
 	if err != nil {
-		return fmt.Errorf("vegadns: couldn't get Record ID in CleanUp: %s", err)
+		return fmt.Errorf("vegadns: couldn't get Record ID in CleanUp: %w", err)
 	}
 
 	err = d.client.DeleteRecord(recordID)
 	if err != nil {
-		return fmt.Errorf("vegadns: %v", err)
+		return fmt.Errorf("vegadns: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/versio/client.go
+++ b/providers/dns/versio/client.go
@@ -101,7 +101,7 @@ func (d *DNSProvider) do(req *http.Request, result interface{}) error {
 		var body []byte
 		body, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("%d: failed to read response body: %v", resp.StatusCode, err)
+			return fmt.Errorf("%d: failed to read response body: %w", resp.StatusCode, err)
 		}
 
 		respError := &dnsErrorResponse{}
@@ -115,11 +115,11 @@ func (d *DNSProvider) do(req *http.Request, result interface{}) error {
 	if result != nil {
 		content, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("request failed: %v", err)
+			return fmt.Errorf("request failed: %w", err)
 		}
 
 		if err = json.Unmarshal(content, result); err != nil {
-			return fmt.Errorf("%v: %s", err, content)
+			return fmt.Errorf("%w: %s", err, content)
 		}
 	}
 

--- a/providers/dns/versio/versio.go
+++ b/providers/dns/versio/versio.go
@@ -54,7 +54,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("VERSIO_USERNAME", "VERSIO_PASSWORD")
 	if err != nil {
-		return nil, fmt.Errorf("versio: %v", err)
+		return nil, fmt.Errorf("versio: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -91,7 +91,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 
 	// use mutex to prevent race condition from getDNSRecords until postDNSRecords
@@ -101,7 +101,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	zoneName := dns01.UnFqdn(authZone)
 	domains, err := d.getDNSRecords(zoneName)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 
 	txtRecord := record{
@@ -116,7 +116,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	err = d.postDNSRecords(zoneName, msg)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 	return nil
 }
@@ -126,7 +126,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _ := dns01.GetRecord(domain, keyAuth)
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 
 	// use mutex to prevent race condition from getDNSRecords until postDNSRecords
@@ -136,7 +136,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	zoneName := dns01.UnFqdn(authZone)
 	domains, err := d.getDNSRecords(zoneName)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 
 	// loop through the existing entries and remove the specific record
@@ -149,7 +149,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.postDNSRecords(zoneName, msg)
 	if err != nil {
-		return fmt.Errorf("versio: %v", err)
+		return fmt.Errorf("versio: %w", err)
 	}
 	return nil
 }

--- a/providers/dns/vscale/internal/client.go
+++ b/providers/dns/vscale/internal/client.go
@@ -32,7 +32,7 @@ type APIError struct {
 	Field       string `json:"field"`
 }
 
-func (a *APIError) Error() string {
+func (a APIError) Error() string {
 	return fmt.Sprintf("API error: %d - %s - %s", a.Code, a.Description, a.Field)
 }
 
@@ -143,13 +143,13 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 	if body != nil {
 		err := json.NewEncoder(buf).Encode(body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode request body with error: %v", err)
+			return nil, fmt.Errorf("failed to encode request body with error: %w", err)
 		}
 	}
 
 	req, err := http.NewRequest(method, c.baseURL+uri, buf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new http request with error: %v", err)
+		return nil, fmt.Errorf("failed to create new http request with error: %w", err)
 	}
 
 	req.Header.Add("X-Token", c.token)
@@ -162,7 +162,7 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 func (c *Client) do(req *http.Request, to interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed with error: %v", err)
+		return nil, fmt.Errorf("request failed with error: %w", err)
 	}
 
 	err = checkResponse(resp)
@@ -197,7 +197,7 @@ func checkResponse(resp *http.Response) error {
 			return fmt.Errorf("request failed with status code %d, response body: %s", resp.StatusCode, string(body))
 		}
 
-		return fmt.Errorf("request failed with status code %d: %v", resp.StatusCode, apiError)
+		return fmt.Errorf("request failed with status code %d: %w", resp.StatusCode, apiError)
 	}
 
 	return nil
@@ -212,7 +212,7 @@ func unmarshalBody(resp *http.Response, to interface{}) error {
 
 	err = json.Unmarshal(body, to)
 	if err != nil {
-		return fmt.Errorf("unmarshaling error: %v: %s", err, string(body))
+		return fmt.Errorf("unmarshaling error: %w: %s", err, string(body))
 	}
 
 	return nil

--- a/providers/dns/vscale/vscale.go
+++ b/providers/dns/vscale/vscale.go
@@ -64,7 +64,7 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get(apiTokenEnvVar)
 	if err != nil {
-		return nil, fmt.Errorf("vscale: %v", err)
+		return nil, fmt.Errorf("vscale: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -108,7 +108,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	domainObj, err := d.client.GetDomainByName(domain)
 	if err != nil {
-		return fmt.Errorf("vscale: %v", err)
+		return fmt.Errorf("vscale: %w", err)
 	}
 
 	txtRecord := internal.Record{
@@ -119,7 +119,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 	_, err = d.client.AddRecord(domainObj.ID, txtRecord)
 	if err != nil {
-		return fmt.Errorf("vscale: %v", err)
+		return fmt.Errorf("vscale: %w", err)
 	}
 
 	return nil
@@ -132,12 +132,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	domainObj, err := d.client.GetDomainByName(domain)
 	if err != nil {
-		return fmt.Errorf("vscale: %v", err)
+		return fmt.Errorf("vscale: %w", err)
 	}
 
 	records, err := d.client.ListRecords(domainObj.ID)
 	if err != nil {
-		return fmt.Errorf("vscale: %v", err)
+		return fmt.Errorf("vscale: %w", err)
 	}
 
 	// Delete records with specific FQDN
@@ -146,7 +146,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		if record.Name == recordName {
 			err = d.client.DeleteRecord(domainObj.ID, record.ID)
 			if err != nil {
-				lastErr = fmt.Errorf("vscale: %v", err)
+				lastErr = fmt.Errorf("vscale: %w", err)
 			}
 		}
 	}

--- a/providers/dns/zoneee/client.go
+++ b/providers/dns/zoneee/client.go
@@ -107,7 +107,7 @@ func (d *DNSProvider) sendRequest(req *http.Request, result interface{}) error {
 
 	err = json.Unmarshal(raw, result)
 	if err != nil {
-		return fmt.Errorf("unmarshaling %T error [status code=%d]: %v: %s", result, resp.StatusCode, err, string(raw))
+		return fmt.Errorf("unmarshaling %T error [status code=%d]: %w: %s", result, resp.StatusCode, err, string(raw))
 	}
 	return err
 }
@@ -125,7 +125,7 @@ func checkResponse(resp *http.Response) error {
 
 	raw, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("unable to read body: status code=%d, error=%v", resp.StatusCode, err)
+		return fmt.Errorf("unable to read body: status code=%d, error=%w", resp.StatusCode, err)
 	}
 
 	return fmt.Errorf("status code=%d: %s", resp.StatusCode, string(raw))

--- a/providers/dns/zoneee/zoneee.go
+++ b/providers/dns/zoneee/zoneee.go
@@ -46,13 +46,13 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("ZONEEE_API_USER", "ZONEEE_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("zoneee: %v", err)
+		return nil, fmt.Errorf("zoneee: %w", err)
 	}
 
 	rawEndpoint := env.GetOrDefaultString("ZONEEE_ENDPOINT", defaultEndpoint)
 	endpoint, err := url.Parse(rawEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("zoneee: %v", err)
+		return nil, fmt.Errorf("zoneee: %w", err)
 	}
 
 	config := NewDefaultConfig()
@@ -70,11 +70,11 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.Username == "" {
-		return nil, fmt.Errorf("zoneee: credentials missing: username")
+		return nil, errors.New("zoneee: credentials missing: username")
 	}
 
 	if config.APIKey == "" {
-		return nil, fmt.Errorf("zoneee: credentials missing: API key")
+		return nil, errors.New("zoneee: credentials missing: API key")
 	}
 
 	if config.Endpoint == nil {
@@ -101,12 +101,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	authZone, err := getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("zoneee: %v", err)
+		return fmt.Errorf("zoneee: %w", err)
 	}
 
 	_, err = d.addTxtRecord(authZone, record)
 	if err != nil {
-		return fmt.Errorf("zoneee: %v", err)
+		return fmt.Errorf("zoneee: %w", err)
 	}
 	return nil
 }
@@ -117,12 +117,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := getHostedZone(domain)
 	if err != nil {
-		return fmt.Errorf("zoneee: %v", err)
+		return fmt.Errorf("zoneee: %w", err)
 	}
 
 	records, err := d.getTxtRecords(authZone)
 	if err != nil {
-		return fmt.Errorf("zoneee: %v", err)
+		return fmt.Errorf("zoneee: %w", err)
 	}
 
 	var id string
@@ -133,11 +133,11 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}
 
 	if id == "" {
-		return fmt.Errorf("zoneee: txt record does not exist for %v", value)
+		return fmt.Errorf("zoneee: txt record does not exist for %s", value)
 	}
 
 	if err = d.removeTxtRecord(authZone, id); err != nil {
-		return fmt.Errorf("zoneee: %v", err)
+		return fmt.Errorf("zoneee: %w", err)
 	}
 
 	return nil

--- a/providers/http/memcached/memcached.go
+++ b/providers/http/memcached/memcached.go
@@ -3,6 +3,7 @@
 package memcached
 
 import (
+	"errors"
 	"fmt"
 	"path"
 
@@ -18,7 +19,7 @@ type HTTPProvider struct {
 // NewMemcachedProvider returns a HTTPProvider instance with a configured webroot path
 func NewMemcachedProvider(hosts []string) (*HTTPProvider, error) {
 	if len(hosts) == 0 {
-		return nil, fmt.Errorf("no memcached hosts provided")
+		return nil, errors.New("no memcached hosts provided")
 	}
 
 	c := &HTTPProvider{

--- a/providers/http/webroot/webroot.go
+++ b/providers/http/webroot/webroot.go
@@ -2,6 +2,7 @@
 package webroot
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -18,7 +19,7 @@ type HTTPProvider struct {
 // NewHTTPProvider returns a HTTPProvider instance with a configured webroot path
 func NewHTTPProvider(path string) (*HTTPProvider, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, fmt.Errorf("webroot path does not exist")
+		return nil, errors.New("webroot path does not exist")
 	}
 
 	return &HTTPProvider{path: path}, nil
@@ -31,12 +32,12 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 	challengeFilePath := filepath.Join(w.path, http01.ChallengePath(token))
 	err = os.MkdirAll(filepath.Dir(challengeFilePath), 0755)
 	if err != nil {
-		return fmt.Errorf("could not create required directories in webroot for HTTP challenge -> %v", err)
+		return fmt.Errorf("could not create required directories in webroot for HTTP challenge -> %w", err)
 	}
 
 	err = ioutil.WriteFile(challengeFilePath, []byte(keyAuth), 0644)
 	if err != nil {
-		return fmt.Errorf("could not write file in webroot for HTTP challenge -> %v", err)
+		return fmt.Errorf("could not write file in webroot for HTTP challenge -> %w", err)
 	}
 
 	return nil
@@ -46,7 +47,7 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 func (w *HTTPProvider) CleanUp(domain, token, keyAuth string) error {
 	err := os.Remove(filepath.Join(w.path, http01.ChallengePath(token)))
 	if err != nil {
-		return fmt.Errorf("could not remove file in webroot after HTTP challenge -> %v", err)
+		return fmt.Errorf("could not remove file in webroot after HTTP challenge -> %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Use the go1.13 errors wrapping.

before:
```go
fmt.Errorf("test: %v", err)
```

after:
```go
fmt.Errorf("test: %w", err)
```
