### PR TITLE
doc: improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# lego
+# ![lego](./docs/static/images/logo.png)
 
 Let's Encrypt client and ACME library written in Go.
 
-[![GoDoc](https://godoc.org/github.com/go-acme/lego?status.svg)](https://godoc.org/github.com/go-acme/lego/acme)
+[![GoDoc](https://godoc.org/github.com/go-acme/lego?status.svg)](https://pkg.go.dev/mod/github.com/go-acme/lego/v3)
 [![Build Status](https://travis-ci.com/go-acme/lego.svg?branch=master)](https://travis-ci.com/go-acme/lego)
 [![Docker Pulls](https://img.shields.io/docker/pulls/goacme/lego.svg)](https://hub.docker.com/r/goacme/lego/)
 

--- a/providers/dns/oraclecloud/oraclecloud.go
+++ b/providers/dns/oraclecloud/oraclecloud.go
@@ -1,3 +1,4 @@
+// Package oraclecloud implements a DNS provider for solving the DNS-01 challenge using Oracle Cloud DNS.
 package oraclecloud
 
 import (


### PR DESCRIPTION
- use https://pkg.go.dev instead of https://godoc.org
- add godoc on oracle package.