### PR TITLE
godaddy: allow parallel solve.

### DIFF
--- a/providers/dns/godaddy/client.go
+++ b/providers/dns/godaddy/client.go
@@ -7,35 +7,64 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // DNSRecord a DNS record
 type DNSRecord struct {
-	Type     string `json:"type"`
-	Name     string `json:"name"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
 	Data     string `json:"data"`
 	Priority int    `json:"priority,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 }
 
-func (d *DNSProvider) updateRecords(records []DNSRecord, domainZone string, recordName string) error {
+func (d *DNSProvider) getRecords(domainZone string, rType string, recordName string) ([]DNSRecord, error) {
+	resource := path.Clean(fmt.Sprintf("/v1/domains/%s/records/%s/%s", domainZone, rType, recordName))
+
+	resp, err := d.makeRequest(http.MethodGet, resource, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("could not get records: Domain: %s; Record: %s, Status: %v; Body: %s",
+			domainZone, recordName, resp.StatusCode, string(bodyBytes))
+	}
+
+	var records []DNSRecord
+	err = json.NewDecoder(resp.Body).Decode(&records)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+func (d *DNSProvider) updateTxtRecords(records []DNSRecord, domainZone string, recordName string) error {
 	body, err := json.Marshal(records)
 	if err != nil {
 		return err
 	}
 
+	resource := path.Clean(fmt.Sprintf("/v1/domains/%s/records/TXT/%s", domainZone, recordName))
+
 	var resp *http.Response
-	resp, err = d.makeRequest(http.MethodPut, fmt.Sprintf("/v1/domains/%s/records/TXT/%s", domainZone, recordName), bytes.NewReader(body))
+	resp, err = d.makeRequest(http.MethodPut, resource, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("could not create record %v; Status: %v; Body: %s", string(body), resp.StatusCode, string(bodyBytes))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION

```console
$ ./lego -m email@example.com --dns godaddy -d *.example.org -d example.org -s https://acme-staging-v02.api.letsencrypt.org/directory run

2020/04/17 13:11:31 Please review the TOS at https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf
Do you accept the TOS? Y/n
y
2020/04/17 13:11:40 [INFO] acme: Registering account for email@example.com
!!!! HEADS UP !!!!

                Your account credentials have been saved in your Let's Encrypt
                configuration directory at "/home/ldez/sources/go/src/github.com/go-acme/lego/.lego/accounts".
                You should make a secure backup of this folder now. This
                configuration directory will also contain certificates and
                private keys obtained from Let's Encrypt so making regular
                backups of this folder is ideal.2020/04/17 13:11:41 [INFO] [*.example.org, example.org] acme: Obtaining bundled SAN certificate
2020/04/17 13:11:42 [INFO] [*.example.org] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/49829715
2020/04/17 13:11:42 [INFO] [example.org] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/49829716
2020/04/17 13:11:42 [INFO] [*.example.org] acme: use dns-01 solver
2020/04/17 13:11:42 [INFO] [example.org] acme: Could not find solver for: tls-alpn-01
2020/04/17 13:11:42 [INFO] [example.org] acme: Could not find solver for: http-01
2020/04/17 13:11:42 [INFO] [example.org] acme: use dns-01 solver
2020/04/17 13:11:42 [INFO] [*.example.org] acme: Preparing to solve DNS-01
2020/04/17 13:11:45 [INFO] [example.org] acme: Preparing to solve DNS-01
2020/04/17 13:11:46 [INFO] [*.example.org] acme: Trying to solve DNS-01
2020/04/17 13:11:46 [INFO] [*.example.org] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/04/17 13:11:46 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2020/04/17 13:11:46 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:11:48 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:11:51 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:11:53 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:11:55 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:11:58 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:12:00 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:12:02 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:12:04 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:12:07 [INFO] [*.example.org] acme: Waiting for DNS record propagation.
2020/04/17 13:12:15 [INFO] [*.example.org] The server validated our request
2020/04/17 13:12:15 [INFO] [example.org] acme: Trying to solve DNS-01
2020/04/17 13:12:15 [INFO] [example.org] acme: Checking DNS record propagation using [192.168.1.1:53]
2020/04/17 13:12:15 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2020/04/17 13:12:23 [INFO] [example.org] The server validated our request
2020/04/17 13:12:23 [INFO] [*.example.org] acme: Cleaning DNS-01 challenge
2020/04/17 13:12:25 [INFO] [example.org] acme: Cleaning DNS-01 challenge
2020/04/17 13:12:26 [INFO] [*.example.org, example.org] acme: Validations succeeded; requesting certificates
2020/04/17 13:12:28 [INFO] [*.example.org] Server responded with a certificate.

```

Fix #1113