### PR TITLE
Add optional programmatic configuration of the DNS provider

### DIFF
--- a/challenge/dns01/dns_challenge_manual.go
+++ b/challenge/dns01/dns_challenge_manual.go
@@ -15,7 +15,7 @@ const (
 type DNSProviderManual struct{}
 
 // NewDNSProviderManual returns a DNSProviderManual instance.
-func NewDNSProviderManual() (*DNSProviderManual, error) {
+func NewDNSProviderManual(conf map[string]string) (*DNSProviderManual, error) {
 	return &DNSProviderManual{}, nil
 }
 

--- a/challenge/dns01/dns_challenge_manual_test.go
+++ b/challenge/dns01/dns_challenge_manual_test.go
@@ -44,7 +44,7 @@ func TestDNSProviderManual(t *testing.T) {
 
 			os.Stdin = file
 
-			manualProvider, err := NewDNSProviderManual()
+			manualProvider, err := NewDNSProviderManual(nil)
 			require.NoError(t, err)
 
 			err = manualProvider.Present("example.com", "", "")

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -106,7 +106,7 @@ func setupTLSProvider(ctx *cli.Context) challenge.Provider {
 }
 
 func setupDNS(ctx *cli.Context, client *lego.Client) {
-	provider, err := dns.NewDNSChallengeProviderByName(ctx.GlobalString("dns"))
+	provider, err := dns.NewDNSChallengeProviderByName(ctx.GlobalString("dns"), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -89,7 +89,7 @@ func TestChallengeDNS_Client_Obtain(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	provider, err := dns.NewDNSChallengeProviderByName("exec")
+	provider, err := dns.NewDNSChallengeProviderByName("exec", nil)
 	require.NoError(t, err)
 
 	err = client.Challenge.SetDNS01Provider(provider,

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -42,8 +42,8 @@ type DNSProvider struct {
 
 // NewDNSProvider creates an ACME-DNS provider using file based account storage.
 // Its configuration is loaded from the environment by reading EnvAPIBase and EnvStoragePath.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIBase, EnvStoragePath)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIBase, EnvStoragePath)
 	if err != nil {
 		return nil, fmt.Errorf("acme-dns: %w", err)
 	}

--- a/providers/dns/alidns/alidns.go
+++ b/providers/dns/alidns/alidns.go
@@ -44,12 +44,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 600),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		HTTPTimeout:        env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 600),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		HTTPTimeout:        env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 	}
 }
 
@@ -62,16 +62,16 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Alibaba Cloud DNS.
 // Credentials must be passed in the environment variables:
 // ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAccessKey, EnvSecretKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAccessKey, EnvSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("alicloud: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAccessKey]
 	config.SecretKey = values[EnvSecretKey]
-	config.RegionID = env.GetOrFile(EnvRegionID)
+	config.RegionID = env.GetOrFile(conf, EnvRegionID)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/alidns/alidns_test.go
+++ b/providers/dns/alidns/alidns_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.SecretKey = test.secretKey
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/arvancloud/arvancloud.go
+++ b/providers/dns/arvancloud/arvancloud.go
@@ -38,13 +38,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -60,13 +60,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for ArvanCloud.
 // Credentials must be passed in the environment variable: ARVANCLOUD_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("arvancloud: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/arvancloud/arvancloud_test.go
+++ b/providers/dns/arvancloud/arvancloud_test.go
@@ -41,7 +41,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.TTL = test.ttl
 
@@ -104,7 +104,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -117,7 +117,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/auroradns/auroradns.go
+++ b/providers/dns/auroradns/auroradns.go
@@ -38,11 +38,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -57,14 +57,14 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for AuroraDNS.
 // Credentials must be passed in the environment variables:
 // AURORA_USER_ID and AURORA_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUserID, EnvKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUserID, EnvKey)
 	if err != nil {
 		return nil, fmt.Errorf("aurora: %w", err)
 	}
 
-	config := NewDefaultConfig()
-	config.BaseURL = env.GetOrFile(EnvEndpoint)
+	config := NewDefaultConfig(conf)
+	config.BaseURL = env.GetOrFile(conf, EnvEndpoint)
 	config.UserID = values[EnvUserID]
 	config.Key = values[EnvKey]
 

--- a/providers/dns/auroradns/auroradns_test.go
+++ b/providers/dns/auroradns/auroradns_test.go
@@ -20,7 +20,7 @@ func setupTest() (*DNSProvider, *http.ServeMux, func()) {
 	handler := http.NewServeMux()
 	server := httptest.NewServer(handler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.UserID = "asdf1234"
 	config.Key = "key"
 	config.BaseURL = server.URL
@@ -79,7 +79,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.UserID = test.userID
 			config.Key = test.key
 

--- a/providers/dns/autodns/autodns.go
+++ b/providers/dns/autodns/autodns.go
@@ -45,17 +45,17 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
-	endpoint, _ := url.Parse(env.GetOrDefaultString(EnvAPIEndpoint, defaultEndpoint))
+func NewDefaultConfig(conf map[string]string) *Config {
+	endpoint, _ := url.Parse(env.GetOrDefaultString(conf, EnvAPIEndpoint, defaultEndpoint))
 
 	return &Config{
 		Endpoint:           endpoint,
-		Context:            env.GetOrDefaultInt(EnvAPIEndpointContext, defaultEndpointContext),
-		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		Context:            env.GetOrDefaultInt(conf, EnvAPIEndpointContext, defaultEndpointContext),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, defaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -67,13 +67,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for autoDNS.
 // Credentials must be passed in the environment variables.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIUser, EnvAPIPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIUser, EnvAPIPassword)
 	if err != nil {
 		return nil, fmt.Errorf("autodns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvAPIUser]
 	config.Password = values[EnvAPIPassword]
 

--- a/providers/dns/autodns/autodns_test.go
+++ b/providers/dns/autodns/autodns_test.go
@@ -62,7 +62,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.Password = test.password
 
@@ -132,7 +132,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	assert.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -145,7 +145,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -60,12 +60,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                     env.GetOrDefaultInt(EnvTTL, 60),
-		PropagationTimeout:      env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:         env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
-		MetadataEndpoint:        env.GetOrFile(EnvMetadataEndpoint),
+		TTL:                     env.GetOrDefaultInt(conf, EnvTTL, 60),
+		PropagationTimeout:      env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:         env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
+		MetadataEndpoint:        env.GetOrFile(conf, EnvMetadataEndpoint),
 		ResourceManagerEndpoint: aazure.PublicCloud.ResourceManagerEndpoint,
 		ActiveDirectoryEndpoint: aazure.PublicCloud.ActiveDirectoryEndpoint,
 	}
@@ -84,10 +84,10 @@ type DNSProvider struct {
 // If the credentials are _not_ set via the environment,
 // then it will attempt to get a bearer token via the instance metadata service.
 // see: https://github.com/Azure/go-autorest/blob/v10.14.0/autorest/azure/auth/auth.go#L38-L42
-func NewDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	config := NewDefaultConfig(conf)
 
-	environmentName := env.GetOrFile(EnvEnvironment)
+	environmentName := env.GetOrFile(conf, EnvEnvironment)
 	if environmentName != "" {
 		var environment aazure.Environment
 		switch environmentName {
@@ -107,11 +107,11 @@ func NewDNSProvider() (*DNSProvider, error) {
 		config.ActiveDirectoryEndpoint = environment.ActiveDirectoryEndpoint
 	}
 
-	config.SubscriptionID = env.GetOrFile(EnvSubscriptionID)
-	config.ResourceGroup = env.GetOrFile(EnvResourceGroup)
-	config.ClientSecret = env.GetOrFile(EnvClientSecret)
-	config.ClientID = env.GetOrFile(EnvClientID)
-	config.TenantID = env.GetOrFile(EnvTenantID)
+	config.SubscriptionID = env.GetOrFile(conf, EnvSubscriptionID)
+	config.ResourceGroup = env.GetOrFile(conf, EnvResourceGroup)
+	config.ClientSecret = env.GetOrFile(conf, EnvClientSecret)
+	config.ClientID = env.GetOrFile(conf, EnvClientID)
+	config.TenantID = env.GetOrFile(conf, EnvTenantID)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/azure/azure_test.go
+++ b/providers/dns/azure/azure_test.go
@@ -57,7 +57,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.ClientID = test.clientID
 			config.ClientSecret = test.clientSecret
 			config.SubscriptionID = test.subscriptionID
@@ -161,7 +161,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -174,7 +174,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/bindman/bindman.go
+++ b/providers/dns/bindman/bindman.go
@@ -32,12 +32,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, time.Minute),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, time.Minute),
 		},
 	}
 }
@@ -50,13 +50,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Bindman.
 // BINDMAN_MANAGER_ADDRESS should have the scheme, hostname, and port (if required) of the authoritative Bindman Manager server.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvManagerAddress)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvManagerAddress)
 	if err != nil {
 		return nil, fmt.Errorf("bindman: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.BaseURL = values[EnvManagerAddress]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/bindman/bindman_test.go
+++ b/providers/dns/bindman/bindman_test.go
@@ -51,7 +51,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -209,7 +209,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/bluecat/bluecat.go
+++ b/providers/dns/bluecat/bluecat.go
@@ -51,13 +51,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -73,13 +73,13 @@ type DNSProvider struct {
 // BLUECAT_SERVER_URL should have the scheme, hostname, and port (if required) of the authoritative Bluecat BAM server.
 // The REST endpoint will be appended.
 // In addition, the Configuration name and external DNS View Name must be passed in BLUECAT_CONFIG_NAME and BLUECAT_DNS_VIEW.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvServerURL, EnvUserName, EnvPassword, EnvConfigName, EnvDNSView)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvServerURL, EnvUserName, EnvPassword, EnvConfigName, EnvDNSView)
 	if err != nil {
 		return nil, fmt.Errorf("bluecat: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.BaseURL = values[EnvServerURL]
 	config.UserName = values[EnvUserName]
 	config.Password = values[EnvPassword]

--- a/providers/dns/bluecat/bluecat_test.go
+++ b/providers/dns/bluecat/bluecat_test.go
@@ -109,7 +109,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.BaseURL = test.baseURL
 			config.UserName = test.userName
 			config.Password = test.password
@@ -219,7 +219,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -232,7 +232,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(time.Second * 1)

--- a/providers/dns/checkdomain/checkdomain.go
+++ b/providers/dns/checkdomain/checkdomain.go
@@ -42,13 +42,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 5*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 7*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, defaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 5*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 7*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -62,16 +62,16 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for CheckDomain.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("checkdomain: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
-	endpoint, err := url.Parse(env.GetOrDefaultString(EnvEndpoint, defaultEndpoint))
+	endpoint, err := url.Parse(env.GetOrDefaultString(conf, EnvEndpoint, defaultEndpoint))
 	if err != nil {
 		return nil, fmt.Errorf("checkdomain: invalid %s: %w", EnvEndpoint, err)
 	}

--- a/providers/dns/checkdomain/checkdomain_test.go
+++ b/providers/dns/checkdomain/checkdomain_test.go
@@ -50,7 +50,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint, _ = url.Parse(defaultEndpoint)
 
 			if test.token != "" {
@@ -108,7 +108,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	assert.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -121,7 +121,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/checkdomain/client_test.go
+++ b/providers/dns/checkdomain/client_test.go
@@ -19,7 +19,7 @@ func setupTestProvider(t *testing.T) (*DNSProvider, *http.ServeMux, func()) {
 	handler := http.NewServeMux()
 	svr := httptest.NewServer(handler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Endpoint, _ = url.Parse(svr.URL)
 	config.Token = "secret"
 

--- a/providers/dns/clouddns/clouddns.go
+++ b/providers/dns/clouddns/clouddns.go
@@ -39,13 +39,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 5*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -59,13 +59,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for CloudDNS.
 // Credentials must be passed in the environment variables:
 // CLOUDDNS_CLIENT_ID, CLOUDDNS_EMAIL, CLOUDDNS_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvClientID, EnvEmail, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvClientID, EnvEmail, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("clouddns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.ClientID = values[EnvClientID]
 	config.Email = values[EnvEmail]
 	config.Password = values[EnvPassword]

--- a/providers/dns/clouddns/clouddns_test.go
+++ b/providers/dns/clouddns/clouddns_test.go
@@ -67,7 +67,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.ClientID = test.clientID
 			config.Email = test.email
 			config.Password = test.password
@@ -148,7 +148,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -161,7 +161,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -33,13 +33,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt("CLOUDFLARE_TTL", minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond("CLOUDFLARE_PROPAGATION_TIMEOUT", 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond("CLOUDFLARE_POLLING_INTERVAL", 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, "CLOUDFLARE_TTL", minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, "CLOUDFLARE_PROPAGATION_TIMEOUT", 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, "CLOUDFLARE_POLLING_INTERVAL", 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond("CLOUDFLARE_HTTP_TIMEOUT", 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, "CLOUDFLARE_HTTP_TIMEOUT", 30*time.Second),
 		},
 	}
 }
@@ -65,14 +65,14 @@ type DNSProvider struct {
 // Instead setup a API token with both Zone:Read and DNS:Edit permission, and pass the CLOUDFLARE_DNS_API_TOKEN environment variable.
 // You can split the Zone:Read and DNS:Edit permissions across multiple API tokens:
 // in this case pass both CLOUDFLARE_ZONE_API_TOKEN and CLOUDFLARE_DNS_API_TOKEN accordingly.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.GetWithFallback(
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.GetWithFallback(conf,
 		[]string{"CLOUDFLARE_EMAIL", "CF_API_EMAIL"},
 		[]string{"CLOUDFLARE_API_KEY", "CF_API_KEY"},
 	)
 	if err != nil {
 		var errT error
-		values, errT = env.GetWithFallback(
+		values, errT = env.GetWithFallback(conf,
 			[]string{"CLOUDFLARE_DNS_API_TOKEN", "CF_DNS_API_TOKEN"},
 			[]string{"CLOUDFLARE_ZONE_API_TOKEN", "CF_ZONE_API_TOKEN", "CLOUDFLARE_DNS_API_TOKEN", "CF_DNS_API_TOKEN"},
 		)
@@ -81,7 +81,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 		}
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.AuthEmail = values["CLOUDFLARE_EMAIL"]
 	config.AuthKey = values["CLOUDFLARE_API_KEY"]
 	config.AuthToken = values["CLOUDFLARE_DNS_API_TOKEN"]

--- a/providers/dns/cloudflare/cloudflare_test.go
+++ b/providers/dns/cloudflare/cloudflare_test.go
@@ -76,7 +76,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestNewDNSProviderWithToken(t *testing.T) {
 			localEnvTest.ClearEnv()
 			localEnvTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if test.expected.error != "" {
 				require.EqualError(t, err, test.expected.error)
@@ -246,7 +246,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AuthEmail = test.authEmail
 			config.AuthKey = test.authKey
 			config.AuthToken = test.authToken
@@ -271,7 +271,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -284,7 +284,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/cloudns/cloudns.go
+++ b/providers/dns/cloudns/cloudns.go
@@ -38,13 +38,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 60),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 4*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 60),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 4*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -58,23 +58,23 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for ClouDNS.
 // Credentials must be passed in the environment variables:
 // CLOUDNS_AUTH_ID and CLOUDNS_AUTH_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
 	var subAuthID string
-	authID := env.GetOrFile(EnvAuthID)
+	authID := env.GetOrFile(conf, EnvAuthID)
 	if authID == "" {
-		subAuthID = env.GetOrFile(EnvSubAuthID)
+		subAuthID = env.GetOrFile(conf, EnvSubAuthID)
 	}
 
 	if authID == "" && subAuthID == "" {
 		return nil, fmt.Errorf("ClouDNS: some credentials information are missing: %s or %s", EnvAuthID, EnvSubAuthID)
 	}
 
-	values, err := env.Get(EnvAuthPassword)
+	values, err := env.Get(conf, EnvAuthPassword)
 	if err != nil {
 		return nil, fmt.Errorf("ClouDNS: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.AuthID = authID
 	config.SubAuthID = subAuthID
 	config.AuthPassword = values[EnvAuthPassword]

--- a/providers/dns/cloudns/cloudns_test.go
+++ b/providers/dns/cloudns/cloudns_test.go
@@ -83,7 +83,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AuthID = test.authID
 			config.SubAuthID = test.subAuthID
 			config.AuthPassword = test.authPassword
@@ -169,7 +169,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -182,7 +182,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/cloudxns/cloudxns.go
+++ b/providers/dns/cloudxns/cloudxns.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for CloudXNS.
 // Credentials must be passed in the environment variables:
 // CLOUDXNS_API_KEY and CLOUDXNS_SECRET_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvSecretKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("CloudXNS: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.SecretKey = values[EnvSecretKey]
 

--- a/providers/dns/cloudxns/cloudxns_test.go
+++ b/providers/dns/cloudxns/cloudxns_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.SecretKey = test.secretKey
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/conoha/conoha.go
+++ b/providers/dns/conoha/conoha.go
@@ -40,14 +40,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		Region:             env.GetOrDefaultString(EnvRegion, "tyo1"),
-		TTL:                env.GetOrDefaultInt(EnvTTL, 60),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		Region:             env.GetOrDefaultString(conf, EnvRegion, "tyo1"),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 60),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -61,13 +61,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for ConoHa DNS.
 // Credentials must be passed in the environment variables:
 // CONOHA_TENANT_ID, CONOHA_API_USERNAME, CONOHA_API_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvTenantID, EnvAPIUsername, EnvAPIPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvTenantID, EnvAPIUsername, EnvAPIPassword)
 	if err != nil {
 		return nil, fmt.Errorf("conoha: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.TenantID = values[EnvTenantID]
 	config.Username = values[EnvAPIUsername]
 	config.Password = values[EnvAPIPassword]

--- a/providers/dns/conoha/conoha_test.go
+++ b/providers/dns/conoha/conoha_test.go
@@ -76,7 +76,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.TenantID = test.tenant
 			config.Username = test.username
 			config.Password = test.password
@@ -155,7 +155,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -168,7 +168,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/constellix/constellix.go
+++ b/providers/dns/constellix/constellix.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 60),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 10*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 60),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 10*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Constellix.
 // Credentials must be passed in the environment variables:
 // CONSTELLIX_API_KEY and CONSTELLIX_SECRET_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvSecretKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("constellix: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.SecretKey = values[EnvSecretKey]
 

--- a/providers/dns/constellix/constellix_test.go
+++ b/providers/dns/constellix/constellix_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.SecretKey = test.secretKey
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/desec/desec.go
+++ b/providers/dns/desec/desec.go
@@ -34,13 +34,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -53,13 +53,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for deSEC.
 // Credentials must be passed in the environment variable: DESEC_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("desec: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/desec/desec_test.go
+++ b/providers/dns/desec/desec_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.token
 
 			p, err := NewDNSProviderConfig(config)
@@ -93,7 +93,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -106,7 +106,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/designate/designate.go
+++ b/providers/dns/designate/designate.go
@@ -46,11 +46,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 10),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 10*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 10*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 10),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 10*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 10*time.Second),
 	}
 }
 
@@ -65,10 +65,10 @@ type DNSProvider struct {
 // Credentials must be passed in the environment variables:
 // OS_AUTH_URL, OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME, OS_REGION_NAME.
 // Or you can specify OS_CLOUD to read the credentials from the according cloud entry.
-func NewDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	config := NewDefaultConfig(conf)
 
-	val, err := env.Get(EnvCloud)
+	val, err := env.Get(conf, EnvCloud)
 	if err == nil {
 		opts, erro := clientconfig.AuthOptions(&clientconfig.ClientOpts{
 			Cloud: val[EnvCloud],
@@ -80,7 +80,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 		config.opts = *opts
 	} else {
-		_, err = env.Get(EnvAuthURL, EnvUsername, EnvPassword, EnvTenantName, EnvRegionName)
+		_, err = env.Get(conf, EnvAuthURL, EnvUsername, EnvPassword, EnvTenantName, EnvRegionName)
 		if err != nil {
 			return nil, fmt.Errorf("designate: %w", err)
 		}

--- a/providers/dns/designate/designate_test.go
+++ b/providers/dns/designate/designate_test.go
@@ -124,7 +124,7 @@ func TestNewDNSProvider_fromEnv(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestNewDNSProvider_fromCloud(t *testing.T) {
 				envOSClientConfigFile: createCloudsYaml(t, test.osCloud, test.cloud),
 			})
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.opts.TenantName = test.tenantName
 			config.opts.Password = test.password
 			config.opts.Username = test.userName
@@ -307,7 +307,7 @@ func getServer(t *testing.T) *httptest.Server {
 		"user": {
 			"name": "a",
 			"roles": [ ],
-			"role_links": [ ] 
+			"role_links": [ ]
 		},
 		"serviceCatalog": [
 			{
@@ -343,7 +343,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -356,7 +356,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -35,14 +35,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
 		BaseURL:            defaultBaseURL,
-		TTL:                env.GetOrDefaultInt(EnvTTL, 30),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 60*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 30),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 60*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 5*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -57,13 +57,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Digital
 // Ocean. Credentials must be passed in the environment variable:
 // DO_AUTH_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAuthToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAuthToken)
 	if err != nil {
 		return nil, fmt.Errorf("digitalocean: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.AuthToken = values[EnvAuthToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/digitalocean/digitalocean_test.go
+++ b/providers/dns/digitalocean/digitalocean_test.go
@@ -18,7 +18,7 @@ func setupTest() (*DNSProvider, *http.ServeMux, func()) {
 	handler := http.NewServeMux()
 	server := httptest.NewServer(handler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.AuthToken = "asdf1234"
 	config.BaseURL = server.URL
 
@@ -58,7 +58,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AuthToken = test.authToken
 
 			p, err := NewDNSProviderConfig(config)

--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -86,166 +86,166 @@ import (
 )
 
 // NewDNSChallengeProviderByName Factory for DNS providers.
-func NewDNSChallengeProviderByName(name string) (challenge.Provider, error) {
+func NewDNSChallengeProviderByName(name string, config map[string]string) (challenge.Provider, error) {
 	switch name {
 	case "acme-dns":
-		return acmedns.NewDNSProvider()
+		return acmedns.NewDNSProvider(config)
 	case "alidns":
-		return alidns.NewDNSProvider()
+		return alidns.NewDNSProvider(config)
 	case "arvancloud":
-		return arvancloud.NewDNSProvider()
+		return arvancloud.NewDNSProvider(config)
 	case "azure":
-		return azure.NewDNSProvider()
+		return azure.NewDNSProvider(config)
 	case "auroradns":
-		return auroradns.NewDNSProvider()
+		return auroradns.NewDNSProvider(config)
 	case "autodns":
-		return autodns.NewDNSProvider()
+		return autodns.NewDNSProvider(config)
 	case "bindman":
-		return bindman.NewDNSProvider()
+		return bindman.NewDNSProvider(config)
 	case "bluecat":
-		return bluecat.NewDNSProvider()
+		return bluecat.NewDNSProvider(config)
 	case "checkdomain":
-		return checkdomain.NewDNSProvider()
+		return checkdomain.NewDNSProvider(config)
 	case "clouddns":
-		return clouddns.NewDNSProvider()
+		return clouddns.NewDNSProvider(config)
 	case "cloudflare":
-		return cloudflare.NewDNSProvider()
+		return cloudflare.NewDNSProvider(config)
 	case "cloudns":
-		return cloudns.NewDNSProvider()
+		return cloudns.NewDNSProvider(config)
 	case "cloudxns":
-		return cloudxns.NewDNSProvider()
+		return cloudxns.NewDNSProvider(config)
 	case "conoha":
-		return conoha.NewDNSProvider()
+		return conoha.NewDNSProvider(config)
 	case "constellix":
-		return constellix.NewDNSProvider()
+		return constellix.NewDNSProvider(config)
 	case "desec":
-		return desec.NewDNSProvider()
+		return desec.NewDNSProvider(config)
 	case "designate":
-		return designate.NewDNSProvider()
+		return designate.NewDNSProvider(config)
 	case "digitalocean":
-		return digitalocean.NewDNSProvider()
+		return digitalocean.NewDNSProvider(config)
 	case "dnsimple":
-		return dnsimple.NewDNSProvider()
+		return dnsimple.NewDNSProvider(config)
 	case "dnsmadeeasy":
-		return dnsmadeeasy.NewDNSProvider()
+		return dnsmadeeasy.NewDNSProvider(config)
 	case "dnspod":
-		return dnspod.NewDNSProvider()
+		return dnspod.NewDNSProvider(config)
 	case "dode":
-		return dode.NewDNSProvider()
+		return dode.NewDNSProvider(config)
 	case "dreamhost":
-		return dreamhost.NewDNSProvider()
+		return dreamhost.NewDNSProvider(config)
 	case "duckdns":
-		return duckdns.NewDNSProvider()
+		return duckdns.NewDNSProvider(config)
 	case "dyn":
-		return dyn.NewDNSProvider()
+		return dyn.NewDNSProvider(config)
 	case "dynu":
-		return dynu.NewDNSProvider()
+		return dynu.NewDNSProvider(config)
 	case "edgedns":
-		return edgedns.NewDNSProvider()
+		return edgedns.NewDNSProvider(config)
 	case "fastdns":
-		return fastdns.NewDNSProvider()
+		return fastdns.NewDNSProvider(config)
 	case "easydns":
-		return easydns.NewDNSProvider()
+		return easydns.NewDNSProvider(config)
 	case "exec":
-		return exec.NewDNSProvider()
+		return exec.NewDNSProvider(config)
 	case "exoscale":
-		return exoscale.NewDNSProvider()
+		return exoscale.NewDNSProvider(config)
 	case "gandi":
-		return gandi.NewDNSProvider()
+		return gandi.NewDNSProvider(config)
 	case "gandiv5":
-		return gandiv5.NewDNSProvider()
+		return gandiv5.NewDNSProvider(config)
 	case "glesys":
-		return glesys.NewDNSProvider()
+		return glesys.NewDNSProvider(config)
 	case "gcloud":
-		return gcloud.NewDNSProvider()
+		return gcloud.NewDNSProvider(config)
 	case "godaddy":
-		return godaddy.NewDNSProvider()
+		return godaddy.NewDNSProvider(config)
 	case "hetzner":
-		return hetzner.NewDNSProvider()
+		return hetzner.NewDNSProvider(config)
 	case "hostingde":
-		return hostingde.NewDNSProvider()
+		return hostingde.NewDNSProvider(config)
 	case "httpreq":
-		return httpreq.NewDNSProvider()
+		return httpreq.NewDNSProvider(config)
 	case "iij":
-		return iij.NewDNSProvider()
+		return iij.NewDNSProvider(config)
 	case "inwx":
-		return inwx.NewDNSProvider()
+		return inwx.NewDNSProvider(config)
 	case "joker":
-		return joker.NewDNSProvider()
+		return joker.NewDNSProvider(config)
 	case "lightsail":
-		return lightsail.NewDNSProvider()
+		return lightsail.NewDNSProvider(config)
 	case "linode":
-		return linode.NewDNSProvider()
+		return linode.NewDNSProvider(config)
 	case "linodev4":
-		return linodev4.NewDNSProvider()
+		return linodev4.NewDNSProvider(config)
 	case "liquidweb":
-		return liquidweb.NewDNSProvider()
+		return liquidweb.NewDNSProvider(config)
 	case "luadns":
-		return luadns.NewDNSProvider()
+		return luadns.NewDNSProvider(config)
 	case "manual":
-		return dns01.NewDNSProviderManual()
+		return dns01.NewDNSProviderManual(config)
 	case "mydnsjp":
-		return mydnsjp.NewDNSProvider()
+		return mydnsjp.NewDNSProvider(config)
 	case "mythicbeasts":
-		return mythicbeasts.NewDNSProvider()
+		return mythicbeasts.NewDNSProvider(config)
 	case "namecheap":
-		return namecheap.NewDNSProvider()
+		return namecheap.NewDNSProvider(config)
 	case "namedotcom":
-		return namedotcom.NewDNSProvider()
+		return namedotcom.NewDNSProvider(config)
 	case "namesilo":
-		return namesilo.NewDNSProvider()
+		return namesilo.NewDNSProvider(config)
 	case "netcup":
-		return netcup.NewDNSProvider()
+		return netcup.NewDNSProvider(config)
 	case "netlify":
-		return netlify.NewDNSProvider()
+		return netlify.NewDNSProvider(config)
 	case "nifcloud":
-		return nifcloud.NewDNSProvider()
+		return nifcloud.NewDNSProvider(config)
 	case "ns1":
-		return ns1.NewDNSProvider()
+		return ns1.NewDNSProvider(config)
 	case "oraclecloud":
-		return oraclecloud.NewDNSProvider()
+		return oraclecloud.NewDNSProvider(config)
 	case "otc":
-		return otc.NewDNSProvider()
+		return otc.NewDNSProvider(config)
 	case "ovh":
-		return ovh.NewDNSProvider()
+		return ovh.NewDNSProvider(config)
 	case "pdns":
-		return pdns.NewDNSProvider()
+		return pdns.NewDNSProvider(config)
 	case "rackspace":
-		return rackspace.NewDNSProvider()
+		return rackspace.NewDNSProvider(config)
 	case "regru":
-		return regru.NewDNSProvider()
+		return regru.NewDNSProvider(config)
 	case "rfc2136":
-		return rfc2136.NewDNSProvider()
+		return rfc2136.NewDNSProvider(config)
 	case "rimuhosting":
-		return rimuhosting.NewDNSProvider()
+		return rimuhosting.NewDNSProvider(config)
 	case "route53":
-		return route53.NewDNSProvider()
+		return route53.NewDNSProvider(config)
 	case "sakuracloud":
-		return sakuracloud.NewDNSProvider()
+		return sakuracloud.NewDNSProvider(config)
 	case "scaleway":
-		return scaleway.NewDNSProvider()
+		return scaleway.NewDNSProvider(config)
 	case "selectel":
-		return selectel.NewDNSProvider()
+		return selectel.NewDNSProvider(config)
 	case "servercow":
-		return servercow.NewDNSProvider()
+		return servercow.NewDNSProvider(config)
 	case "stackpath":
-		return stackpath.NewDNSProvider()
+		return stackpath.NewDNSProvider(config)
 	case "transip":
-		return transip.NewDNSProvider()
+		return transip.NewDNSProvider(config)
 	case "vegadns":
-		return vegadns.NewDNSProvider()
+		return vegadns.NewDNSProvider(config)
 	case "versio":
-		return versio.NewDNSProvider()
+		return versio.NewDNSProvider(config)
 	case "vultr":
-		return vultr.NewDNSProvider()
+		return vultr.NewDNSProvider(config)
 	case "vscale":
-		return vscale.NewDNSProvider()
+		return vscale.NewDNSProvider(config)
 	case "yandex":
-		return yandex.NewDNSProvider()
+		return yandex.NewDNSProvider(config)
 	case "zoneee":
-		return zoneee.NewDNSProvider()
+		return zoneee.NewDNSProvider(config)
 	case "zonomi":
-		return zonomi.NewDNSProvider()
+		return zonomi.NewDNSProvider(config)
 	default:
 		return nil, fmt.Errorf("unrecognized DNS provider: %s", name)
 	}

--- a/providers/dns/dns_providers_test.go
+++ b/providers/dns/dns_providers_test.go
@@ -17,7 +17,7 @@ func TestKnownDNSProviderSuccess(t *testing.T) {
 		"EXEC_PATH": "abc",
 	})
 
-	provider, err := NewDNSChallengeProviderByName("exec")
+	provider, err := NewDNSChallengeProviderByName("exec", nil)
 	require.NoError(t, err)
 	assert.NotNil(t, provider)
 
@@ -28,13 +28,13 @@ func TestKnownDNSProviderError(t *testing.T) {
 	defer envTest.RestoreEnv()
 	envTest.ClearEnv()
 
-	provider, err := NewDNSChallengeProviderByName("exec")
+	provider, err := NewDNSChallengeProviderByName("exec", nil)
 	assert.Error(t, err)
 	assert.Nil(t, provider)
 }
 
 func TestUnknownDNSProvider(t *testing.T) {
-	provider, err := NewDNSChallengeProviderByName("foobar")
+	provider, err := NewDNSChallengeProviderByName("foobar", nil)
 	assert.Error(t, err)
 	assert.Nil(t, provider)
 }

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -37,11 +37,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -55,10 +55,10 @@ type DNSProvider struct {
 // Credentials must be passed in the environment variable: DNSIMPLE_OAUTH_TOKEN.
 //
 // See: https://developer.dnsimple.com/v2/#authentication
-func NewDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
-	config.AccessToken = env.GetOrFile(EnvOAuthToken)
-	config.BaseURL = env.GetOrFile(EnvBaseURL)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	config := NewDefaultConfig(conf)
+	config.AccessToken = env.GetOrFile(conf, EnvOAuthToken)
+	config.BaseURL = env.GetOrFile(conf, EnvBaseURL)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/dnsimple/dnsimple_test.go
+++ b/providers/dns/dnsimple/dnsimple_test.go
@@ -55,7 +55,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AccessToken = test.accessToken
 			config.BaseURL = test.baseURL
 
@@ -132,7 +132,7 @@ func TestLivePresent(t *testing.T) {
 		os.Setenv(EnvBaseURL, sandboxURL)
 	}
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -150,7 +150,7 @@ func TestLiveCleanUp(t *testing.T) {
 		os.Setenv(EnvBaseURL, sandboxURL)
 	}
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/dnsmadeeasy/dnsmadeeasy.go
+++ b/providers/dns/dnsmadeeasy/dnsmadeeasy.go
@@ -41,13 +41,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
@@ -64,14 +64,14 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for DNSMadeEasy DNS.
 // Credentials must be passed in the environment variables:
 // DNSMADEEASY_API_KEY and DNSMADEEASY_API_SECRET.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvAPISecret)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvAPISecret)
 	if err != nil {
 		return nil, fmt.Errorf("dnsmadeeasy: %w", err)
 	}
 
-	config := NewDefaultConfig()
-	config.Sandbox = env.GetOrDefaultBool(EnvSandbox, false)
+	config := NewDefaultConfig(conf)
+	config.Sandbox = env.GetOrDefaultBool(conf, EnvSandbox, false)
 	config.APIKey = values[EnvAPIKey]
 	config.APISecret = values[EnvAPISecret]
 

--- a/providers/dns/dnsmadeeasy/dnsmadeeasy_test.go
+++ b/providers/dns/dnsmadeeasy/dnsmadeeasy_test.go
@@ -63,7 +63,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.APISecret = test.apiSecret
 
@@ -135,7 +135,7 @@ func TestLivePresentAndCleanup(t *testing.T) {
 	os.Setenv(EnvSandbox, "true")
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/dnspod/dnspod.go
+++ b/providers/dns/dnspod/dnspod.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 600),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 600),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30),
 		},
 	}
 }
@@ -55,13 +55,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for dnspod.
 // Credentials must be passed in the environment variables: DNSPOD_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("dnspod: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.LoginToken = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/dnspod/dnspod_test.go
+++ b/providers/dns/dnspod/dnspod_test.go
@@ -41,7 +41,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.LoginToken = test.loginToken
 
 			p, err := NewDNSProviderConfig(config)
@@ -96,7 +96,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -109,7 +109,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/dode/dode.go
+++ b/providers/dns/dode/dode.go
@@ -33,13 +33,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		SequenceInterval:   env.GetOrDefaultSecond(conf, EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -51,13 +51,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a new DNS provider using
 // environment variable DODE_TOKEN for adding and removing the DNS record.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("do.de: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/dode/dode_test.go
+++ b/providers/dns/dode/dode_test.go
@@ -41,7 +41,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.token
 
 			p, err := NewDNSProviderConfig(config)
@@ -94,7 +94,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -107,7 +107,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/dreamhost/client_test.go
+++ b/providers/dns/dreamhost/client_test.go
@@ -40,7 +40,7 @@ func TestDNSProvider_buildQuery(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			if test.baseURL != "" {
 				config.BaseURL = test.baseURL

--- a/providers/dns/dreamhost/dreamhost.go
+++ b/providers/dns/dreamhost/dreamhost.go
@@ -34,13 +34,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
 		BaseURL:            defaultBaseURL,
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 60*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 1*time.Minute),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 60*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 1*time.Minute),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -52,13 +52,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a new DNS provider using
 // environment variable DREAMHOST_API_KEY for adding and removing the DNS record.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("dreamhost: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/dreamhost/dreamhost_test.go
+++ b/providers/dns/dreamhost/dreamhost_test.go
@@ -27,7 +27,7 @@ func setupTest() (*DNSProvider, *http.ServeMux, func()) {
 	handler := http.NewServeMux()
 	server := httptest.NewServer(handler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.APIKey = fakeAPIKey
 	config.BaseURL = server.URL
 
@@ -67,7 +67,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				assert.NoError(t, err)
@@ -97,7 +97,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -185,7 +185,7 @@ func TestLivePresentAndCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/duckdns/duckdns.go
+++ b/providers/dns/duckdns/duckdns.go
@@ -34,13 +34,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		SequenceInterval:   env.GetOrDefaultSecond(conf, EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -52,13 +52,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a new DNS provider using
 // environment variable DUCKDNS_TOKEN for adding and removing the DNS record.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("duckdns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/duckdns/duckdns_test.go
+++ b/providers/dns/duckdns/duckdns_test.go
@@ -42,7 +42,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.token
 
 			p, err := NewDNSProviderConfig(config)
@@ -154,7 +154,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -167,7 +167,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/dyn/dyn.go
+++ b/providers/dns/dyn/dyn.go
@@ -38,13 +38,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -58,13 +58,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Dyn DNS.
 // Credentials must be passed in the environment variables:
 // DYN_CUSTOMER_NAME, DYN_USER_NAME and DYN_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvCustomerName, EnvUserName, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvCustomerName, EnvUserName, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("dyn: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.CustomerName = values[EnvCustomerName]
 	config.UserName = values[EnvUserName]
 	config.Password = values[EnvPassword]

--- a/providers/dns/dyn/dyn_test.go
+++ b/providers/dns/dyn/dyn_test.go
@@ -75,7 +75,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.CustomerName = test.customerName
 			config.Password = test.password
 			config.UserName = test.userName
@@ -155,7 +155,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -168,7 +168,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/dynu/dynu.go
+++ b/providers/dns/dynu/dynu.go
@@ -37,13 +37,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 3*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 10*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 3*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 10*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Dynu.
 // Credentials must be passed in the environment variables.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("dynu: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/dynu/dynu_test.go
+++ b/providers/dns/dynu/dynu_test.go
@@ -42,7 +42,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -96,7 +96,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -109,7 +109,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/easydns/easydns.go
+++ b/providers/dns/easydns/easydns.go
@@ -44,14 +44,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		SequenceInterval:   env.GetOrDefaultSecond(conf, EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -64,16 +64,16 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance.
-func NewDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	config := NewDefaultConfig(conf)
 
-	endpoint, err := url.Parse(env.GetOrDefaultString(EnvEndpoint, defaultEndpoint))
+	endpoint, err := url.Parse(env.GetOrDefaultString(conf, EnvEndpoint, defaultEndpoint))
 	if err != nil {
 		return nil, fmt.Errorf("easydns: %w", err)
 	}
 	config.Endpoint = endpoint
 
-	values, err := env.Get(EnvToken, EnvKey)
+	values, err := env.Get(conf, EnvToken, EnvKey)
 	if err != nil {
 		return nil, fmt.Errorf("easydns: %w", err)
 	}

--- a/providers/dns/easydns/easydns_test.go
+++ b/providers/dns/easydns/easydns_test.go
@@ -31,7 +31,7 @@ func setup() (*DNSProvider, *http.ServeMux, func()) {
 		panic(err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Token = "TOKEN"
 	config.Key = "SECRET"
 	config.Endpoint = endpoint
@@ -80,7 +80,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -307,7 +307,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/edgedns/edgedns.go
+++ b/providers/dns/edgedns/edgedns.go
@@ -40,11 +40,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, DefaultPollInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, DefaultPollInterval),
 		Config: edgegrid.Config{
 			MaxBody: 131072,
 		},
@@ -58,13 +58,13 @@ type DNSProvider struct {
 
 // NewDNSProvider uses the supplied environment variables to return a DNSProvider instance:
 // AKAMAI_HOST, AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvHost, EnvClientToken, EnvClientSecret, EnvAccessToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvHost, EnvClientToken, EnvClientSecret, EnvAccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("edgedns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Config.Host = values[EnvHost]
 	config.Config.ClientToken = values[EnvClientToken]
 	config.Config.ClientSecret = values[EnvClientSecret]

--- a/providers/dns/edgedns/edgedns_test.go
+++ b/providers/dns/edgedns/edgedns_test.go
@@ -92,7 +92,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.ClientToken = test.clientToken
 			config.ClientSecret = test.clientSecret
 			config.Host = test.host
@@ -216,7 +216,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -233,7 +233,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/exec/exec.go
+++ b/providers/dns/exec/exec.go
@@ -33,10 +33,10 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -47,13 +47,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a new DNS provider which runs the program in the
 // environment variable EXEC_PATH for adding and removing the DNS record.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvPath)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvPath)
 	if err != nil {
 		return nil, fmt.Errorf("exec: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Program = values[EnvPath]
 	config.Mode = os.Getenv(EnvMode)
 

--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -41,13 +41,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -60,16 +60,16 @@ type DNSProvider struct {
 
 // NewDNSProvider Credentials must be passed in the environment variables:
 // EXOSCALE_API_KEY, EXOSCALE_API_SECRET, EXOSCALE_ENDPOINT.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvAPISecret)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvAPISecret)
 	if err != nil {
 		return nil, fmt.Errorf("exoscale: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.APISecret = values[EnvAPISecret]
-	config.Endpoint = env.GetOrFile(EnvEndpoint)
+	config.Endpoint = env.GetOrFile(conf, EnvEndpoint)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/exoscale/exoscale_test.go
+++ b/providers/dns/exoscale/exoscale_test.go
@@ -62,7 +62,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.APISecret = test.apiSecret
 
@@ -125,7 +125,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestDNSProvider_FindZoneAndRecordName(t *testing.T) {
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.APIKey = "example@example.com"
 	config.APISecret = "123"
 
@@ -182,7 +182,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -199,7 +199,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/fastdns/fastdns.go
+++ b/providers/dns/fastdns/fastdns.go
@@ -36,11 +36,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -51,13 +51,13 @@ type DNSProvider struct {
 
 // NewDNSProvider uses the supplied environment variables to return a DNSProvider instance:
 // AKAMAI_HOST, AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvHost, EnvClientToken, EnvClientSecret, EnvAccessToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvHost, EnvClientToken, EnvClientSecret, EnvAccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("fastdns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Config = edgegrid.Config{
 		Host:         values[EnvHost],
 		ClientToken:  values[EnvClientToken],

--- a/providers/dns/fastdns/fastdns_test.go
+++ b/providers/dns/fastdns/fastdns_test.go
@@ -92,7 +92,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.ClientToken = test.clientToken
 			config.ClientSecret = test.clientSecret
 			config.Host = test.host
@@ -181,7 +181,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestDNSProvider_findZoneAndRecordName(t *testing.T) {
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Host = "somehost"
 	config.ClientToken = "someclienttoken"
 	config.ClientSecret = "someclientsecret"
@@ -240,7 +240,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -257,7 +257,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/gandi/gandi.go
+++ b/providers/dns/gandi/gandi.go
@@ -45,13 +45,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 40*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 60*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 40*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 60*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 60*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 60*time.Second),
 		},
 	}
 }
@@ -75,13 +75,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Gandi.
 // Credentials must be passed in the environment variable: GANDI_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("gandi: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/gandi/gandi_test.go
+++ b/providers/dns/gandi/gandi_test.go
@@ -43,7 +43,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -145,7 +145,7 @@ func TestDNSProvider(t *testing.T) {
 		return "example.com.", nil
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.BaseURL = fakeServer.URL + "/"
 	config.APIKey = "123412341234123412341234"
 

--- a/providers/dns/gandiv5/gandiv5.go
+++ b/providers/dns/gandiv5/gandiv5.go
@@ -50,13 +50,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 20*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 20*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 20*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 20*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -72,13 +72,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Gandi.
 // Credentials must be passed in the environment variable: GANDIV5_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("gandi: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/gandiv5/gandiv5_test.go
+++ b/providers/dns/gandiv5/gandiv5_test.go
@@ -43,7 +43,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -163,7 +163,7 @@ func TestDNSProvider(t *testing.T) {
 		return "example.com.", nil
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.APIKey = "123412341234123412341234"
 	config.BaseURL = server.URL
 

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -87,7 +87,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			defer envTest.RestoreEnv()
 			envTest.ClearEnv()
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Project = test.project
 
 			p, err := NewDNSProviderConfig(config)
@@ -205,7 +205,7 @@ func TestPresentNoExistingRR(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.HTTPClient = &http.Client{}
 	config.Project = "manhattan"
 
@@ -305,7 +305,7 @@ func TestPresentWithExistingRR(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.HTTPClient = &http.Client{}
 	config.Project = "manhattan"
 
@@ -368,7 +368,7 @@ func TestPresentSkipExistingRR(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.HTTPClient = &http.Client{}
 	config.Project = "manhattan"
 
@@ -390,7 +390,7 @@ func TestLivePresent(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject))
+	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject), nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -404,7 +404,7 @@ func TestLivePresentMultiple(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject))
+	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject), nil)
 	require.NoError(t, err)
 
 	// Check that we're able to create multiple entries
@@ -422,7 +422,7 @@ func TestLiveCleanUp(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject))
+	provider, err := NewDNSProviderCredentials(envTest.GetValue(EnvProject), nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/glesys/glesys.go
+++ b/providers/dns/glesys/glesys.go
@@ -43,13 +43,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 20*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 20*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 20*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 20*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -64,13 +64,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for GleSYS.
 // Credentials must be passed in the environment variables:
 // GLESYS_API_USER and GLESYS_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIUser, EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIUser, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("glesys: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIUser = values[EnvAPIUser]
 	config.APIKey = values[EnvAPIKey]
 

--- a/providers/dns/glesys/glesys_test.go
+++ b/providers/dns/glesys/glesys_test.go
@@ -60,7 +60,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.APIUser = test.apiUser
 
@@ -130,7 +130,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -143,7 +143,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/godaddy/godaddy.go
+++ b/providers/dns/godaddy/godaddy.go
@@ -42,13 +42,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -61,13 +61,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for godaddy.
 // Credentials must be passed in the environment variables:
 // GODADDY_API_KEY and GODADDY_API_SECRET.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvAPISecret)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvAPISecret)
 	if err != nil {
 		return nil, fmt.Errorf("godaddy: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.APISecret = values[EnvAPISecret]
 

--- a/providers/dns/godaddy/godaddy_test.go
+++ b/providers/dns/godaddy/godaddy_test.go
@@ -60,7 +60,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.APISecret = test.apiSecret
 
@@ -126,7 +126,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -139,7 +139,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/hetzner/hetzner.go
+++ b/providers/dns/hetzner/hetzner.go
@@ -37,13 +37,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for hetzner.
 // Credentials must be passed in the environment variable: HETZNER_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("hetzner: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/hetzner/hetzner_test.go
+++ b/providers/dns/hetzner/hetzner_test.go
@@ -41,7 +41,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.TTL = test.ttl
 
@@ -104,7 +104,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -117,7 +117,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/hostingde/hostingde.go
+++ b/providers/dns/hostingde/hostingde.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -57,13 +57,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for hosting.de.
 // Credentials must be passed in the environment variables:
 // HOSTINGDE_ZONE_NAME and HOSTINGDE_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvZoneName)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvZoneName)
 	if err != nil {
 		return nil, fmt.Errorf("hostingde: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.ZoneName = values[EnvZoneName]
 

--- a/providers/dns/hostingde/hostingde_test.go
+++ b/providers/dns/hostingde/hostingde_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.ZoneName = test.zoneName
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/httpreq/httpreq.go
+++ b/providers/dns/httpreq/httpreq.go
@@ -53,12 +53,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -69,8 +69,8 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvEndpoint)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("httpreq: %w", err)
 	}
@@ -80,10 +80,10 @@ func NewDNSProvider() (*DNSProvider, error) {
 		return nil, fmt.Errorf("httpreq: %w", err)
 	}
 
-	config := NewDefaultConfig()
-	config.Mode = env.GetOrFile(EnvMode)
-	config.Username = env.GetOrFile(EnvUsername)
-	config.Password = env.GetOrFile(EnvPassword)
+	config := NewDefaultConfig(conf)
+	config.Mode = env.GetOrFile(conf, EnvMode)
+	config.Username = env.GetOrFile(conf, EnvUsername)
+	config.Password = env.GetOrFile(conf, EnvPassword)
 	config.Endpoint = endpoint
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/httpreq/httpreq_test.go
+++ b/providers/dns/httpreq/httpreq_test.go
@@ -50,7 +50,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint = test.endpoint
 
 			p, err := NewDNSProviderConfig(config)
@@ -160,7 +160,7 @@ func TestNewDNSProvider_Present(t *testing.T) {
 			mux.HandleFunc(path.Join("/", test.pathPrefix, "present"), test.handler)
 			server := httptest.NewServer(mux)
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint = mustParse(server.URL + test.pathPrefix)
 			config.Mode = test.mode
 			config.Username = test.username
@@ -235,7 +235,7 @@ func TestNewDNSProvider_Cleanup(t *testing.T) {
 			mux.HandleFunc("/cleanup", test.handler)
 			server := httptest.NewServer(mux)
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint = mustParse(server.URL)
 			config.Mode = test.mode
 			config.Username = test.username

--- a/providers/dns/iij/iij.go
+++ b/providers/dns/iij/iij.go
@@ -38,11 +38,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 4*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 4*time.Second),
 	}
 }
 
@@ -53,13 +53,13 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for IIJ DNS.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIAccessKey, EnvAPISecretKey, EnvDoServiceCode)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIAccessKey, EnvAPISecretKey, EnvDoServiceCode)
 	if err != nil {
 		return nil, fmt.Errorf("iij: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.AccessKey = values[EnvAPIAccessKey]
 	config.SecretKey = values[EnvAPISecretKey]
 	config.DoServiceCode = values[EnvDoServiceCode]

--- a/providers/dns/iij/iij_test.go
+++ b/providers/dns/iij/iij_test.go
@@ -75,7 +75,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AccessKey = test.accessKey
 			config.SecretKey = test.secretKey
 			config.DoServiceCode = test.doServiceCode
@@ -209,7 +209,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -222,7 +222,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -39,12 +39,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		Sandbox:            env.GetOrDefaultBool(EnvSandbox, false),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		Sandbox:            env.GetOrDefaultBool(conf, EnvSandbox, false),
 	}
 }
 
@@ -57,16 +57,16 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Dyn DNS.
 // Credentials must be passed in the environment variables:
 // INWX_USERNAME, INWX_PASSWORD, and INWX_SHARED_SECRET.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("inwx: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
-	config.SharedSecret = env.GetOrFile(EnvSharedSecret)
+	config.SharedSecret = env.GetOrFile(conf, EnvSharedSecret)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/inwx/inwx_test.go
+++ b/providers/dns/inwx/inwx_test.go
@@ -64,7 +64,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.Password = test.password
 
@@ -128,7 +128,7 @@ func TestLivePresentAndCleanup(t *testing.T) {
 	})
 	defer envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/joker/client_test.go
+++ b/providers/dns/joker/client_test.go
@@ -83,7 +83,7 @@ func TestDNSProvider_login_api_key(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.BaseURL = server.URL
 			config.APIKey = test.apiKey
 
@@ -164,7 +164,7 @@ func TestDNSProvider_login_username(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.BaseURL = server.URL
 			config.Username = test.username
 			config.Password = test.password
@@ -233,7 +233,7 @@ func TestDNSProvider_logout(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.BaseURL = server.URL
 			config.APIKey = "12345"
 			config.AuthSid = test.authSid
@@ -312,7 +312,7 @@ func TestDNSProvider_getZone(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.BaseURL = server.URL
 			config.APIKey = "12345"
 			config.AuthSid = test.authSid

--- a/providers/dns/joker/joker.go
+++ b/providers/dns/joker/joker.go
@@ -43,15 +43,15 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
 		BaseURL:            defaultBaseURL,
-		Debug:              env.GetOrDefaultBool(EnvDebug, false),
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		Debug:              env.GetOrDefaultBool(conf, EnvDebug, false),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 60*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 60*time.Second),
 		},
 	}
 }
@@ -63,17 +63,17 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Joker DMAPI.
 // Credentials must be passed in the environment variable JOKER_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		var errU error
-		values, errU = env.Get(EnvUsername, EnvPassword)
+		values, errU = env.Get(conf, EnvUsername, EnvPassword)
 		if errU != nil {
 			return nil, fmt.Errorf("joker: %v or %v", errU, err)
 		}
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]

--- a/providers/dns/joker/joker_test.go
+++ b/providers/dns/joker/joker_test.go
@@ -69,7 +69,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.Username = test.username
 			config.Password = test.password
@@ -165,7 +165,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -178,7 +178,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/lightsail/lightsail.go
+++ b/providers/dns/lightsail/lightsail.go
@@ -61,12 +61,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		DNSZone:            env.GetOrFile(EnvDNSZone),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		Region:             env.GetOrDefaultString(EnvRegion, "us-east-1"),
+		DNSZone:            env.GetOrFile(conf, EnvDNSZone),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		Region:             env.GetOrDefaultString(conf, EnvRegion, "us-east-1"),
 	}
 }
 
@@ -88,8 +88,8 @@ type DNSProvider struct {
 // public hosted zone via the FQDN.
 //
 // See also: https://github.com/aws/aws-sdk-go/wiki/configuring-sdk
-func NewDNSProvider() (*DNSProvider, error) {
-	return NewDNSProviderConfig(NewDefaultConfig())
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	return NewDNSProviderConfig(NewDefaultConfig(conf))
 }
 
 // NewDNSProviderConfig return a DNSProvider instance configured for AWS Lightsail.

--- a/providers/dns/lightsail/lightsail_integration_test.go
+++ b/providers/dns/lightsail/lightsail_integration_test.go
@@ -16,7 +16,7 @@ func TestLiveTTL(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	domain := envTest.GetDomain()

--- a/providers/dns/lightsail/lightsail_test.go
+++ b/providers/dns/lightsail/lightsail_test.go
@@ -43,7 +43,7 @@ func makeProvider(ts *httptest.Server) (*DNSProvider, error) {
 		return nil, err
 	}
 
-	conf := NewDefaultConfig()
+	conf := NewDefaultConfig(nil)
 
 	client := lightsail.New(sess)
 	return &DNSProvider{client: client, config: conf}, nil

--- a/providers/dns/linode/linode.go
+++ b/providers/dns/linode/linode.go
@@ -36,10 +36,10 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:             env.GetOrDefaultInt(EnvTTL, minTTL),
-		PollingInterval: env.GetOrDefaultSecond(EnvPollingInterval, 15*time.Second),
+		TTL:             env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PollingInterval: env.GetOrDefaultSecond(conf, EnvPollingInterval, 15*time.Second),
 	}
 }
 
@@ -56,13 +56,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Linode.
 // Credentials must be passed in the environment variable: LINODE_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("linode: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/linode/linode_test.go
+++ b/providers/dns/linode/linode_test.go
@@ -96,7 +96,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -149,7 +149,7 @@ func TestDNSProvider_Present(t *testing.T) {
 	defer envTest.RestoreEnv()
 	os.Setenv(EnvAPIKey, "testing")
 
-	p, err := NewDNSProvider()
+	p, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	domain := "example.com"
@@ -236,7 +236,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 	defer envTest.RestoreEnv()
 	os.Setenv(EnvAPIKey, "testing")
 
-	p, err := NewDNSProvider()
+	p, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	domain := "example.com"

--- a/providers/dns/linodev4/linodev4.go
+++ b/providers/dns/linodev4/linodev4.go
@@ -44,12 +44,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 0),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 15*time.Second),
-		HTTPTimeout:        env.GetOrDefaultSecond(EnvHTTPTimeout, 0),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 0),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 15*time.Second),
+		HTTPTimeout:        env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 0),
 	}
 }
 
@@ -66,13 +66,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Linode.
 // Credentials must be passed in the environment variable: LINODE_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("linodev4: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/linodev4/linodev4_test.go
+++ b/providers/dns/linodev4/linodev4_test.go
@@ -85,7 +85,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -138,7 +138,7 @@ func TestDNSProvider_Present(t *testing.T) {
 	defer envTest.RestoreEnv()
 	os.Setenv(EnvToken, "testing")
 
-	p, err := NewDNSProvider()
+	p, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 
@@ -227,7 +227,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 	defer envTest.RestoreEnv()
 	os.Setenv(EnvToken, "testing")
 
-	p, err := NewDNSProvider()
+	p, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	domain := "example.com"

--- a/providers/dns/liquidweb/liquidweb.go
+++ b/providers/dns/liquidweb/liquidweb.go
@@ -44,13 +44,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	config := &Config{
 		BaseURL:            defaultBaseURL,
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
-		HTTPTimeout:        env.GetOrDefaultSecond(EnvHTTPTimeout, 1*time.Minute),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
+		HTTPTimeout:        env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 1*time.Minute),
 	}
 
 	return config
@@ -65,14 +65,14 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Liquid Web.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvPassword, EnvZone)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvPassword, EnvZone)
 	if err != nil {
 		return nil, fmt.Errorf("liquidweb: %w", err)
 	}
 
-	config := NewDefaultConfig()
-	config.BaseURL = env.GetOrFile(EnvURL)
+	config := NewDefaultConfig(conf)
+	config.BaseURL = env.GetOrFile(conf, EnvURL)
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
 	config.Zone = values[EnvZone]

--- a/providers/dns/liquidweb/liquidweb_test.go
+++ b/providers/dns/liquidweb/liquidweb_test.go
@@ -26,7 +26,7 @@ func setupTest() (*DNSProvider, *http.ServeMux, func()) {
 	handler := http.NewServeMux()
 	server := httptest.NewServer(handler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Username = "blars"
 	config.Password = "tacoman"
 	config.BaseURL = server.URL
@@ -91,7 +91,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.Password = test.password
 			config.Zone = test.zone
@@ -252,7 +252,7 @@ func TestLivePresent(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -266,7 +266,7 @@ func TestLiveCleanUp(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/luadns/luadns.go
+++ b/providers/dns/luadns/luadns.go
@@ -40,13 +40,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -63,13 +63,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for LuaDNS.
 // Credentials must be passed in the environment variables:
 // LUADNS_API_USERNAME and LUADNS_API_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIUsername, EnvAPIToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIUsername, EnvAPIToken)
 	if err != nil {
 		return nil, fmt.Errorf("luadns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIUsername = values[EnvAPIUsername]
 	config.APIToken = values[EnvAPIToken]
 

--- a/providers/dns/luadns/luadns_test.go
+++ b/providers/dns/luadns/luadns_test.go
@@ -62,7 +62,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIUsername = test.apiKey
 			config.APIToken = test.apiSecret
 			config.TTL = test.tll
@@ -200,7 +200,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -213,7 +213,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/mydnsjp/mydnsjp.go
+++ b/providers/dns/mydnsjp/mydnsjp.go
@@ -35,12 +35,12 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -52,13 +52,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for MyDNS.jp.
 // Credentials must be passed in the environment variables: MYDNSJP_MASTER_ID and MYDNSJP_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvMasterID, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvMasterID, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("mydnsjp: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.MasterID = values[EnvMasterID]
 	config.Password = values[EnvPassword]
 

--- a/providers/dns/mydnsjp/mydnsjp_test.go
+++ b/providers/dns/mydnsjp/mydnsjp_test.go
@@ -60,7 +60,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				assert.NoError(t, err)
@@ -102,7 +102,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.MasterID = test.masterID
 			config.Password = test.password
 
@@ -124,7 +124,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -137,7 +137,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/mythicbeasts/mythicbeasts.go
+++ b/providers/dns/mythicbeasts/mythicbeasts.go
@@ -40,25 +40,25 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() (*Config, error) {
-	apiEndpoint, err := url.Parse(env.GetOrDefaultString(EnvAPIEndpoint, apiBaseURL))
+func NewDefaultConfig(conf map[string]string) (*Config, error) {
+	apiEndpoint, err := url.Parse(env.GetOrDefaultString(conf, EnvAPIEndpoint, apiBaseURL))
 	if err != nil {
 		return nil, fmt.Errorf("mythicbeasts: Unable to parse API URL: %w", err)
 	}
 
-	authEndpoint, err := url.Parse(env.GetOrDefaultString(EnvAuthAPIEndpoint, authBaseURL))
+	authEndpoint, err := url.Parse(env.GetOrDefaultString(conf, EnvAuthAPIEndpoint, authBaseURL))
 	if err != nil {
 		return nil, fmt.Errorf("mythicbeasts: Unable to parse AUTH API URL: %w", err)
 	}
 
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		APIEndpoint:        apiEndpoint,
 		AuthAPIEndpoint:    authEndpoint,
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}, nil
 }
@@ -72,13 +72,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for mythicbeasts DNSv2 API.
 // Credentials must be passed in the environment variables:
 // MYTHICBEASTS_USER_NAME and MYTHICBEASTS_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUserName, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUserName, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("mythicbeasts: %w", err)
 	}
 
-	config, err := NewDefaultConfig()
+	config, err := NewDefaultConfig(conf)
 	if err != nil {
 		return nil, fmt.Errorf("mythicbeasts: %w", err)
 	}

--- a/providers/dns/mythicbeasts/mythicbeasts_test.go
+++ b/providers/dns/mythicbeasts/mythicbeasts_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config, err := NewDefaultConfig()
+			config, err := NewDefaultConfig(nil)
 			require.NoError(t, err)
 			config.UserName = test.username
 			config.Password = test.password
@@ -130,7 +130,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -143,7 +143,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -76,20 +76,20 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	baseURL := defaultBaseURL
-	if env.GetOrDefaultBool(EnvSandbox, false) {
+	if env.GetOrDefaultBool(conf, EnvSandbox, false) {
 		baseURL = sandboxBaseURL
 	}
 
 	return &Config{
 		BaseURL:            baseURL,
-		Debug:              env.GetOrDefaultBool(EnvDebug, false),
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 60*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 15*time.Second),
+		Debug:              env.GetOrDefaultBool(conf, EnvDebug, false),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 60*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 15*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 60*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 60*time.Second),
 		},
 	}
 }
@@ -102,13 +102,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for namecheap.
 // Credentials must be passed in the environment variables:
 // NAMECHEAP_API_USER and NAMECHEAP_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIUser, EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIUser, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("namecheap: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIUser = values[EnvAPIUser]
 	config.APIKey = values[EnvAPIKey]
 

--- a/providers/dns/namecheap/namecheap_test.go
+++ b/providers/dns/namecheap/namecheap_test.go
@@ -222,7 +222,7 @@ func mockServer(tc *testCase, t *testing.T) http.Handler {
 }
 
 func mockDNSProvider(url string) *DNSProvider {
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.BaseURL = url
 	config.APIUser = envTestUser
 	config.APIKey = envTestKey

--- a/providers/dns/namedotcom/namedotcom.go
+++ b/providers/dns/namedotcom/namedotcom.go
@@ -42,13 +42,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 15*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 20*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 15*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 20*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -62,16 +62,16 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for namedotcom.
 // Credentials must be passed in the environment variables:
 // NAMECOM_USERNAME and NAMECOM_API_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvAPIToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvAPIToken)
 	if err != nil {
 		return nil, fmt.Errorf("namedotcom: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvUsername]
 	config.APIToken = values[EnvAPIToken]
-	config.Server = env.GetOrFile(EnvServer)
+	config.Server = env.GetOrFile(conf, EnvServer)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/namedotcom/namedotcom_test.go
+++ b/providers/dns/namedotcom/namedotcom_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.APIToken = test.apiToken
 
@@ -131,7 +131,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -144,7 +144,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/namesilo/namesilo.go
+++ b/providers/dns/namesilo/namesilo.go
@@ -37,11 +37,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, defaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -55,13 +55,13 @@ type DNSProvider struct {
 // API_KEY must be passed in the environment variables: NAMESILO_API_KEY.
 //
 // See: https://www.namesilo.com/api_reference.php
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("namesilo: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/namesilo/namesilo_test.go
+++ b/providers/dns/namesilo/namesilo_test.go
@@ -49,7 +49,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.TTL = test.ttl
 
@@ -113,7 +113,7 @@ func TestLivePresent(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -127,7 +127,7 @@ func TestLiveCleanUp(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/netcup/netcup.go
+++ b/providers/dns/netcup/netcup.go
@@ -40,13 +40,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 5*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -60,13 +60,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for netcup.
 // Credentials must be passed in the environment variables:
 // NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, NETCUP_API_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvCustomerNumber, EnvAPIKey, EnvAPIPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvCustomerNumber, EnvAPIKey, EnvAPIPassword)
 	if err != nil {
 		return nil, fmt.Errorf("netcup: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Customer = values[EnvCustomerNumber]
 	config.Key = values[EnvAPIKey]
 	config.Password = values[EnvAPIPassword]

--- a/providers/dns/netcup/netcup_test.go
+++ b/providers/dns/netcup/netcup_test.go
@@ -76,7 +76,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Customer = test.customer
 			config.Key = test.key
 			config.Password = test.password
@@ -158,7 +158,7 @@ func TestLivePresentAndCleanup(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	p, err := NewDNSProvider()
+	p, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	fqdn, _ := dns01.GetRecord(envTest.GetDomain(), "123d==")

--- a/providers/dns/netlify/netlify.go
+++ b/providers/dns/netlify/netlify.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -58,13 +58,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Netlify.
 // Credentials must be passed in the environment variable: NETLIFY_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvToken)
 	if err != nil {
 		return nil, fmt.Errorf("netlify: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/netlify/netlify_test.go
+++ b/providers/dns/netlify/netlify_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.token
 
 			p, err := NewDNSProviderConfig(config)
@@ -93,7 +93,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -106,7 +106,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -39,13 +39,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -59,14 +59,14 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for the NIFCLOUD DNS service.
 // Credentials must be passed in the environment variables:
 // NIFCLOUD_ACCESS_KEY_ID and NIFCLOUD_SECRET_ACCESS_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAccessKeyID, EnvSecretAccessKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAccessKeyID, EnvSecretAccessKey)
 	if err != nil {
 		return nil, fmt.Errorf("nifcloud: %w", err)
 	}
 
-	config := NewDefaultConfig()
-	config.BaseURL = env.GetOrFile(EnvDNSEndpoint)
+	config := NewDefaultConfig(conf)
+	config.BaseURL = env.GetOrFile(conf, EnvDNSEndpoint)
 	config.AccessKey = values[EnvAccessKeyID]
 	config.SecretKey = values[EnvSecretAccessKey]
 

--- a/providers/dns/nifcloud/nifcloud_test.go
+++ b/providers/dns/nifcloud/nifcloud_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AccessKey = test.accessKey
 			config.SecretKey = test.secretKey
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/ns1/ns1.go
+++ b/providers/dns/ns1/ns1.go
@@ -37,13 +37,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for NS1.
 // Credentials must be passed in the environment variables: NS1_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("ns1: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/ns1/ns1_test.go
+++ b/providers/dns/ns1/ns1_test.go
@@ -42,7 +42,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -148,7 +148,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -161,7 +161,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/oraclecloud/configprovider.go
+++ b/providers/dns/oraclecloud/configprovider.go
@@ -16,10 +16,10 @@ type configProvider struct {
 	privateKeyPassphrase string
 }
 
-func newConfigProvider(values map[string]string) *configProvider {
+func newConfigProvider(values map[string]string, conf map[string]string) *configProvider {
 	return &configProvider{
 		values:               values,
-		privateKeyPassphrase: env.GetOrFile(EnvPrivKeyPass),
+		privateKeyPassphrase: env.GetOrFile(conf, EnvPrivKeyPass),
 	}
 }
 

--- a/providers/dns/oraclecloud/oraclecloud.go
+++ b/providers/dns/oraclecloud/oraclecloud.go
@@ -44,13 +44,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 60*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 60*time.Second),
 		},
 	}
 }
@@ -62,15 +62,15 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for OracleCloud.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(envPrivKey, EnvTenancyOCID, EnvUserOCID, EnvPubKeyFingerprint, EnvRegion, EnvCompartmentOCID)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, envPrivKey, EnvTenancyOCID, EnvUserOCID, EnvPubKeyFingerprint, EnvRegion, EnvCompartmentOCID)
 	if err != nil {
 		return nil, fmt.Errorf("oraclecloud: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.CompartmentID = values[EnvCompartmentOCID]
-	config.OCIConfigProvider = newConfigProvider(values)
+	config.OCIConfigProvider = newConfigProvider(values, conf)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/oraclecloud/oraclecloud_test.go
+++ b/providers/dns/oraclecloud/oraclecloud_test.go
@@ -183,7 +183,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.CompartmentID = test.compartmentID
 			config.OCIConfigProvider = test.configurationProvider
 
@@ -247,7 +247,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -260,7 +260,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/otc/otc.go
+++ b/providers/dns/otc/otc.go
@@ -47,14 +47,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		IdentityEndpoint:   env.GetOrDefaultString(EnvIdentityEndpoint, defaultIdentityEndpoint),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
+		IdentityEndpoint:   env.GetOrDefaultString(conf, EnvIdentityEndpoint, defaultIdentityEndpoint),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
@@ -84,13 +84,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for OTC DNS.
 // Credentials must be passed in the environment variables: OTC_USER_NAME,
 // OTC_DOMAIN_NAME, OTC_PASSWORD OTC_PROJECT_NAME and OTC_IDENTITY_ENDPOINT.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvDomainName, EnvUserName, EnvPassword, EnvProjectName)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvDomainName, EnvUserName, EnvPassword, EnvProjectName)
 	if err != nil {
 		return nil, fmt.Errorf("otc: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.DomainName = values[EnvDomainName]
 	config.UserName = values[EnvUserName]
 	config.Password = values[EnvPassword]

--- a/providers/dns/otc/otc_test.go
+++ b/providers/dns/otc/otc_test.go
@@ -37,7 +37,7 @@ func TestTestSuite(t *testing.T) {
 }
 
 func (s *OTCSuite) createDNSProvider() (*DNSProvider, error) {
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.UserName = "UserName"
 	config.Password = "Password"
 	config.DomainName = "DomainName"
@@ -69,7 +69,7 @@ func (s *OTCSuite) TestLoginEnv() {
 		EnvIdentityEndpoint: "unittest5",
 	})
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	s.Require().NoError(err)
 
 	s.Equal(provider.config.DomainName, "unittest1")
@@ -80,7 +80,7 @@ func (s *OTCSuite) TestLoginEnv() {
 
 	os.Setenv(EnvIdentityEndpoint, "")
 
-	provider, err = NewDNSProvider()
+	provider, err = NewDNSProvider(nil)
 	s.Require().NoError(err)
 
 	s.Equal(provider.config.IdentityEndpoint, "https://iam.eu-de.otc.t-systems.com:443/v3/auth/tokens")
@@ -89,7 +89,7 @@ func (s *OTCSuite) TestLoginEnv() {
 func (s *OTCSuite) TestLoginEnvEmpty() {
 	s.envTest.ClearEnv()
 
-	_, err := NewDNSProvider()
+	_, err := NewDNSProvider(nil)
 	s.EqualError(err, "otc: some credentials information are missing: OTC_DOMAIN_NAME,OTC_USER_NAME,OTC_PASSWORD,OTC_PROJECT_NAME")
 }
 

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -55,13 +55,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, ovh.DefaultTimeout),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, ovh.DefaultTimeout),
 		},
 	}
 }
@@ -77,13 +77,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for OVH
 // Credentials must be passed in the environment variables:
 // OVH_ENDPOINT (must be either "ovh-eu" or "ovh-ca"), OVH_APPLICATION_KEY, OVH_APPLICATION_SECRET, OVH_CONSUMER_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvEndpoint, EnvApplicationKey, EnvApplicationSecret, EnvConsumerKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvEndpoint, EnvApplicationKey, EnvApplicationSecret, EnvConsumerKey)
 	if err != nil {
 		return nil, fmt.Errorf("ovh: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIEndpoint = values[EnvEndpoint]
 	config.ApplicationKey = values[EnvApplicationKey]
 	config.ApplicationSecret = values[EnvApplicationSecret]

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -101,7 +101,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIEndpoint = test.apiEndpoint
 			config.ApplicationKey = test.applicationKey
 			config.ApplicationSecret = test.applicationSecret
@@ -207,7 +207,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -220,7 +220,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -39,13 +39,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -59,8 +59,8 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for pdns.
 // Credentials must be passed in the environment variable:
 // PDNS_API_URL and PDNS_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey, EnvAPIURL)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey, EnvAPIURL)
 	if err != nil {
 		return nil, fmt.Errorf("pdns: %w", err)
 	}
@@ -70,7 +70,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 		return nil, fmt.Errorf("pdns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Host = hostURL
 	config.APIKey = values[EnvAPIKey]
 

--- a/providers/dns/pdns/pdns_test.go
+++ b/providers/dns/pdns/pdns_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.Host = test.host
 
@@ -134,7 +134,7 @@ func TestLivePresentAndCleanup(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/rackspace/rackspace.go
+++ b/providers/dns/rackspace/rackspace.go
@@ -41,14 +41,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
 		BaseURL:            defaultBaseURL,
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -63,13 +63,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Rackspace.
 // Credentials must be passed in the environment variables:
 // RACKSPACE_USER and RACKSPACE_API_KEY.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUser, EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUser, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("rackspace: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIUser = values[EnvUser]
 	config.APIKey = values[EnvAPIKey]
 

--- a/providers/dns/rackspace/rackspace_test.go
+++ b/providers/dns/rackspace/rackspace_test.go
@@ -33,7 +33,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestNewDNSProviderConfig_MissingCredErr(t *testing.T) {
-	_, err := NewDNSProviderConfig(NewDefaultConfig())
+	_, err := NewDNSProviderConfig(NewDefaultConfig(nil))
 	assert.EqualError(t, err, "rackspace: credentials missing")
 }
 
@@ -67,7 +67,7 @@ func TestLiveNewDNSProvider_ValidEnv(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, provider.cloudDNSEndpoint, "https://dns.api.rackspacecloud.com/v1.0/", "The endpoint URL should contain the base")
@@ -79,7 +79,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "112233445566==")
@@ -92,7 +92,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(15 * time.Second)
@@ -104,7 +104,7 @@ func TestLiveCleanUp(t *testing.T) {
 func setupTest() (*Config, func()) {
 	apiURL, tearDown := startTestServers()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.APIUser = "testUser"
 	config.APIKey = "testKey"
 	config.BaseURL = apiURL

--- a/providers/dns/regru/regru.go
+++ b/providers/dns/regru/regru.go
@@ -38,13 +38,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -58,13 +58,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for reg.ru.
 // Credentials must be passed in the environment variables:
 // REGRU_USERNAME and REGRU_PASSWORD.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("regru: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
 

--- a/providers/dns/regru/regru_test.go
+++ b/providers/dns/regru/regru_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.Password = test.password
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/rfc2136/rfc2136.go
+++ b/providers/dns/rfc2136/rfc2136.go
@@ -43,14 +43,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TSIGAlgorithm:      env.GetOrDefaultString(EnvTSIGAlgorithm, dns.HmacMD5),
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, env.GetOrDefaultSecond("RFC2136_TIMEOUT", 60*time.Second)),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
-		DNSTimeout:         env.GetOrDefaultSecond(EnvDNSTimeout, 10*time.Second),
+		TSIGAlgorithm:      env.GetOrDefaultString(conf, EnvTSIGAlgorithm, dns.HmacMD5),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, env.GetOrDefaultSecond(conf, "RFC2136_TIMEOUT", 60*time.Second)),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
+		SequenceInterval:   env.GetOrDefaultSecond(conf, EnvSequenceInterval, dns01.DefaultPropagationTimeout),
+		DNSTimeout:         env.GetOrDefaultSecond(conf, EnvDNSTimeout, 10*time.Second),
 	}
 }
 
@@ -68,16 +68,16 @@ type DNSProvider struct {
 // RFC2136_TSIG_SECRET: Secret key payload.
 // RFC2136_PROPAGATION_TIMEOUT: DNS propagation timeout in time.ParseDuration format. (60s)
 // To disable TSIG authentication, leave the RFC2136_TSIG* variables unset.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvNameserver)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvNameserver)
 	if err != nil {
 		return nil, fmt.Errorf("rfc2136: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Nameserver = values[EnvNameserver]
-	config.TSIGKey = env.GetOrFile(EnvTSIGKey)
-	config.TSIGSecret = env.GetOrFile(EnvTSIGSecret)
+	config.TSIGKey = env.GetOrFile(conf, EnvTSIGKey)
+	config.TSIGSecret = env.GetOrFile(conf, EnvTSIGSecret)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/rfc2136/rfc2136_test.go
+++ b/providers/dns/rfc2136/rfc2136_test.go
@@ -57,7 +57,7 @@ func TestServerSuccess(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer func() { _ = server.Shutdown() }()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Nameserver = addr
 
 	provider, err := NewDNSProviderConfig(config)
@@ -76,7 +76,7 @@ func TestServerError(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer func() { _ = server.Shutdown() }()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Nameserver = addr
 
 	provider, err := NewDNSProviderConfig(config)
@@ -98,7 +98,7 @@ func TestTsigClient(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer func() { _ = server.Shutdown() }()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Nameserver = addr
 	config.TSIGKey = fakeTsigKey
 	config.TSIGSecret = fakeTsigSecret
@@ -132,7 +132,7 @@ func TestValidUpdatePacket(t *testing.T) {
 	expect, err := m.Pack()
 	require.NoError(t, err, "error packing")
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Nameserver = addr
 
 	provider, err := NewDNSProviderConfig(config)

--- a/providers/dns/rimuhosting/rimuhosting.go
+++ b/providers/dns/rimuhosting/rimuhosting.go
@@ -35,13 +35,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 3600),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 3600),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -54,13 +54,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for RimuHosting.
 // Credentials must be passed in the environment variables.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("rimuhosting: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/rimuhosting/rimuhosting_test.go
+++ b/providers/dns/rimuhosting/rimuhosting_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -97,7 +97,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -110,7 +110,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -44,13 +44,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		MaxRetries:         env.GetOrDefaultInt(EnvMaxRetries, 5),
-		TTL:                env.GetOrDefaultInt(EnvTTL, 10),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 4*time.Second),
-		HostedZoneID:       env.GetOrFile(EnvHostedZoneID),
+		MaxRetries:         env.GetOrDefaultInt(conf, EnvMaxRetries, 5),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 10),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 4*time.Second),
+		HostedZoneID:       env.GetOrFile(conf, EnvHostedZoneID),
 	}
 }
 
@@ -92,8 +92,8 @@ func (d customRetryer) RetryRules(r *request.Request) time.Duration {
 // If AWS_HOSTED_ZONE_ID is not set, Lego tries to determine the correct public hosted zone via the FQDN.
 //
 // See also: https://github.com/aws/aws-sdk-go/wiki/configuring-sdk
-func NewDNSProvider() (*DNSProvider, error) {
-	return NewDNSProviderConfig(NewDefaultConfig())
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	return NewDNSProviderConfig(NewDefaultConfig(conf))
 }
 
 // NewDNSProviderConfig takes a given config ans returns a custom configured DNSProvider instance.

--- a/providers/dns/route53/route53_integration_test.go
+++ b/providers/dns/route53/route53_integration_test.go
@@ -16,7 +16,7 @@ func TestLiveTTL(t *testing.T) {
 
 	envTest.RestoreEnv()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	domain := envTest.GetDomain()

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -42,7 +42,7 @@ func makeTestProvider(ts *httptest.Server) *DNSProvider {
 		panic(err)
 	}
 	client := route53.New(sess)
-	cfg := NewDefaultConfig()
+	cfg := NewDefaultConfig(nil)
 	return &DNSProvider{client: client, config: cfg}
 }
 
@@ -94,7 +94,7 @@ func Test_getHostedZoneID_FromEnv(t *testing.T) {
 
 	os.Setenv(EnvHostedZoneID, expectedZoneID)
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	hostedZoneID, err := provider.getHostedZoneID("whatever")
@@ -146,7 +146,7 @@ func TestNewDefaultConfig(t *testing.T) {
 				os.Setenv(key, value)
 			}
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 
 			assert.Equal(t, test.expected, config)
 		})

--- a/providers/dns/sakuracloud/client_test.go
+++ b/providers/dns/sakuracloud/client_test.go
@@ -81,7 +81,7 @@ func TestDNSProvider_addTXTRecord(t *testing.T) {
 	})
 	defer tearDown()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Token = "token1"
 	config.Secret = "secret1"
 
@@ -144,7 +144,7 @@ func TestDNSProvider_cleanupTXTRecord(t *testing.T) {
 	})
 	defer tearDown()
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.Token = "token2"
 	config.Secret = "secret2"
 
@@ -210,7 +210,7 @@ func TestDNSProvider_addTXTRecord_concurrent(t *testing.T) {
 
 	var providers []*DNSProvider
 	for i := 0; i < dummyRecordCount; i++ {
-		config := NewDefaultConfig()
+		config := NewDefaultConfig(nil)
 		config.Token = "token3"
 		config.Secret = "secret3"
 
@@ -290,7 +290,7 @@ func TestDNSProvider_cleanupTXTRecord_concurrent(t *testing.T) {
 
 	var providers []*DNSProvider
 	for i := 0; i < dummyRecordCount; i++ {
-		config := NewDefaultConfig()
+		config := NewDefaultConfig(nil)
 		config.Token = "token4"
 		config.Secret = "secret4"
 

--- a/providers/dns/sakuracloud/sakuracloud.go
+++ b/providers/dns/sakuracloud/sakuracloud.go
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 10*time.Second),
 		},
 	}
 }
@@ -56,13 +56,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for SakuraCloud.
 // Credentials must be passed in the environment variables:
 // SAKURACLOUD_ACCESS_TOKEN & SAKURACLOUD_ACCESS_TOKEN_SECRET.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAccessToken, EnvAccessTokenSecret)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAccessToken, EnvAccessTokenSecret)
 	if err != nil {
 		return nil, fmt.Errorf("sakuracloud: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvAccessToken]
 	config.Secret = values[EnvAccessTokenSecret]
 

--- a/providers/dns/sakuracloud/sakuracloud_test.go
+++ b/providers/dns/sakuracloud/sakuracloud_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Token = test.token
 			config.Secret = test.secret
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/scaleway/scaleway.go
+++ b/providers/dns/scaleway/scaleway.go
@@ -48,15 +48,15 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		BaseURL:            env.GetOrDefaultString(EnvBaseURL, defaultBaseURL),
-		Version:            env.GetOrDefaultString(EnvAPIVersion, defaultVersion),
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, defaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, defaultPollingInterval),
+		BaseURL:            env.GetOrDefaultString(conf, EnvBaseURL, defaultBaseURL),
+		Version:            env.GetOrDefaultString(conf, EnvAPIVersion, defaultVersion),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, defaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, defaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -69,13 +69,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Scaleway Domains API.
 // API token must be passed in the environment variable SCALEWAY_API_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIToken)
 	if err != nil {
 		return nil, fmt.Errorf("scaleway: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvAPIToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/scaleway/scaleway_test.go
+++ b/providers/dns/scaleway/scaleway_test.go
@@ -42,7 +42,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.TTL = test.ttl
 			config.Token = test.token
 
@@ -104,7 +104,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -119,7 +119,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(cleanUpDelay)

--- a/providers/dns/selectel/selectel.go
+++ b/providers/dns/selectel/selectel.go
@@ -40,14 +40,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		BaseURL:            env.GetOrDefaultString(EnvBaseURL, selectel.DefaultSelectelBaseURL),
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		BaseURL:            env.GetOrDefaultString(conf, EnvBaseURL, selectel.DefaultSelectelBaseURL),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -60,13 +60,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Selectel Domains API.
 // API token must be passed in the environment variable SELECTEL_API_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIToken)
 	if err != nil {
 		return nil, fmt.Errorf("selectel: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvAPIToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/selectel/selectel_test.go
+++ b/providers/dns/selectel/selectel_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.TTL = test.ttl
 			config.Token = test.token
 
@@ -106,7 +106,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -119,7 +119,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/servercow/servercow.go
+++ b/providers/dns/servercow/servercow.go
@@ -39,13 +39,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, defaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -57,13 +57,13 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("servercow: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
 

--- a/providers/dns/servercow/servercow_test.go
+++ b/providers/dns/servercow/servercow_test.go
@@ -61,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Username = test.username
 			config.Password = test.password
 
@@ -129,7 +129,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -142,7 +142,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/stackpath/stackpath.go
+++ b/providers/dns/stackpath/stackpath.go
@@ -46,11 +46,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 120),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 120),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 	}
 }
 
@@ -64,13 +64,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Stackpath.
 // Credentials must be passed in the environment variables:
 // STACKPATH_CLIENT_ID, STACKPATH_CLIENT_SECRET, and STACKPATH_STACK_ID.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvClientID, EnvClientSecret, EnvStackID)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvClientID, EnvClientSecret, EnvStackID)
 	if err != nil {
 		return nil, fmt.Errorf("stackpath: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.ClientID = values[EnvClientID]
 	config.ClientSecret = values[EnvClientSecret]
 	config.StackID = values[EnvStackID]

--- a/providers/dns/stackpath/stackpath_test.go
+++ b/providers/dns/stackpath/stackpath_test.go
@@ -79,7 +79,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -139,7 +139,7 @@ func setupMockAPITest() (*DNSProvider, *http.ServeMux, func()) {
 	apiHandler := http.NewServeMux()
 	server := httptest.NewServer(apiHandler)
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(nil)
 	config.ClientID = "CLIENT_ID"
 	config.ClientSecret = "CLIENT_SECRET"
 	config.StackID = "STACK_ID"
@@ -269,7 +269,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -282,7 +282,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/transip/transip.go
+++ b/providers/dns/transip/transip.go
@@ -35,11 +35,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                int64(env.GetOrDefaultInt(EnvTTL, 10)),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 10*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 10*time.Second),
+		TTL:                int64(env.GetOrDefaultInt(conf, EnvTTL, 10)),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 10*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 10*time.Second),
 	}
 }
 
@@ -52,13 +52,13 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for TransIP.
 // Credentials must be passed in the environment variables:
 // TRANSIP_ACCOUNTNAME, TRANSIP_PRIVATEKEYPATH.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAccountName, EnvPrivateKeyPath)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAccountName, EnvPrivateKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("transip: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.AccountName = values[EnvAccountName]
 	config.PrivateKeyPath = values[EnvPrivateKeyPath]
 

--- a/providers/dns/transip/transip_test.go
+++ b/providers/dns/transip/transip_test.go
@@ -68,7 +68,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestNewDNSProvider(t *testing.T) {
 			EnvPrivateKeyPath: "./fixtures/non/existent/private.key",
 		})
 
-		_, err := NewDNSProvider()
+		_, err := NewDNSProvider(nil)
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("Expected an os.ErrNotExists error, actual: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.AccountName = test.accountName
 			config.PrivateKeyPath = test.privateKeyPath
 
@@ -149,7 +149,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 	// The error message for a file not existing is different on Windows and Linux.
 	// Therefore we test if the error type is the same.
 	t.Run("could not open private key path", func(t *testing.T) {
-		config := NewDefaultConfig()
+		config := NewDefaultConfig(nil)
 		config.AccountName = "johndoe"
 		config.PrivateKeyPath = "./fixtures/non/existent/private.key"
 
@@ -171,7 +171,7 @@ func TestDNSProvider_concurrentGetDNSEntries(t *testing.T) {
 	repo := domain.Repository{Client: client}
 
 	p := &DNSProvider{
-		config:     NewDefaultConfig(),
+		config:     NewDefaultConfig(nil),
 		repository: repo,
 	}
 
@@ -227,7 +227,7 @@ func TestDNSProvider_concurrentAddDNSEntry(t *testing.T) {
 	repo := domain.Repository{Client: client}
 
 	p := &DNSProvider{
-		config:     NewDefaultConfig(),
+		config:     NewDefaultConfig(nil),
 		repository: repo,
 	}
 
@@ -268,7 +268,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -281,7 +281,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/vegadns/vegadns.go
+++ b/providers/dns/vegadns/vegadns.go
@@ -36,11 +36,11 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 10),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 12*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 1*time.Minute),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 10),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 12*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 1*time.Minute),
 	}
 }
 
@@ -53,16 +53,16 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for VegaDNS.
 // Credentials must be passed in the environment variables:
 // VEGADNS_URL, SECRET_VEGADNS_KEY, SECRET_VEGADNS_SECRET.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvURL)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvURL)
 	if err != nil {
 		return nil, fmt.Errorf("vegadns: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.BaseURL = values[EnvURL]
-	config.APIKey = env.GetOrFile(EnvKey)
-	config.APISecret = env.GetOrFile(EnvSecret)
+	config.APIKey = env.GetOrFile(conf, EnvKey)
+	config.APISecret = env.GetOrFile(conf, EnvSecret)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/vegadns/vegadns_test.go
+++ b/providers/dns/vegadns/vegadns_test.go
@@ -20,7 +20,7 @@ func TestNewDNSProvider_Fail(t *testing.T) {
 	defer envTest.RestoreEnv()
 	envTest.ClearEnv()
 
-	_, err := NewDNSProvider()
+	_, err := NewDNSProvider(nil)
 	assert.Error(t, err, "VEGADNS_URL env missing")
 }
 
@@ -31,7 +31,7 @@ func TestDNSProvider_TimeoutSuccess(t *testing.T) {
 	tearDown := startTestServer(muxSuccess())
 	defer tearDown()
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	timeout, interval := provider.Timeout()
@@ -69,7 +69,7 @@ func TestDNSProvider_Present(t *testing.T) {
 			tearDown := startTestServer(test.handler)
 			defer tearDown()
 
-			provider, err := NewDNSProvider()
+			provider, err := NewDNSProvider(nil)
 			require.NoError(t, err)
 
 			err = provider.Present(testDomain, "token", "keyAuth")
@@ -112,7 +112,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 			tearDown := startTestServer(test.handler)
 			defer tearDown()
 
-			provider, err := NewDNSProvider()
+			provider, err := NewDNSProvider(nil)
 			require.NoError(t, err)
 
 			err = provider.CleanUp(testDomain, "token", "keyAuth")

--- a/providers/dns/versio/versio.go
+++ b/providers/dns/versio/versio.go
@@ -41,20 +41,20 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
-	baseURL, err := url.Parse(env.GetOrDefaultString(EnvEndpoint, defaultBaseURL))
+func NewDefaultConfig(conf map[string]string) *Config {
+	baseURL, err := url.Parse(env.GetOrDefaultString(conf, EnvEndpoint, defaultBaseURL))
 	if err != nil {
 		baseURL, _ = url.Parse(defaultBaseURL)
 	}
 
 	return &Config{
 		BaseURL:            baseURL,
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 60*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 300),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 60*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 5*time.Second),
+		SequenceInterval:   env.GetOrDefaultSecond(conf, EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -66,13 +66,13 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUsername, EnvPassword)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvUsername, EnvPassword)
 	if err != nil {
 		return nil, fmt.Errorf("versio: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
 

--- a/providers/dns/versio/versio_test.go
+++ b/providers/dns/versio/versio_test.go
@@ -59,7 +59,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestDNSProvider_Present(t *testing.T) {
 				EnvPassword: "secret",
 				EnvEndpoint: baseURL,
 			})
-			provider, err := NewDNSProvider()
+			provider, err := NewDNSProvider(nil)
 			require.NoError(t, err)
 
 			err = provider.Present(testDomain, "token", "keyAuth")
@@ -200,7 +200,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 				EnvEndpoint: baseURL,
 			})
 
-			provider, err := NewDNSProvider()
+			provider, err := NewDNSProvider(nil)
 			require.NoError(t, err)
 
 			err = provider.CleanUp(testDomain, "token", "keyAuth")
@@ -285,7 +285,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -298,7 +298,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/vscale/vscale.go
+++ b/providers/dns/vscale/vscale.go
@@ -40,14 +40,14 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		BaseURL:            env.GetOrDefaultString(EnvBaseURL, selectel.DefaultVScaleBaseURL),
-		TTL:                env.GetOrDefaultInt(EnvTTL, minTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		BaseURL:            env.GetOrDefaultString(conf, EnvBaseURL, selectel.DefaultVScaleBaseURL),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 2*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -60,13 +60,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Vscale Domains API.
 // API token must be passed in the environment variable VSCALE_API_TOKEN.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIToken)
 	if err != nil {
 		return nil, fmt.Errorf("vscale: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Token = values[EnvAPIToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/vscale/vscale_test.go
+++ b/providers/dns/vscale/vscale_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.TTL = test.ttl
 			config.Token = test.token
 
@@ -106,7 +106,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -119,7 +119,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/vultr/vultr.go
+++ b/providers/dns/vultr/vultr.go
@@ -39,13 +39,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30),
 			// from Vultr Client
 			Transport: &http.Transport{
 				TLSNextProto: make(map[string]func(string, *tls.Conn) http.RoundTripper),
@@ -62,13 +62,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance with a configured Vultr client.
 // Authentication uses the VULTR_API_KEY environment variable.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("vultr: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/vultr/vultr_test.go
+++ b/providers/dns/vultr/vultr_test.go
@@ -41,7 +41,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -96,7 +96,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -109,7 +109,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/providers/dns/yandex/yandex.go
+++ b/providers/dns/yandex/yandex.go
@@ -37,13 +37,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, defaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -55,13 +55,13 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Yandex.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvPddToken)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvPddToken)
 	if err != nil {
 		return nil, fmt.Errorf("yandex: %v", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.PddToken = values[EnvPddToken]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/yandex/yandex_test.go
+++ b/providers/dns/yandex/yandex_test.go
@@ -37,7 +37,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -108,7 +108,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")

--- a/providers/dns/zoneee/zoneee.go
+++ b/providers/dns/zoneee/zoneee.go
@@ -36,16 +36,16 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	endpoint, _ := url.Parse(defaultEndpoint)
 
 	return &Config{
 		Endpoint: endpoint,
 		// zone.ee can take up to 5min to propagate according to the support
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 5*time.Minute),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, 5*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, 5*time.Second),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -56,19 +56,19 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIUser, EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIUser, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("zoneee: %w", err)
 	}
 
-	rawEndpoint := env.GetOrDefaultString(EnvEndpoint, defaultEndpoint)
+	rawEndpoint := env.GetOrDefaultString(conf, EnvEndpoint, defaultEndpoint)
 	endpoint, err := url.Parse(rawEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("zoneee: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.Username = values[EnvAPIUser]
 	config.APIKey = values[EnvAPIKey]
 	config.Endpoint = endpoint

--- a/providers/dns/zoneee/zoneee_test.go
+++ b/providers/dns/zoneee/zoneee_test.go
@@ -74,7 +74,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 			config.Username = test.apiUser
 
@@ -187,7 +187,7 @@ func TestDNSProvider_Present(t *testing.T) {
 
 			server := httptest.NewServer(mux)
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint = mustParse(server.URL)
 			config.Username = test.username
 			config.APIKey = test.apiKey
@@ -277,7 +277,7 @@ func TestDNSProvider_Cleanup(t *testing.T) {
 
 			server := httptest.NewServer(mux)
 
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.Endpoint = mustParse(server.URL)
 			config.Username = test.username
 			config.APIKey = test.apiKey
@@ -301,7 +301,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -314,7 +314,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/providers/dns/zonomi/zonomi.go
+++ b/providers/dns/zonomi/zonomi.go
@@ -35,13 +35,13 @@ type Config struct {
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
-func NewDefaultConfig() *Config {
+func NewDefaultConfig(conf map[string]string) *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 3600),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		TTL:                env.GetOrDefaultInt(conf, EnvTTL, 3600),
+		PropagationTimeout: env.GetOrDefaultSecond(conf, EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(conf, EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout: env.GetOrDefaultSecond(conf, EnvHTTPTimeout, 30*time.Second),
 		},
 	}
 }
@@ -54,13 +54,13 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Zonomi.
 // Credentials must be passed in the environment variables.
-func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvAPIKey)
+func NewDNSProvider(conf map[string]string) (*DNSProvider, error) {
+	values, err := env.Get(conf, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("zonomi: %w", err)
 	}
 
-	config := NewDefaultConfig()
+	config := NewDefaultConfig(conf)
 	config.APIKey = values[EnvAPIKey]
 
 	return NewDNSProviderConfig(config)

--- a/providers/dns/zonomi/zonomi_test.go
+++ b/providers/dns/zonomi/zonomi_test.go
@@ -40,7 +40,7 @@ func TestNewDNSProvider(t *testing.T) {
 
 			envTest.Apply(test.envVars)
 
-			p, err := NewDNSProvider()
+			p, err := NewDNSProvider(nil)
 
 			if len(test.expected) == 0 {
 				require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			config := NewDefaultConfig()
+			config := NewDefaultConfig(nil)
 			config.APIKey = test.apiKey
 
 			p, err := NewDNSProviderConfig(config)
@@ -97,7 +97,7 @@ func TestLivePresent(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	err = provider.Present(envTest.GetDomain(), "", "123d==")
@@ -110,7 +110,7 @@ func TestLiveCleanUp(t *testing.T) {
 	}
 
 	envTest.RestoreEnv()
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProvider(nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
In https://github.com/remilapeyre/vault-acme/issues/19 we would like to be able to use instantiate the same provider multiple times with a different configuration. We could use `os.Setenv()` to change the environment variables before doing this but it is cumbersome and would require to have a Mutex to avoid race conditions.

This patch add a new `config` parameters where the values for the configuration is first looked into before looking in the environment variables. Callers that only want to use the environment variables can set this parameter to `nil` and the old behaviour of looking in the environment variables will be kept.