### PR TITLE
Registrar.ResolveAccountByKey: Fix issues found testing with Pebble

### DIFF
--- a/registration/registar.go
+++ b/registration/registar.go
@@ -156,10 +156,10 @@ func (r *Registrar) ResolveAccountByKey() (*Resource, error) {
 	log.Infof("acme: Trying to resolve account by key")
 
 	accMsg := acme.Account{OnlyReturnExisting: true}
-	resp, err := r.core.Accounts.New(accMsg)
+	account, err := r.core.Accounts.New(accMsg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Resource{URI: resp.Location, Body: resp.Account}, nil
+	return &Resource{URI: account.Location, Body: account.Account}, nil
 }

--- a/registration/registar.go
+++ b/registration/registar.go
@@ -156,15 +156,10 @@ func (r *Registrar) ResolveAccountByKey() (*Resource, error) {
 	log.Infof("acme: Trying to resolve account by key")
 
 	accMsg := acme.Account{OnlyReturnExisting: true}
-	accountTransit, err := r.core.Accounts.New(accMsg)
+	resp, err := r.core.Accounts.New(accMsg)
 	if err != nil {
 		return nil, err
 	}
 
-	account, err := r.core.Accounts.Get(accountTransit.Location)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Resource{URI: accountTransit.Location, Body: account}, nil
+	return &Resource{URI: resp.Location, Body: resp.Account}, nil
 }

--- a/registration/registar_test.go
+++ b/registration/registar_test.go
@@ -18,14 +18,7 @@ func TestRegistrar_ResolveAccountByKey(t *testing.T) {
 	defer tearDown()
 
 	mux.HandleFunc("/account", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Location", apiURL+"/account_recovery")
-		_, err := w.Write([]byte("{}"))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	mux.HandleFunc("/account_recovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", apiURL+"/account")
 		err := tester.WriteJSONResponse(w, acme.Account{
 			Status: "valid",
 		})


### PR DESCRIPTION
We use [pebble:latest](https://github.com/letsencrypt/pebble) as a way to integration-test our own LetsEncrypt certificate fetcher. 

One notable issue I found was that the `Registrar.ResolveAccountByKey` method errors out when we try to resolve an existing account with the following error: 

```
unable to resolve account by key: acme: error: 400 :: POST :: https://127.0.0.1:14000/my-account/1 :: urn:ietf:params:acme:e
rror:malformed :: Use POST-as-GET to retrieve account data instead of doing an empty update
```

Based on the pebble source [here](https://github.com/letsencrypt/pebble/blob/35691f87bc2df5a34577c4617975e269eec86f87/wfe/wfe.go#L987), our `POST-as-GET` gets interpreted as an update call and is failed as a malformed request. 

It seems like we used to be able to get account information this way, but this seems to have changed as a result of: https://github.com/letsencrypt/pebble/pull/171