### PR TITLE
azure: pass AZURE_CLIENT_SECRET_FILE to autorest.Authorizer

### DIFF
--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -83,6 +83,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config := NewDefaultConfig()
 	config.SubscriptionID = env.GetOrFile(EnvSubscriptionID)
 	config.ResourceGroup = env.GetOrFile(EnvResourceGroup)
+	config.ClientSecret = env.GetOrFile(EnvClientSecret)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -84,6 +84,8 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config.SubscriptionID = env.GetOrFile(EnvSubscriptionID)
 	config.ResourceGroup = env.GetOrFile(EnvResourceGroup)
 	config.ClientSecret = env.GetOrFile(EnvClientSecret)
+	config.ClientID = env.GetOrFile(EnvClientID)
+	config.TenantID = env.GetOrFile(EnvTenantID)
 
 	return NewDNSProviderConfig(config)
 }


### PR DESCRIPTION
`github.com/Azure/go-autorest` expects `AZURE_CLIENT_SECRET` to be set. Otherwise, it will fall back to using metadata endpoint, which is only available from inside Azure.

This change essentially allows to set `AZURE_CLIENT_SECRET_FILE` instead of `AZURE_CLIENT_SECRET` and have client secret propagated to `autorest.Authorizer`.