### PR TITLE
doc: always display CLI help.

### DIFF
--- a/docs/content/usage/cli/_index.md
+++ b/docs/content/usage/cli/_index.md
@@ -10,7 +10,6 @@ Lego can be use as a CLI.
 
 ## Usage
 
-{{%expand "CLI help" %}}
 ```slim
 NAME:
    lego - Let's Encrypt client written in Go
@@ -55,8 +54,6 @@ GLOBAL OPTIONS:
    --help, -h                   show help
    --version, -v                print the version
 ```
-{{% /expand%}}
-
 
 When using the standard `--path` option, all certificates and account configurations are saved to a folder `.lego` in the current working directory.
 


### PR DESCRIPTION
https://github.com/go-acme/lego/issues/1183#issuecomment-642089179