### PR TITLE
Fix minor typo in docs

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -372,7 +372,7 @@ func (c *Certifier) Revoke(cert []byte) error {
 
 // Renew takes a Resource and tries to renew the certificate.
 //
-// If the renewal process succeeds, the new certificate will ge returned in a new CertResource.
+// If the renewal process succeeds, the new certificate will be returned in a new CertResource.
 // Please be aware that this function will return a new certificate in ANY case that is not an error.
 // If the server does not provide us with a new cert on a GET request to the CertURL
 // this function will start a new-cert flow where a new certificate gets generated.


### PR DESCRIPTION
`ge` either should have been `get` or `be`. Changed to `be` here.