### PR TITLE
Adjust default TTL to be twice the propagation time

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -24,7 +24,7 @@ const (
 	DefaultPollingInterval = 2 * time.Second
 
 	// DefaultTTL default TTL.
-	DefaultTTL = 120
+	DefaultTTL = 30
 )
 
 type ValidateFunc func(core *api.Core, domain string, chlng acme.Challenge) error


### PR DESCRIPTION
I have the impression that the propagation time should be longer than TTL. Because the DNS cache stops propagation of changes for the period defined by TTL.