### PR TITLE
pdns: get exact zone instead of all zones

### DIFF
--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -66,27 +66,8 @@ func (d *DNSProvider) getHostedZone(fqdn string) (*hostedZone, error) {
 		return nil, err
 	}
 
-	u := "/servers/localhost/zones"
+	u := fmt.Sprintf("/servers/localhost/zones/%s.", dns01.UnFqdn(authZone))
 	result, err := d.sendRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var zones []hostedZone
-	err = json.Unmarshal(result, &zones)
-	if err != nil {
-		return nil, err
-	}
-
-	u = ""
-	for _, zone := range zones {
-		if dns01.UnFqdn(zone.Name) == dns01.UnFqdn(authZone) {
-			u = zone.URL
-			break
-		}
-	}
-
-	result, err = d.sendRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
+	"github.com/miekg/dns"
 )
 
 type Record struct {
@@ -60,18 +61,19 @@ type apiVersion struct {
 }
 
 func (d *DNSProvider) getHostedZone(fqdn string) (*hostedZone, error) {
-	var zone hostedZone
 	authZone, err := dns01.FindZoneByFqdn(fqdn)
 	if err != nil {
 		return nil, err
 	}
 
-	u := fmt.Sprintf("/servers/localhost/zones/%s.", dns01.UnFqdn(authZone))
-	result, err := d.sendRequest(http.MethodGet, u, nil)
+	p := path.Join("/servers/localhost/zones/", dns.Fqdn(authZone))
+
+	result, err := d.sendRequest(http.MethodGet, p, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	var zone hostedZone
 	err = json.Unmarshal(result, &zone)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello,

When trying obtain a certificate, I got an error message

```
acme: error presenting token: pdns: error talking to PDNS API: Get "http://pdns-server:8081/api/v1/servers/localhost/zones": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

My PDNS server has > 5k zones, to get all zones it takes >30s. I can increase timeout by using `PDNS_HTTP_TIMEOUT` but I think we can get exact zone instead of all zones ( for single zone, it takes only ~50ms )

Fixes #817