### PR TITLE
rfc2136: ensure TSIG algorithm is fully qualified

### DIFF
--- a/providers/dns/rfc2136/rfc2136.go
+++ b/providers/dns/rfc2136/rfc2136.go
@@ -181,7 +181,9 @@ func (d *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 
 	// TSIG authentication / msg signing
 	if len(d.config.TSIGKey) > 0 && len(d.config.TSIGSecret) > 0 {
-		m.SetTsig(dns.Fqdn(d.config.TSIGKey), d.config.TSIGAlgorithm, 300, time.Now().Unix())
+		key := dns.Fqdn(d.config.TSIGKey)
+		alg := dns.Fqdn(d.config.TSIGAlgorithm)
+		m.SetTsig(key, alg, 300, time.Now().Unix())
 		c.TsigSecret = map[string]string{dns.Fqdn(d.config.TSIGKey): d.config.TSIGSecret}
 	}
 


### PR DESCRIPTION
Issue #1256 has revealed an issue with the way we read the TSIG algorithm from the environment.

The RFC specifies the algorithm to be fully-qualified, but the CLI docs don't communicate this clearly to the end user.

This PR just wraps the algorithm in a `dns.Fqdn()` call, ensuring a trailing dot.