### PR TITLE
Fix exoscale HTTP timeout

### DIFF
--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -47,7 +47,7 @@ func NewDefaultConfig() *Config {
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30),
+			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }


### PR DESCRIPTION
The second argument of `GetOrDefaultSecond` should be of type `time.Duration`.
When passing in a straight `int`, the argument will be interpreted as nanoseconds. This causes all HTTP requests to time out.