### PR TITLE
Use colon instead a arrow in error messages

### DIFF
--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -118,7 +118,7 @@ func (a *Core) retrievablePost(uri string, content []byte, response interface{})
 func (a *Core) signedPost(uri string, content []byte, response interface{}) (*http.Response, error) {
 	signedContent, err := a.jws.SignContent(uri, content)
 	if err != nil {
-		return nil, fmt.Errorf("failed to post JWS message -> failed to sign content -> %w", err)
+		return nil, fmt.Errorf("failed to post JWS message: failed to sign content: %w", err)
 	}
 
 	signedBody := bytes.NewBuffer([]byte(signedContent.FullSerialize()))

--- a/acme/api/internal/nonces/nonce_manager.go
+++ b/acme/api/internal/nonces/nonce_manager.go
@@ -57,7 +57,7 @@ func (n *Manager) Nonce() (string, error) {
 func (n *Manager) getNonce() (string, error) {
 	resp, err := n.do.Head(n.nonceURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce from HTTP HEAD -> %w", err)
+		return "", fmt.Errorf("failed to get nonce from HTTP HEAD: %w", err)
 	}
 
 	return GetFromResponse(resp)

--- a/acme/api/internal/secure/jws.go
+++ b/acme/api/internal/secure/jws.go
@@ -65,12 +65,12 @@ func (j *JWS) SignContent(url string, content []byte) (*jose.JSONWebSignature, e
 
 	signer, err := jose.NewSigner(signKey, &options)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create jose signer -> %w", err)
+		return nil, fmt.Errorf("failed to create jose signer: %w", err)
 	}
 
 	signed, err := signer.Sign(content)
 	if err != nil {
-		return nil, fmt.Errorf("failed to sign content -> %w", err)
+		return nil, fmt.Errorf("failed to sign content: %w", err)
 	}
 	return signed, nil
 }
@@ -94,12 +94,12 @@ func (j *JWS) SignEABContent(url, kid string, hmac []byte) (*jose.JSONWebSignatu
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create External Account Binding jose signer -> %w", err)
+		return nil, fmt.Errorf("failed to create External Account Binding jose signer: %w", err)
 	}
 
 	signed, err := signer.Sign(jwkJSON)
 	if err != nil {
-		return nil, fmt.Errorf("failed to External Account Binding sign content -> %w", err)
+		return nil, fmt.Errorf("failed to External Account Binding sign content: %w", err)
 	}
 
 	return signed, nil

--- a/certificate/errors.go
+++ b/certificate/errors.go
@@ -10,7 +10,7 @@ import (
 type obtainError map[string]error
 
 func (e obtainError) Error() string {
-	buffer := bytes.NewBufferString("acme: Error -> One or more domains had a problem:\n")
+	buffer := bytes.NewBufferString("error: one or more domains had a problem:\n")
 
 	var domains []string
 	for domain := range e {

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -37,7 +37,7 @@ func (s *ProviderServer) Present(domain, token, keyAuth string) error {
 	var err error
 	s.listener, err = net.Listen("tcp", s.GetAddress())
 	if err != nil {
-		return fmt.Errorf("could not start HTTP server for challenge -> %w", err)
+		return fmt.Errorf("could not start HTTP server for challenge: %w", err)
 	}
 
 	s.done = make(chan bool)

--- a/challenge/resolver/errors.go
+++ b/challenge/resolver/errors.go
@@ -10,7 +10,7 @@ import (
 type obtainError map[string]error
 
 func (e obtainError) Error() string {
-	buffer := bytes.NewBufferString("acme: Error -> One or more domains had a problem:\n")
+	buffer := bytes.NewBufferString("error: one or more domains had a problem:\n")
 
 	var domains []string
 	for domain := range e {

--- a/challenge/resolver/prober_test.go
+++ b/challenge/resolver/prober_test.go
@@ -66,7 +66,7 @@ func TestProber_Solve(t *testing.T) {
 				createStubAuthorizationHTTP01("lego.wtf", acme.StatusProcessing),
 				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusProcessing),
 			},
-			expectedError: `acme: Error -> One or more domains had a problem:
+			expectedError: `error: one or more domains had a problem:
 [acme.wtf] preSolve error acme.wtf
 `,
 		},
@@ -91,7 +91,7 @@ func TestProber_Solve(t *testing.T) {
 				createStubAuthorizationHTTP01("lego.wtf", acme.StatusProcessing),
 				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusProcessing),
 			},
-			expectedError: `acme: Error -> One or more domains had a problem:
+			expectedError: `error: one or more domains had a problem:
 [acme.wtf] preSolve error acme.wtf
 [lego.wtf] solve error lego.wtf
 `,

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -66,7 +66,7 @@ func (s *ProviderServer) Present(domain, token, keyAuth string) error {
 	// Create the listener with the created tls.Config.
 	s.listener, err = tls.Listen("tcp", s.GetAddress(), tlsConf)
 	if err != nil {
-		return fmt.Errorf("could not start HTTPS server for challenge -> %w", err)
+		return fmt.Errorf("could not start HTTPS server for challenge: %w", err)
 	}
 
 	// Shut the server down when we're finished.

--- a/cmd/accounts_storage.go
+++ b/cmd/accounts_storage.go
@@ -128,13 +128,13 @@ func (s *AccountsStorage) Save(account *Account) error {
 func (s *AccountsStorage) LoadAccount(privateKey crypto.PrivateKey) *Account {
 	fileBytes, err := ioutil.ReadFile(s.accountFilePath)
 	if err != nil {
-		log.Fatalf("Could not load file for account %s -> %v", s.userID, err)
+		log.Fatalf("Could not load file for account %s: %v", s.userID, err)
 	}
 
 	var account Account
 	err = json.Unmarshal(fileBytes, &account)
 	if err != nil {
-		log.Fatalf("Could not parse file for account %s -> %v", s.userID, err)
+		log.Fatalf("Could not parse file for account %s: %v", s.userID, err)
 	}
 
 	account.key = privateKey
@@ -142,13 +142,13 @@ func (s *AccountsStorage) LoadAccount(privateKey crypto.PrivateKey) *Account {
 	if account.Registration == nil || account.Registration.Body.Status == "" {
 		reg, err := tryRecoverRegistration(s.ctx, privateKey)
 		if err != nil {
-			log.Fatalf("Could not load account for %s. Registration is nil -> %#v", s.userID, err)
+			log.Fatalf("Could not load account for %s. Registration is nil: %#v", s.userID, err)
 		}
 
 		account.Registration = reg
 		err = s.Save(&account)
 		if err != nil {
-			log.Fatalf("Could not save account for %s. Registration is nil -> %#v", s.userID, err)
+			log.Fatalf("Could not save account for %s. Registration is nil: %#v", s.userID, err)
 		}
 	}
 

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -160,7 +160,7 @@ func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawM
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error talking to PDNS API -> %w", err)
+		return nil, fmt.Errorf("error talking to PDNS API: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -188,7 +188,7 @@ func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawM
 			return nil, err
 		}
 		if errInfo.ShortMsg != "" {
-			return nil, fmt.Errorf("error talking to PDNS API -> %w", errInfo)
+			return nil, fmt.Errorf("error talking to PDNS API: %w", errInfo)
 		}
 	}
 	return msg, nil

--- a/providers/http/memcached/memcached.go
+++ b/providers/http/memcached/memcached.go
@@ -48,7 +48,7 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	if len(errs) == len(w.hosts) {
-		return fmt.Errorf("unable to store key in any of the memcache hosts -> %v", errs)
+		return fmt.Errorf("unable to store key in any of the memcache hosts: %v", errs)
 	}
 
 	return nil

--- a/providers/http/webroot/webroot.go
+++ b/providers/http/webroot/webroot.go
@@ -32,12 +32,12 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 	challengeFilePath := filepath.Join(w.path, http01.ChallengePath(token))
 	err = os.MkdirAll(filepath.Dir(challengeFilePath), 0755)
 	if err != nil {
-		return fmt.Errorf("could not create required directories in webroot for HTTP challenge -> %w", err)
+		return fmt.Errorf("could not create required directories in webroot for HTTP challenge: %w", err)
 	}
 
 	err = ioutil.WriteFile(challengeFilePath, []byte(keyAuth), 0644)
 	if err != nil {
-		return fmt.Errorf("could not write file in webroot for HTTP challenge -> %w", err)
+		return fmt.Errorf("could not write file in webroot for HTTP challenge: %w", err)
 	}
 
 	return nil
@@ -47,7 +47,7 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 func (w *HTTPProvider) CleanUp(domain, token, keyAuth string) error {
 	err := os.Remove(filepath.Join(w.path, http01.ChallengePath(token)))
 	if err != nil {
-		return fmt.Errorf("could not remove file in webroot after HTTP challenge -> %w", err)
+		return fmt.Errorf("could not remove file in webroot after HTTP challenge: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Replaces arrows (`->`) to a more standard separator (`:`).

This avoid this kind of output:
```
acme: Error -\u003e 
```

Because some users think that `\u003e` is an error code.

https://community.containo.us/t/dns-01-challenge-with-ovh-not-working-acme-error-cleaning-up-ovh-unknown-record-id-acme-error-u003e/5030