### PR TITLE
Add additional namecheap-specific infos

### DIFF
--- a/docs/content/dns/zz_gen_edgedns.md
+++ b/docs/content/dns/zz_gen_edgedns.md
@@ -10,6 +10,7 @@ slug: edgedns
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 
 Since: v3.9.0
+
 Akamai edgedns supercedes fastdns; implementing a DNS provider for solving the DNS-01 challenge using Akamai EdgeDNS
 
 

--- a/docs/content/dns/zz_gen_namecheap.md
+++ b/docs/content/dns/zz_gen_namecheap.md
@@ -13,6 +13,9 @@ Since: v0.3.0
 
 Configuration for [Namecheap](https://www.namecheap.com).
 
+**To enable API access on the Namecheap production environment, some opaque requirements must be met.** More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation. (2020-08: Account balance of $50+, 20+ domains in your account, or purchases totaling $50+ within the last 2 years.)
+
+
 
 <!--more-->
 

--- a/providers/dns/edgedns/edgedns.toml
+++ b/providers/dns/edgedns/edgedns.toml
@@ -1,5 +1,6 @@
 Name = "Akamai EdgeDNS"
 Description = '''
+
 Akamai edgedns supercedes fastdns; implementing a DNS provider for solving the DNS-01 challenge using Akamai EdgeDNS
 '''
 URL = "https://www.akamai.com/us/en/products/security/edge-dns.jsp"

--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -10,6 +10,12 @@ NAMECHEAP_API_KEY=key \
 lego --dns namecheap --email someaccount@email.com --domains "foo.email.com" run
 '''
 
+Additional = '''
+As of Aug. 2020, to enable API access on the Namecheap production environment, some opaque requirements must be met.
+
+More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation.
+'''
+
 [Configuration]
   [Configuration.Credentials]
     NAMECHEAP_API_USER = "API user"

--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -1,19 +1,18 @@
 Name = "Namecheap"
-Description = ''''''
 URL = "https://www.namecheap.com"
 Code = "namecheap"
 Since = "v0.3.0"
+Description = '''
+
+Configuration for [Namecheap](https://www.namecheap.com).
+
+**To enable API access on the Namecheap production environment, some opaque requirements must be met.** More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation. (2020-08: Account balance of $50+, 20+ domains in your account, or purchases totaling $50+ within the last 2 years.)
+'''
 
 Example = '''
 NAMECHEAP_API_USER=user \
 NAMECHEAP_API_KEY=key \
 lego --dns namecheap --email someaccount@email.com --domains "foo.email.com" run
-'''
-
-Additional = '''
-As of Aug. 2020, to enable API access on the Namecheap production environment, some opaque requirements must be met.
-
-More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation.
 '''
 
 [Configuration]


### PR DESCRIPTION
Currently, only after trying to enable API access, you get to see the following requirements:
"Account balance of $50+, 20+ domains in your account, or purchases totaling $50+ within the last 2 years."

Closes #1229