### PR TITLE
fetchSoaByFqdn: retry DNS query

### DIFF
--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -178,6 +178,13 @@ func fetchSoaByFqdn(fqdn string, nameservers []string) (*soaCacheEntry, error) {
 		domain := fqdn[index:]
 
 		in, err = dnsQuery(domain, dns.TypeSOA, nameservers, true)
+
+		retry := 3
+		for err != nil && retry > 0 {
+			in, err = dnsQuery(domain, dns.TypeSOA, nameservers, true)
+			retry--
+		}
+
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
This is a very crude solution (I don't fully understand the failure modes of `dnsQuery`) to demonstrate https://github.com/go-acme/lego/issues/1008.

I suspect you will want something more robust, maybe react differently on different class of error, but it does solve (or greatly mitigate) the problem for me.