### PR TITLE
hetzner: fix record name.

### DIFF
--- a/providers/dns/hetzner/hetzner.go
+++ b/providers/dns/hetzner/hetzner.go
@@ -113,7 +113,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	record := internal.DNSRecord{
 		Type:   "TXT",
-		Name:   d.extractRecordName(fqdn, domain),
+		Name:   d.extractRecordName(fqdn, zone),
 		Value:  value,
 		TTL:    d.config.TTL,
 		ZoneID: zoneID,
@@ -140,7 +140,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("hetzner: %w", err)
 	}
 
-	recordName := d.extractRecordName(fqdn, domain)
+	recordName := d.extractRecordName(fqdn, zone)
 
 	record, err := d.client.GetTxtRecord(recordName, value, zoneID)
 	if err != nil {

--- a/providers/dns/hetzner/hetzner.go
+++ b/providers/dns/hetzner/hetzner.go
@@ -101,7 +101,7 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
 
-	zone, err := d.getZone(fqdn)
+	zone, err := getZone(fqdn)
 	if err != nil {
 		return fmt.Errorf("hetzner: failed to find zone: fqdn=%s: %w", fqdn, err)
 	}
@@ -113,7 +113,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	record := internal.DNSRecord{
 		Type:   "TXT",
-		Name:   d.extractRecordName(fqdn, zone),
+		Name:   extractRecordName(fqdn, zone),
 		Value:  value,
 		TTL:    d.config.TTL,
 		ZoneID: zoneID,
@@ -130,7 +130,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, value := dns01.GetRecord(domain, keyAuth)
 
-	zone, err := d.getZone(fqdn)
+	zone, err := getZone(fqdn)
 	if err != nil {
 		return fmt.Errorf("hetzner: failed to find zone: fqdn=%s: %w", fqdn, err)
 	}
@@ -140,7 +140,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("hetzner: %w", err)
 	}
 
-	recordName := d.extractRecordName(fqdn, zone)
+	recordName := extractRecordName(fqdn, zone)
 
 	record, err := d.client.GetTxtRecord(recordName, value, zoneID)
 	if err != nil {
@@ -154,15 +154,15 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	return nil
 }
 
-func (d *DNSProvider) extractRecordName(fqdn, domain string) string {
+func extractRecordName(fqdn, zone string) string {
 	name := dns01.UnFqdn(fqdn)
-	if idx := strings.Index(name, "."+domain); idx != -1 {
+	if idx := strings.Index(name, "."+zone); idx != -1 {
 		return name[:idx]
 	}
 	return name
 }
 
-func (d *DNSProvider) getZone(fqdn string) (string, error) {
+func getZone(fqdn string) (string, error) {
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Hi folks,

Hope you're doing well.

I've made a PR to fix an issue that I'm having with the Hetzner DNS provider. From what I understand in the current situation when you try to request a certificate for let's say ``test.frikandel.nl`` the following will happen:

- It will recurse DNS to find SOA of ``test.frikandel.nl`` and then try to fetch this zone via Hetzner API, in this case SOA is ``frikandel.nl``
- When it succesfully finds SOA it will query the Hetzner Zone ID from Hetzner API for further requests
- From FQDN, in this case ``_acme-challenge.test.frikandel.nl.``, it will strip the domain provided by user, in this case ``test.frikandel.nl`` resulting in ``_acme-challenge``
- It will create ``_acme-challenge`` in DNS via Hetzner API which will result in ``_acme-challenge.frikandel.nl.``

To my understanding this is not correct, the TXT-record should be on ``_acme-challenge.test.frikandel.nl.``. 

What I've done is a simple change and I hope it'll do fine. (for me it does but I'm not really well invested in your code). Instead of passing the domain provided by user to the function used to strip the domain from FQDN it will pass the SOA domain so the correct relative record will be created.

Thanks for your consideration and feedback!

Best regards,

Juergen Brunink