### PR TITLE
mythicbeasts: Update API base URL for released v2 API

### DIFF
--- a/providers/dns/mythicbeasts/client.go
+++ b/providers/dns/mythicbeasts/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	apiBaseURL  = "https://api.mythic-beasts.com/beta/dns"
+	apiBaseURL  = "https://api.mythic-beasts.com/dns/v2"
 	authBaseURL = "https://auth.mythic-beasts.com/login"
 )
 


### PR DESCRIPTION
Mythic Beasts just released their v2 api officially, so this updates
the API endpoint to use it.

This should fix #1129 and thus make it sane to do a release with this provider in.