### PR TITLE
desec: Fix version in docs

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -432,7 +432,7 @@ func displayDNSHelp(name string) error {
 		// generated from: providers/dns/desec/desec.toml
 		ew.writeln(`Configuration for deSEC.io.`)
 		ew.writeln(`Code:	'desec'`)
-		ew.writeln(`Since:	'v0.3.7'`)
+		ew.writeln(`Since:	'v3.7.0'`)
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)

--- a/docs/content/dns/zz_gen_desec.md
+++ b/docs/content/dns/zz_gen_desec.md
@@ -9,7 +9,7 @@ slug: desec
 <!-- providers/dns/desec/desec.toml -->
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 
-Since: v0.3.7
+Since: v3.7.0
 
 Configuration for [deSEC.io](https://desec.io).
 

--- a/providers/dns/desec/desec.toml
+++ b/providers/dns/desec/desec.toml
@@ -2,7 +2,7 @@ Name = "deSEC.io"
 Description = ''''''
 URL = "https://desec.io"
 Code = "desec"
-Since = "v0.3.7"
+Since = "v3.7.0"
 
 Example = '''
 DESEC_TOKEN=x-xxxxxxxxxxxxxxxxxxxxxxxxxx \


### PR DESCRIPTION
The deSEC.io DNS provider was added in verision 3.7.0. The docs incorrectly state it was added 0.3.7. This PR cleans that up.