### PR TITLE
acme/api: use postAsGet instead of post for AccountService.Get

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -51,7 +51,7 @@ func (a *AccountService) Get(accountURL string) (acme.Account, error) {
 	}
 
 	var account acme.Account
-	_, err := a.core.post(accountURL, acme.Account{}, &account)
+	_, err := a.core.postAsGet(accountURL, &account)
 	if err != nil {
 		return acme.Account{}, err
 	}


### PR DESCRIPTION
Similar to #1142, Registrar.QueryRegistration is affected by pebble's enforcement of Post-as-GET for account retrieval.

This updates AccountService.Get to use postAsGet instead of the full post to facilitate this.

-----

I was a little hesitant to add this so far down the call stack, but it looks like `Registrar.QueryRegistration` is the only consumer of this call at this point in time (checked using references and call hierarchy in VSCode). As such I think this is safe, but we could duplicate the logic if need be.

No tests as it seems like a challenge to test this non-trivially at this point in time. Post-as-GET still sends some degree of body as a JWS payload (see [`signedPost()`](https://github.com/go-acme/lego/blob/6860f823daa4bbdff2792d836d0499d148f39f17/acme/api/api.go#L118-L135)) so that would need to be authenticated and the payload extracted to validate the empty payload. Hopefully switching to a known working function (`postAsGet()`) should be enough here.

I tested this manually on a local pebble installation (working on updates to the Terraform ACME provider).