### PR TITLE
Upgrade DNSimple client to 0.60.0

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -478,11 +478,11 @@ func displayDNSHelp(name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "DNSIMPLE_BASE_URL":	API endpoint URL`)
 		ew.writeln(`	- "DNSIMPLE_OAUTH_TOKEN":	OAuth token`)
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "DNSIMPLE_BASE_URL":	API endpoint URL`)
 		ew.writeln(`	- "DNSIMPLE_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "DNSIMPLE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
 		ew.writeln(`	- "DNSIMPLE_TTL":	The TTL of the TXT record used for the DNS challenge`)

--- a/docs/content/dns/zz_gen_dnsimple.md
+++ b/docs/content/dns/zz_gen_dnsimple.md
@@ -18,9 +18,12 @@ Configuration for [DNSimple](https://dnsimple.com/).
 
 - Code: `dnsimple`
 
-{{% notice note %}}
-_Please contribute by adding a CLI example._
-{{% /notice %}}
+Here is an example bash command using the DNSimple provider:
+
+```bash
+DNSIMPLE_OAUTH_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
+lego --dns dnsimple --domains my.domain.com --email my@email.com run
+```
 
 
 
@@ -29,7 +32,6 @@ _Please contribute by adding a CLI example._
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `DNSIMPLE_BASE_URL` | API endpoint URL |
 | `DNSIMPLE_OAUTH_TOKEN` | OAuth token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
@@ -40,6 +42,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `DNSIMPLE_BASE_URL` | API endpoint URL |
 | `DNSIMPLE_POLLING_INTERVAL` | Time between DNS propagation check |
 | `DNSIMPLE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 | `DNSIMPLE_TTL` | The TTL of the TXT record used for the DNS challenge |
@@ -47,6 +50,21 @@ More information [here](/lego/dns/#configuration-and-credentials).
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here](/lego/dns/#configuration-and-credentials).
 
+## Description
+
+`DNSIMPLE_BASE_URL` is optional and must be set to production (https://api.dnsimple.com).
+if `DNSIMPLE_BASE_URL` is not defined or empty, the production URL is used by default.
+
+While you can manage DNS records in the [DNSimple Sandbox environment](https://developer.dnsimple.com/sandbox/),
+DNS records will not resolve and you will not be able to satisfy the ACME DNS challenge.
+
+To authenticate you need to provide a valid API token.
+HTTP Basic Authentication is intentionally not supported.
+
+### API tokens
+
+You can [generate a new API token](https://support.dnsimple.com/articles/api-access-token/) from your account page.
+Only Account API tokens are supported, if you try to use an User API token you will receive an error message.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/cloudflare/cloudflare-go v0.10.2
 	github.com/cpu/goacmedns v0.0.2
-	github.com/dnsimple/dnsimple-go v0.30.0
+	github.com/dnsimple/dnsimple-go v0.60.0
 	github.com/exoscale/egoscale v0.18.1
 	github.com/google/go-querystring v1.0.0
 	github.com/gophercloud/gophercloud v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TR
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v0.0.0-20180814043457-aafff18a5cc2 h1:G9/PqfhOrt8JXnw0DGTfVoOkKHDhOlEZqhE/cu+NvQM=
 github.com/dnaeon/go-vcr v0.0.0-20180814043457-aafff18a5cc2/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/dnsimple/dnsimple-go v0.30.0 h1:IBIrn9jMKRMwporIRwdFyKdnHXVmwy6obnguB+ZMDIY=
-github.com/dnsimple/dnsimple-go v0.30.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
+github.com/dnsimple/dnsimple-go v0.60.0 h1:N+q+ML1CZGf+5r4udu9Opy7WJNtOaFT9aM86Af9gLhk=
+github.com/dnsimple/dnsimple-go v0.60.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -75,7 +75,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.AccessToken})
 	client := dnsimple.NewClient(oauth2.NewClient(context.Background(), ts))
-	client.SetUserAgent("lego-cli")
+	client.SetUserAgent("go-acme/lego")
 
 	if config.BaseURL != "" {
 		client.BaseURL = config.BaseURL

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -75,6 +75,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.AccessToken})
 	client := dnsimple.NewClient(oauth2.NewClient(context.Background(), ts))
+	client.SetUserAgent("lego-cli")
 
 	if config.BaseURL != "" {
 		client.BaseURL = config.BaseURL
@@ -98,7 +99,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	recordAttributes := newTxtRecord(zoneName, fqdn, value, d.config.TTL)
-	_, err = d.client.Zones.CreateRecord(accountID, zoneName, recordAttributes)
+	_, err = d.client.Zones.CreateRecord(context.Background(), accountID, zoneName, recordAttributes)
 	if err != nil {
 		return fmt.Errorf("dnsimple: API call failed: %w", err)
 	}
@@ -122,7 +123,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	var lastErr error
 	for _, rec := range records {
-		_, err := d.client.Zones.DeleteRecord(accountID, rec.ZoneID, rec.ID)
+		_, err := d.client.Zones.DeleteRecord(context.Background(), accountID, rec.ZoneID, rec.ID)
 		if err != nil {
 			lastErr = fmt.Errorf("dnsimple: %w", err)
 		}
@@ -150,7 +151,7 @@ func (d *DNSProvider) getHostedZone(domain string) (string, error) {
 
 	zoneName := dns01.UnFqdn(authZone)
 
-	zones, err := d.client.Zones.ListZones(accountID, &dnsimple.ZoneListOptions{NameLike: zoneName})
+	zones, err := d.client.Zones.ListZones(context.Background(), accountID, &dnsimple.ZoneListOptions{NameLike: &zoneName})
 	if err != nil {
 		return "", fmt.Errorf("API call failed: %w", err)
 	}
@@ -182,7 +183,7 @@ func (d *DNSProvider) findTxtRecords(domain, fqdn string) ([]dnsimple.ZoneRecord
 
 	recordName := extractRecordName(fqdn, zoneName)
 
-	result, err := d.client.Zones.ListRecords(accountID, zoneName, &dnsimple.ZoneRecordListOptions{Name: recordName, Type: "TXT", ListOptions: dnsimple.ListOptions{}})
+	result, err := d.client.Zones.ListRecords(context.Background(), accountID, zoneName, &dnsimple.ZoneRecordListOptions{Name: &recordName, Type: dnsimple.String("TXT"), ListOptions: dnsimple.ListOptions{}})
 	if err != nil {
 		return nil, fmt.Errorf("API call has failed: %w", err)
 	}
@@ -190,12 +191,12 @@ func (d *DNSProvider) findTxtRecords(domain, fqdn string) ([]dnsimple.ZoneRecord
 	return result.Data, nil
 }
 
-func newTxtRecord(zoneName, fqdn, value string, ttl int) dnsimple.ZoneRecord {
+func newTxtRecord(zoneName, fqdn, value string, ttl int) dnsimple.ZoneRecordAttributes {
 	name := extractRecordName(fqdn, zoneName)
 
-	return dnsimple.ZoneRecord{
+	return dnsimple.ZoneRecordAttributes{
 		Type:    "TXT",
-		Name:    name,
+		Name:    &name,
 		Content: value,
 		TTL:     ttl,
 	}
@@ -210,7 +211,7 @@ func extractRecordName(fqdn, domain string) string {
 }
 
 func (d *DNSProvider) getAccountID() (string, error) {
-	whoamiResponse, err := d.client.Identity.Whoami()
+	whoamiResponse, err := d.client.Identity.Whoami(context.Background())
 	if err != nil {
 		return "", err
 	}

--- a/providers/dns/dnsimple/dnsimple.toml
+++ b/providers/dns/dnsimple/dnsimple.toml
@@ -5,7 +5,6 @@ Code = "dnsimple"
 Since = "v0.3.0"
 
 Example = '''
-DNSIMPLE_BASE_URL=https://api.dnsimple.com \
 DNSIMPLE_OAUTH_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
 lego --dns dnsimple --domains my.domain.com --email my@email.com run
 '''
@@ -13,10 +12,14 @@ lego --dns dnsimple --domains my.domain.com --email my@email.com run
 Additional = '''
 ## Description
 
-You should set `DNSIMPLE_BASE_URL` to production. While you can manage DNS records in the [DNSimple Sandbox environment](https://developer.dnsimple.com/sandbox/),
+`DNSIMPLE_BASE_URL` is optional and must be set to production (https://api.dnsimple.com).
+if `DNSIMPLE_BASE_URL` is not defined or empty, the production URL is used by default.
+
+While you can manage DNS records in the [DNSimple Sandbox environment](https://developer.dnsimple.com/sandbox/),
 DNS records will not resolve and you will not be able to satisfy the ACME DNS challenge.
 
-To authenticate you need to provide a valid API token. HTTP Basic Authentication is intentionally not supported.
+To authenticate you need to provide a valid API token.
+HTTP Basic Authentication is intentionally not supported.
 
 ### API tokens
 
@@ -27,8 +30,8 @@ Only Account API tokens are supported, if you try to use an User API token you w
 [Configuration]
   [Configuration.Credentials]
     DNSIMPLE_OAUTH_TOKEN = "OAuth token"
-    DNSIMPLE_BASE_URL = "API endpoint URL"
   [Configuration.Additional]
+    DNSIMPLE_BASE_URL = "API endpoint URL"
     DNSIMPLE_POLLING_INTERVAL = "Time between DNS propagation check"
     DNSIMPLE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     DNSIMPLE_TTL = "The TTL of the TXT record used for the DNS challenge"

--- a/providers/dns/dnsimple/dnsimple.toml
+++ b/providers/dns/dnsimple/dnsimple.toml
@@ -4,7 +4,25 @@ URL = "https://dnsimple.com/"
 Code = "dnsimple"
 Since = "v0.3.0"
 
-Example = ''''''
+Example = '''
+DNSIMPLE_BASE_URL=https://api.dnsimple.com \
+DNSIMPLE_OAUTH_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz \
+lego --dns dnsimple --domains my.domain.com --email my@email.com run
+'''
+
+Additional = '''
+## Description
+
+You should set `DNSIMPLE_BASE_URL` to production. While you can manage DNS records in the [DNSimple Sandbox environment](https://developer.dnsimple.com/sandbox/),
+DNS records will not resolve and you will not be able to satisfy the ACME DNS challenge.
+
+To authenticate you need to provide a valid API token. HTTP Basic Authentication is intentionally not supported.
+
+### API tokens
+
+You can [generate a new API token](https://support.dnsimple.com/articles/api-access-token/) from your account page.
+Only Account API tokens are supported, if you try to use an User API token you will receive an error message.
+'''
 
 [Configuration]
   [Configuration.Credentials]


### PR DESCRIPTION
This PR upgrades the DNSimple client powering the DNSimple provider to the latest version.

There has been a number of changes compared to v0.30.0 that is currently in use, including some fixes that could have prevented the client to miss the proper TXT record to cleanup.

I also took the time to expand the docs with some CLI examples.
