### PR TITLE
dns/rfc2136: fix provider for legacy DynDNS Pro accounts

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1406,7 +1406,7 @@ func displayDNSHelp(name string) error {
 
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "RFC2136_NAMESERVER":	Network address in the form "host" or "host:port"`)
-		ew.writeln(`	- "RFC2136_TSIG_ALGORITHM":	TSIG algorythm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the 'RFC2136_TSIG*' variables unset.`)
+		ew.writeln(`	- "RFC2136_TSIG_ALGORITHM":	TSIG algorithm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the 'RFC2136_TSIG*' variables unset.`)
 		ew.writeln(`	- "RFC2136_TSIG_KEY":	Name of the secret key as defined in DNS server configuration. To disable TSIG authentication, leave the 'RFC2136_TSIG*' variables unset.`)
 		ew.writeln(`	- "RFC2136_TSIG_SECRET":	Secret key payload. To disable TSIG authentication, leave the' RFC2136_TSIG*' variables unset.`)
 		ew.writeln()

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1414,6 +1414,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "RFC2136_DNS_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "RFC2136_POLLING_INTERVAL":	Time between DNS propagation check`)
+		ew.writeln(`	- "RFC2136_PRIMARY":	Network address of the primary server for the DNS Update requests. If unset, Lego will automatically find the zone apex for the update.`)
 		ew.writeln(`	- "RFC2136_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
 		ew.writeln(`	- "RFC2136_SEQUENCE_INTERVAL":	Interval between iteration`)
 		ew.writeln(`	- "RFC2136_TTL":	The TTL of the TXT record used for the DNS challenge`)

--- a/docs/content/dns/zz_gen_rfc2136.md
+++ b/docs/content/dns/zz_gen_rfc2136.md
@@ -30,7 +30,7 @@ _Please contribute by adding a CLI example._
 | Environment Variable Name | Description |
 |-----------------------|-------------|
 | `RFC2136_NAMESERVER` | Network address in the form "host" or "host:port" |
-| `RFC2136_TSIG_ALGORITHM` | TSIG algorythm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset. |
+| `RFC2136_TSIG_ALGORITHM` | TSIG algorithm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset. |
 | `RFC2136_TSIG_KEY` | Name of the secret key as defined in DNS server configuration. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset. |
 | `RFC2136_TSIG_SECRET` | Secret key payload. To disable TSIG authentication, leave the` RFC2136_TSIG*` variables unset. |
 

--- a/docs/content/dns/zz_gen_rfc2136.md
+++ b/docs/content/dns/zz_gen_rfc2136.md
@@ -44,6 +44,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 |--------------------------------|-------------|
 | `RFC2136_DNS_TIMEOUT` | API request timeout |
 | `RFC2136_POLLING_INTERVAL` | Time between DNS propagation check |
+| `RFC2136_PRIMARY` | Network address of the primary server for the DNS Update requests. If unset, Lego will automatically find the zone apex for the update. |
 | `RFC2136_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 | `RFC2136_SEQUENCE_INTERVAL` | Interval between iteration |
 | `RFC2136_TTL` | The TTL of the TXT record used for the DNS challenge |

--- a/providers/dns/rfc2136/rfc2136.toml
+++ b/providers/dns/rfc2136/rfc2136.toml
@@ -10,7 +10,7 @@ Example = ''''''
   [Configuration.Credentials]
     RFC2136_TSIG_KEY = "Name of the secret key as defined in DNS server configuration. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset."
     RFC2136_TSIG_SECRET = "Secret key payload. To disable TSIG authentication, leave the` RFC2136_TSIG*` variables unset."
-    RFC2136_TSIG_ALGORITHM = "TSIG algorythm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset."
+    RFC2136_TSIG_ALGORITHM = "TSIG algorithm. See [miekg/dns#tsig.go](https://github.com/miekg/dns/blob/master/tsig.go) for supported values. To disable TSIG authentication, leave the `RFC2136_TSIG*` variables unset."
     RFC2136_NAMESERVER = 'Network address in the form "host" or "host:port"'
   [Configuration.Additional]
     RFC2136_POLLING_INTERVAL = "Time between DNS propagation check"

--- a/providers/dns/rfc2136/rfc2136.toml
+++ b/providers/dns/rfc2136/rfc2136.toml
@@ -18,6 +18,7 @@ Example = ''''''
     RFC2136_TTL = "The TTL of the TXT record used for the DNS challenge"
     RFC2136_DNS_TIMEOUT = "API request timeout"
     RFC2136_SEQUENCE_INTERVAL = "Interval between iteration"
+    RFC2136_PRIMARY = "Network address of the primary server for the DNS Update requests. If unset, Lego will automatically find the zone apex for the update."
 
 [Links]
   API = "https://tools.ietf.org/html/rfc2136"


### PR DESCRIPTION
The DNS provider for legacy DynDNS accounts does not seem to respond properly to SOA requests, which breaks the zone apex detection.

This commit gives the user a chance to skip the SOA lookup and directly provide the name for the primary DNS server (also known as SOA MNAME) in an environment variable.

Fixes #1186.