### PR TITLE
fix: multi-va.

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -126,6 +126,8 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 	log.Infof("[%s] acme: Checking DNS record propagation using %+v", domain, recursiveNameservers)
 
+	time.Sleep(interval)
+
 	err = wait.For("propagation", timeout, interval, func() (bool, error) {
 		stop, errP := c.preCheck.call(domain, fqdn, value)
 		if !stop || errP != nil {


### PR DESCRIPTION
Related to:

- https://community.letsencrypt.org/t/during-secondary-validation-incorrect-txt-record/113643
- https://community.letsencrypt.org/t/acme-v1-v2-validating-challenges-from-multiple-network-vantage-points/112253
- https://community.letsencrypt.org/t/during-secondary-validation-incorrect-txt-record/113643


