### PR TITLE
azure: Allow for the use of MSI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.54.0
 	github.com/Azure/azure-sdk-for-go v32.4.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.5.0
-	github.com/Azure/go-autorest/autorest/adal v0.2.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.1.0
 	github.com/Azure/go-autorest/autorest/to v0.2.0
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-acme/lego/v3/challenge/dns01"
@@ -240,20 +238,8 @@ func toRelativeRecord(domain, zone string) string {
 
 func getAuthorizer(config *Config) (autorest.Authorizer, error) {
 	if config.ClientID != "" && config.ClientSecret != "" && config.TenantID != "" {
-		oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, config.TenantID)
-		if err != nil {
-			return nil, err
-		}
-
-		spt, err := adal.NewServicePrincipalToken(*oauthConfig, config.ClientID, config.ClientSecret, azure.PublicCloud.ResourceManagerEndpoint)
-		if err != nil {
-			return nil, err
-		}
-
-		spt.SetSender(config.HTTPClient)
-		return autorest.NewBearerAuthorizer(spt), nil
+		return auth.NewClientCredentialsConfig(config.ClientID, config.ClientSecret, config.TenantID).Authorizer()
 	}
-
 	return auth.NewAuthorizerFromEnvironment()
 }
 


### PR DESCRIPTION
Azure provide a way to associate an identity to an instance via [user-managed-identity]( https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).

This PR allows lego to use that identity by updating the azure api to get its credential.

This should be retro-compatible to the previous way to get credentials.