### PR TITLE
chore: update linter.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -38,6 +38,7 @@
     "nestif", # too many false-positive
     "goerr113", # not relevant
     "noctx",
+    "nlreturn",
   ]
 
 [issues]

--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -11,7 +11,7 @@ const (
 	// overallRequestLimit is the overall number of request per second
 	// limited on the "new-reg", "new-authz" and "new-cert" endpoints.
 	// From the documentation the limitation is 20 requests per second,
-	// but using 20 as value doesn't work but 18 do
+	// but using 20 as value doesn't work but 18 do.
 	overallRequestLimit = 18
 )
 

--- a/challenge/challenges.go
+++ b/challenge/challenges.go
@@ -11,11 +11,11 @@ type Type string
 
 const (
 	// HTTP01 is the "http-01" ACME challenge https://tools.ietf.org/html/rfc8555#section-8.3
-	// Note: ChallengePath returns the URL path to fulfill this challenge
+	// Note: ChallengePath returns the URL path to fulfill this challenge.
 	HTTP01 = Type("http-01")
 
 	// DNS01 is the "dns-01" ACME challenge https://tools.ietf.org/html/rfc8555#section-8.4
-	// Note: GetRecord returns a DNS record which will fulfill this challenge
+	// Note: GetRecord returns a DNS record which will fulfill this challenge.
 	DNS01 = Type("dns-01")
 
 	// TLSALPN01 is the "tls-alpn-01" ACME challenge https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-07

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -17,13 +17,13 @@ import (
 )
 
 const (
-	// DefaultPropagationTimeout default propagation timeout
+	// DefaultPropagationTimeout default propagation timeout.
 	DefaultPropagationTimeout = 60 * time.Second
 
-	// DefaultPollingInterval default polling interval
+	// DefaultPollingInterval default polling interval.
 	DefaultPollingInterval = 2 * time.Second
 
-	// DefaultTTL default TTL
+	// DefaultTTL default TTL.
 	DefaultTTL = 120
 )
 

--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -27,10 +27,10 @@ const (
 	// the system-wide trusted root list.
 	caServerNameEnvVar = "LEGO_CA_SERVER_NAME"
 
-	// LEDirectoryProduction URL to the Let's Encrypt production
+	// LEDirectoryProduction URL to the Let's Encrypt production.
 	LEDirectoryProduction = "https://acme-v02.api.letsencrypt.org/directory"
 
-	// LEDirectoryStaging URL to the Let's Encrypt staging
+	// LEDirectoryStaging URL to the Let's Encrypt staging.
 	LEDirectoryStaging = "https://acme-staging-v02.api.letsencrypt.org/directory"
 )
 

--- a/providers/dns/conoha/internal/client_test.go
+++ b/providers/dns/conoha/internal/client_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupClientTest() (*http.ServeMux, *Client, func()) {

--- a/providers/dns/gandi/gandi.go
+++ b/providers/dns/gandi/gandi.go
@@ -17,7 +17,7 @@ import (
 // Gandi API domain examples: http://doc.rpc.gandi.net/domain/faq.html
 
 const (
-	// defaultBaseURL Gandi XML-RPC endpoint used by Present and CleanUp
+	// defaultBaseURL Gandi XML-RPC endpoint used by Present and CleanUp.
 	defaultBaseURL = "https://rpc.gandi.net/xmlrpc/"
 	minTTL         = 300
 )

--- a/providers/dns/netcup/internal/client_test.go
+++ b/providers/dns/netcup/internal/client_test.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-acme/lego/v3/platform/tester"
-
 	"github.com/go-acme/lego/v3/challenge/dns01"
+	"github.com/go-acme/lego/v3/platform/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/dns/netcup/netcup.go
+++ b/providers/dns/netcup/netcup.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-acme/lego/v3/providers/dns/netcup/internal"
-
 	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/log"
 	"github.com/go-acme/lego/v3/platform/config/env"
+	"github.com/go-acme/lego/v3/providers/dns/netcup/internal"
 )
 
 // Environment variables names.

--- a/providers/dns/nifcloud/internal/client.go
+++ b/providers/dns/nifcloud/internal/client.go
@@ -15,7 +15,7 @@ import (
 const (
 	defaultBaseURL = "https://dns.api.nifcloud.com"
 	apiVersion     = "2012-12-12N2013-12-16"
-	// XMLNs XML NS of Route53
+	// XMLNs XML NS of Route53.
 	XMLNs = "https://route53.amazonaws.com/doc/2012-12-12/"
 )
 

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -7,11 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-acme/lego/v3/providers/dns/nifcloud/internal"
-
 	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/platform/config/env"
 	"github.com/go-acme/lego/v3/platform/wait"
+	"github.com/go-acme/lego/v3/providers/dns/nifcloud/internal"
 )
 
 // Environment variables names.


### PR DESCRIPTION
Update golangci-lint to v1.30.0.

The version is defined in the Travis settings.