### PR TITLE
feat: multi-arch Docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ before_install:
   - wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.deb
   - sudo dpkg -i /tmp/hugo.deb
 
+  # Install Docker image multi-arch builder
+  - curl -sfL https://raw.githubusercontent.com/ldez/seihon/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" ${SEIHON_VERSION}
+  - seihon --version
+
 install:
   - go mod tidy
   - git diff --exit-code go.mod
@@ -63,10 +67,18 @@ before_deploy:
   - >
     if ! [ "$BEFORE_DEPLOY_RUN" ]; then
       export BEFORE_DEPLOY_RUN=1;
-      make docs-build
+      make docs-build;
+      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
     fi
 
 deploy:
+  - provider: pages
+    local_dir: docs/public
+    skip_cleanup: true
+    github_token: ${GITHUB_TOKEN}
+    on:
+      condition: $STABLE = true
+
   - provider: script
     skip_cleanup: true
     script: curl -sL https://git.io/goreleaser | bash
@@ -84,9 +96,9 @@ deploy:
       tags: true
       condition: $STABLE = true
 
-  - provider: pages
-    local_dir: docs/public
+  - provider: script
     skip_cleanup: true
-    github_token: ${GITHUB_TOKEN}
+    script: make publish-images
     on:
+      tags: true
       condition: $STABLE = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-FROM golang:1.13-alpine3.10 as builder
+FROM golang:1-alpine as builder
 
 RUN apk --no-cache --no-progress add make git
 
-WORKDIR /go/src/github.com/go-acme/lego
+WORKDIR /go/lego
+
+ENV GO111MODULE on
+
+# Download go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 COPY . .
 RUN make build
 
@@ -11,5 +19,6 @@ RUN apk update \
     && apk add --no-cache ca-certificates tzdata \
     && update-ca-certificates
 
-COPY --from=builder /go/src/github.com/go-acme/lego/dist/lego /usr/bin/lego
+COPY --from=builder /go/lego/dist/lego /usr/bin/lego
+
 ENTRYPOINT [ "/usr/bin/lego" ]

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,10 @@ export GO111MODULE=on
 
 SRCS = $(shell git ls-files '*.go' | grep -v '^vendor/')
 
-LEGO_IMAGE := go-acme/lego
+LEGO_IMAGE := goacme/lego
 MAIN_DIRECTORY := ./cmd/lego/
-ifeq (${GOOS}, windows)
-    BIN_OUTPUT := dist/lego.exe
-else
-    BIN_OUTPUT := dist/lego
-endif
+
+BIN_OUTPUT := $(if $(filter $(shell go env GOOS), windows), dist/lego.exe, dist/lego)
 
 TAG_NAME := $(shell git tag -l --contains HEAD)
 SHA := $(shell git rev-parse HEAD)
@@ -19,6 +16,7 @@ VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 default: clean generate-dns checks test build
 
 clean:
+	@echo BIN_OUTPUT: ${BIN_OUTPUT}
 	rm -rf dist/ builds/ cover.out
 
 build: clean
@@ -28,6 +26,9 @@ build: clean
 image:
 	@echo Version: $(VERSION)
 	docker build -t $(LEGO_IMAGE) .
+
+publish-images:
+	seihon publish -v "$(TAG_NAME)" -v "latest" --image-name="$(LEGO_IMAGE)" --dry-run=false
 
 test: clean
 	go test -v -cover ./...

--- a/tmpl.Dockerfile
+++ b/tmpl.Dockerfile
@@ -1,3 +1,5 @@
+# Dockerfile template used by Seihon to create multi-arch images.
+# https://github.com/ldez/seihon
 FROM golang:1-alpine as builder
 
 RUN apk --update upgrade \

--- a/tmpl.Dockerfile
+++ b/tmpl.Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1-alpine as builder
+
+RUN apk --update upgrade \
+    && apk --no-cache --no-progress add git make ca-certificates tzdata
+
+WORKDIR /go/lego
+
+ENV GO111MODULE on
+
+# Download go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN GOARCH={{ .GoARCH }} GOARM={{ .GoARM }} make build
+
+FROM {{ .RuntimeImage }}
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/lego/dist/lego /usr/bin/lego
+
+ENTRYPOINT [ "/usr/bin/lego" ]


### PR DESCRIPTION
Allows to publish (on tags only) a multi-arch image.

I use a tool that I created to publish multi-arch image easily: https://github.com/ldez/seihon

I already added env vars to Travis CI: https://travis-ci.org/go-acme/lego/settings

Fixes #1071

https://hub.docker.com/r/goacme/lego