### PR TITLE
Make <> around URI in Link header optional (#1285)

### DIFF
--- a/acme/api/service.go
+++ b/acme/api/service.go
@@ -20,7 +20,7 @@ func getLink(header http.Header, rel string) string {
 }
 
 func getLinks(header http.Header, rel string) []string {
-	linkExpr := regexp.MustCompile(`<(.+?)>(?:;[^;]+)*?;\s*rel="(.+?)"`)
+	linkExpr := regexp.MustCompile(`<?(\S+?)>?(?:;[^;]+)*?;\s*rel="(.+?)"`)
 
 	var links []string
 	for _, link := range header["Link"] {

--- a/acme/api/service_test.go
+++ b/acme/api/service_test.go
@@ -41,6 +41,22 @@ func Test_getLink(t *testing.T) {
 			relName:  "up",
 			expected: "",
 		},
+		{
+			desc: "success with multiple values without <> around the auth url",
+			header: http.Header{
+				"Link": []string{`https://acme-staging-v02.api.letsencrypt.org/next; rel="next", https://acme-staging-v02.api.letsencrypt.org/up?query; rel="up"`},
+			},
+			relName:  "up",
+			expected: "https://acme-staging-v02.api.letsencrypt.org/up?query",
+		},
+		{
+			desc: "success with multiple headers without <> around the auth url",
+			header: http.Header{
+				"Link": []string{`https://acme-staging-v02.api.letsencrypt.org/next; rel="next"`, `https://acme-staging-v02.api.letsencrypt.org/up?query; rel="up"`},
+			},
+			relName:  "up",
+			expected: "https://acme-staging-v02.api.letsencrypt.org/up?query",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
The RFC for the Link HTTP header claims that <> is required around the URI but some ACME endpoints don't conform to this standard.
Other ACME tools like cert-manager or certbot handle those headers still correctly so this change should make lego more compatible to non-conformant solutions.

Fixes #1285 


Vincent Link, vincent.link@daimler.com, Mercedes-Benz AG on behalf of Daimler TSS GmbH.
[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)