### PR TITLE
fix: use http.Header.Set method instead of Add.

### DIFF
--- a/acme/api/internal/nonces/nonce_manager_test.go
+++ b/acme/api/internal/nonces/nonce_manager_test.go
@@ -14,8 +14,8 @@ import (
 func TestNotHoldingLockWhileMakingHTTPRequests(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(250 * time.Millisecond)
-		w.Header().Add("Replay-Nonce", "12345")
-		w.Header().Add("Retry-After", "0")
+		w.Header().Set("Replay-Nonce", "12345")
+		w.Header().Set("Retry-After", "0")
 		err := tester.WriteJSONResponse(w, &acme.Challenge{Type: "http-01", Status: "Valid", URL: "http://example.com/", Token: "token"})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/acme/api/internal/secure/jws_test.go
+++ b/acme/api/internal/secure/jws_test.go
@@ -15,8 +15,8 @@ import (
 func TestNotHoldingLockWhileMakingHTTPRequests(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(250 * time.Millisecond)
-		w.Header().Add("Replay-Nonce", "12345")
-		w.Header().Add("Retry-After", "0")
+		w.Header().Set("Replay-Nonce", "12345")
+		w.Header().Set("Retry-After", "0")
 		err := tester.WriteJSONResponse(w, &acme.Challenge{Type: "http-01", Status: "Valid", URL: "http://example.com/", Token: "token"})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -273,7 +273,7 @@ func formatDNSError(msg *dns.Msg, err error) string {
 	}
 
 	if err != nil {
-		parts = append(parts, fmt.Sprintf("%v", err))
+		parts = append(parts, err.Error())
 	}
 
 	if len(parts) > 0 {

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -91,7 +91,7 @@ func (s *ProviderServer) serve(domain, token, keyAuth string) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && s.matcher.matches(r, domain) {
-			w.Header().Add("Content-Type", "text/plain")
+			w.Header().Set("Content-Type", "text/plain")
 			_, err := w.Write([]byte(keyAuth))
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/platform/tester/api.go
+++ b/platform/tester/api.go
@@ -33,8 +33,8 @@ func SetupFakeAPI() (*http.ServeMux, string, func()) {
 				return
 			}
 
-			w.Header().Add("Replay-Nonce", "12345")
-			w.Header().Add("Retry-After", "0")
+			w.Header().Set("Replay-Nonce", "12345")
+			w.Header().Set("Retry-After", "0")
 		})
 
 		if err != nil {

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -301,7 +301,7 @@ func getMetadata(config *Config, field string) (string, error) {
 		return "", err
 	}
 
-	req.Header.Add("Metadata", "True")
+	req.Header.Set("Metadata", "True")
 
 	q := req.URL.Query()
 	q.Add("format", "text")

--- a/providers/dns/constellix/internal/auth.go
+++ b/providers/dns/constellix/internal/auth.go
@@ -47,7 +47,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if t.apiKey != "" && t.secretKey != "" {
 		securityToken := createCnsSecurityToken(t.apiKey, t.secretKey)
-		enrichedReq.Header.Add(securityTokenHeader, securityToken)
+		enrichedReq.Header.Set(securityTokenHeader, securityToken)
 	}
 
 	return t.transport().RoundTrip(enrichedReq)

--- a/providers/dns/dynu/internal/auth.go
+++ b/providers/dns/dynu/internal/auth.go
@@ -36,7 +36,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if t.apiKey != "" {
-		enrichedReq.Header.Add(apiKeyHeader, t.apiKey)
+		enrichedReq.Header.Set(apiKeyHeader, t.apiKey)
 	}
 
 	return t.transport().RoundTrip(enrichedReq)

--- a/providers/dns/dynu/internal/client.go
+++ b/providers/dns/dynu/internal/client.go
@@ -138,8 +138,8 @@ func (c Client) doRetry(method, url string, body []byte, data interface{}) error
 			return err
 		}
 
-		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Accept", "application/json")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
 
 		resp, err = c.HTTPClient.Do(req)
 		if errors.Is(err, io.EOF) {

--- a/providers/dns/internal/selectel/client.go
+++ b/providers/dns/internal/selectel/client.go
@@ -116,9 +116,9 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 		return nil, fmt.Errorf("failed to create new http request with error: %w", err)
 	}
 
-	req.Header.Add("X-Token", c.token)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Set("X-Token", c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 
 	return req, nil
 }

--- a/providers/dns/mythicbeasts/client.go
+++ b/providers/dns/mythicbeasts/client.go
@@ -73,7 +73,7 @@ func (d *DNSProvider) login() error {
 		return err
 	}
 
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(d.config.UserName, d.config.Password)
 
 	resp, err := d.config.HTTPClient.Do(req)
@@ -149,8 +149,8 @@ func (d *DNSProvider) createTXTRecord(zone, leaf, value string) error {
 		return fmt.Errorf("createTXTRecord: %w", err)
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.token))
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
@@ -202,7 +202,7 @@ func (d *DNSProvider) removeTXTRecord(zone, leaf, value string) error {
 		return fmt.Errorf("removeTXTRecord: %w", err)
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.token))
 
 	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {

--- a/providers/dns/scaleway/internal/client.go
+++ b/providers/dns/scaleway/internal/client.go
@@ -182,9 +182,9 @@ func (c *Client) newRequest(method, uri string, body interface{}) (*http.Request
 		return nil, fmt.Errorf("failed to create new http request with error: %w", err)
 	}
 
-	req.Header.Add("X-auth-token", c.token)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Set("X-auth-token", c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 
 	return req, nil
 }


### PR DESCRIPTION
Use `http.Header.Set` method instead of `Add` to overwrite all existing header values when it's useful.
