### PR TITLE
ns1: fix missing domain in log 

### DIFF
--- a/providers/dns/ns1/ns1.go
+++ b/providers/dns/ns1/ns1.go
@@ -96,7 +96,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	// Create a new record
 	if err == rest.ErrRecordMissing || record == nil {
-		log.Infof("Create a new record for [zone: %s, fqdn: %s, domain: %s]", zone.Zone, fqdn)
+		log.Infof("Create a new record for [zone: %s, fqdn: %s, domain: %s]", zone.Zone, fqdn, domain)
 
 		record = dns.NewRecord(zone.Zone, dns01.UnFqdn(fqdn), "TXT")
 		record.TTL = d.config.TTL


### PR DESCRIPTION
I was using the ns1 DNS provider and saw the following weird message when it was trying to create a new record: 

```
Create a new record for [zone: mydomain.st, fqdn: _acme-challenge.mydomain.st., domain: %!s(MISSING)]
```

I had initially thought I had done something wrong programmatically on my end, but I think it's only an issue with regards to what we print to STDOUT.  