### PR TITLE
chore: update linter.

### DIFF
--- a/cmd/certs_storage.go
+++ b/cmd/certs_storage.go
@@ -197,7 +197,7 @@ func (s *CertificatesStorage) MoveToArchive(domain string) error {
 
 // sanitizedDomain Make sure no funny chars are in the cert names (like wildcards ;)).
 func sanitizedDomain(domain string) string {
-	safe, err := idna.ToASCII(strings.Replace(domain, "*", "_", -1))
+	safe, err := idna.ToASCII(strings.ReplaceAll(domain, "*", "_"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Update golangci-lint to v1.31.0.

The version is defined in the Travis settings.

Fixes  #1273