### PR TITLE
fix: preferred chain support.

### DIFF
--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -20,19 +20,82 @@ type CertificateService service
 // Get Returns the certificate and the issuer certificate.
 // 'bundle' is only applied if the issuer is provided by the 'up' link.
 func (c *CertificateService) Get(certURL string, bundle bool) ([]byte, []byte, error) {
-	cert, up, err := c.get(certURL)
+	cert, _, err := c.get(certURL, bundle)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	return cert.Cert, cert.Issuer, nil
+}
+
+// GetAll the certificates and the alternate certificates.
+// bundle' is only applied if the issuer is provided by the 'up' link.
+func (c *CertificateService) GetAll(certURL string, bundle bool) (map[string]*acme.RawCertificate, error) {
+	cert, headers, err := c.get(certURL, bundle)
+	if err != nil {
+		return nil, err
+	}
+
+	certs := map[string]*acme.RawCertificate{certURL: cert}
+
+	// URLs of "alternate" link relation
+	// - https://tools.ietf.org/html/rfc8555#section-7.4.2
+	alts := getLinks(headers, "alternate")
+
+	for _, alt := range alts {
+		altCert, _, err := c.get(alt, bundle)
+		if err != nil {
+			return nil, err
+		}
+
+		certs[alt] = altCert
+	}
+
+	return certs, nil
+}
+
+// Revoke Revokes a certificate.
+func (c *CertificateService) Revoke(req acme.RevokeCertMessage) error {
+	_, err := c.core.post(c.core.GetDirectory().RevokeCertURL, req, nil)
+	return err
+}
+
+// get Returns the certificate and the "up" link.
+func (c *CertificateService) get(certURL string, bundle bool) (*acme.RawCertificate, http.Header, error) {
+	if len(certURL) == 0 {
+		return nil, nil, errors.New("certificate[get]: empty URL")
+	}
+
+	resp, err := c.core.postAsGet(certURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	data, err := ioutil.ReadAll(http.MaxBytesReader(nil, resp.Body, maxBodySize))
+	if err != nil {
+		return nil, resp.Header, err
+	}
+
+	cert := c.getCertificateChain(data, resp.Header, bundle, certURL)
+
+	return cert, resp.Header, err
+}
+
+// getCertificateChain Returns the certificate and the issuer certificate.
+func (c *CertificateService) getCertificateChain(cert []byte, headers http.Header, bundle bool, certURL string) *acme.RawCertificate {
 	// Get issuerCert from bundled response from Let's Encrypt
 	// See https://community.letsencrypt.org/t/acme-v2-no-up-link-in-response/64962
 	_, issuer := pem.Decode(cert)
 	if issuer != nil {
-		return cert, issuer, nil
+		return &acme.RawCertificate{Cert: cert, Issuer: issuer}
 	}
 
-	issuer, err = c.getIssuerFromLink(up)
+	// The issuer certificate link may be supplied via an "up" link
+	// in the response headers of a new certificate.
+	// See https://tools.ietf.org/html/rfc8555#section-7.4.2
+	up := getLink(headers, "up")
+
+	issuer, err := c.getIssuerFromLink(up)
 	if err != nil {
 		// If we fail to acquire the issuer cert, return the issued certificate - do not fail.
 		log.Warnf("acme: Could not bundle issuer certificate [%s]: %v", certURL, err)
@@ -44,37 +107,7 @@ func (c *CertificateService) Get(certURL string, bundle bool) ([]byte, []byte, e
 		}
 	}
 
-	return cert, issuer, nil
-}
-
-// Revoke Revokes a certificate.
-func (c *CertificateService) Revoke(req acme.RevokeCertMessage) error {
-	_, err := c.core.post(c.core.GetDirectory().RevokeCertURL, req, nil)
-	return err
-}
-
-// get Returns the certificate and the "up" link.
-func (c *CertificateService) get(certURL string) ([]byte, string, error) {
-	if len(certURL) == 0 {
-		return nil, "", errors.New("certificate[get]: empty URL")
-	}
-
-	resp, err := c.core.postAsGet(certURL, nil)
-	if err != nil {
-		return nil, "", err
-	}
-
-	cert, err := ioutil.ReadAll(http.MaxBytesReader(nil, resp.Body, maxBodySize))
-	if err != nil {
-		return nil, "", err
-	}
-
-	// The issuer certificate link may be supplied via an "up" link
-	// in the response headers of a new certificate.
-	// See https://tools.ietf.org/html/rfc8555#section-7.4.2
-	up := getLink(resp.Header, "up")
-
-	return cert, up, err
+	return &acme.RawCertificate{Cert: cert, Issuer: issuer}
 }
 
 // getIssuerFromLink requests the issuer certificate.
@@ -85,15 +118,15 @@ func (c *CertificateService) getIssuerFromLink(up string) ([]byte, error) {
 
 	log.Infof("acme: Requesting issuer cert from %s", up)
 
-	cert, _, err := c.get(up)
+	cert, _, err := c.get(up, false)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = x509.ParseCertificate(cert)
+	_, err = x509.ParseCertificate(cert.Cert)
 	if err != nil {
 		return nil, err
 	}
 
-	return certcrypto.PEMEncode(certcrypto.DERCertificateBytes(cert)), nil
+	return certcrypto.PEMEncode(certcrypto.DERCertificateBytes(cert.Cert)), nil
 }

--- a/acme/api/order.go
+++ b/acme/api/order.go
@@ -25,9 +25,8 @@ func (o *OrderService) New(domains []string) (acme.ExtendedOrder, error) {
 	}
 
 	return acme.ExtendedOrder{
-		Order:               order,
-		Location:            resp.Header.Get("Location"),
-		AlternateChainLinks: getLinks(resp.Header, "alternate"),
+		Order:    order,
+		Location: resp.Header.Get("Location"),
 	}, nil
 }
 
@@ -38,15 +37,12 @@ func (o *OrderService) Get(orderURL string) (acme.ExtendedOrder, error) {
 	}
 
 	var order acme.Order
-	resp, err := o.core.postAsGet(orderURL, &order)
+	_, err := o.core.postAsGet(orderURL, &order)
 	if err != nil {
 		return acme.ExtendedOrder{}, err
 	}
 
-	return acme.ExtendedOrder{
-		Order:               order,
-		AlternateChainLinks: getLinks(resp.Header, "alternate"),
-	}, nil
+	return acme.ExtendedOrder{Order: order}, nil
 }
 
 // UpdateForCSR Updates an order for a CSR.
@@ -56,7 +52,7 @@ func (o *OrderService) UpdateForCSR(orderURL string, csr []byte) (acme.ExtendedO
 	}
 
 	var order acme.Order
-	resp, err := o.core.post(orderURL, csrMsg, &order)
+	_, err := o.core.post(orderURL, csrMsg, &order)
 	if err != nil {
 		return acme.ExtendedOrder{}, err
 	}
@@ -65,8 +61,5 @@ func (o *OrderService) UpdateForCSR(orderURL string, csr []byte) (acme.ExtendedO
 		return acme.ExtendedOrder{}, order.Error
 	}
 
-	return acme.ExtendedOrder{
-		Order:               order,
-		AlternateChainLinks: getLinks(resp.Header, "alternate"),
-	}, nil
+	return acme.ExtendedOrder{Order: order}, nil
 }

--- a/acme/api/order_test.go
+++ b/acme/api/order_test.go
@@ -41,10 +41,6 @@ func TestOrderService_New(t *testing.T) {
 			return
 		}
 
-		w.Header().Add("Link", `<https://example.com/acme/cert/1>;rel="alternate"`)
-		w.Header().Add("Link", `<https://example.com/acme/cert/2>;title="foo";rel="alternate"`)
-		w.Header().Add("Link", `<https://example.com/acme/cert/3>;title="foo";rel="alternate", <https://example.com/acme/cert/4>;rel="alternate"`)
-
 		err = tester.WriteJSONResponse(w, acme.Order{
 			Status:      acme.StatusValid,
 			Identifiers: order.Identifiers,
@@ -65,12 +61,6 @@ func TestOrderService_New(t *testing.T) {
 		Order: acme.Order{
 			Status:      "valid",
 			Identifiers: []acme.Identifier{{Type: "dns", Value: "example.com"}},
-		},
-		AlternateChainLinks: []string{
-			"https://example.com/acme/cert/1",
-			"https://example.com/acme/cert/2",
-			"https://example.com/acme/cert/3",
-			"https://example.com/acme/cert/4",
 		},
 	}
 	assert.Equal(t, expected, order)

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -106,13 +106,9 @@ type Account struct {
 // ExtendedOrder a extended Order.
 type ExtendedOrder struct {
 	Order
+
 	// The order URL, contains the value of the response header `Location`
 	Location string `json:"-"`
-
-	// AlternateChainLinks (optional, array of string):
-	// URLs of "alternate" link relation
-	// - https://tools.ietf.org/html/rfc8555#section-7.4.2
-	AlternateChainLinks []string `json:"-"`
 }
 
 // Order the ACME order Object.
@@ -286,4 +282,10 @@ type RevokeCertMessage struct {
 	// If a request contains a disallowed reasonCode the server MUST reject it with the error type "urn:ietf:params:acme:error:badRevocationReason".
 	// The problem document detail SHOULD indicate which reasonCodes are allowed.
 	Reason *uint `json:"reason,omitempty"`
+}
+
+// RawCertificate raw data of a certificate.
+type RawCertificate struct {
+	Cert   []byte
+	Issuer []byte
 }


### PR DESCRIPTION
Fixes #1294

By following the RFC:

>    The server MAY provide one or more link relation header fields
>    [RFC8288] with relation "alternate".  Each such field SHOULD express
>    an alternative certificate chain starting with the same end-entity
>    certificate.

https://tools.ietf.org/html/rfc8555#section-7.4.2

The "alternate" links are NOT provided by the order call but by the certificate call.

I don't understand why I didn't see the problem during the PR review introducing this.
I made a mistake and I want to apologize for it.

```
go run ./cmd/lego/ -m xxx@example.com -d example.com --dns xxx -s https://acme-staging-v02.api.letsencrypt.org/directory run --preferred-chain="Fake LE Root X2"
2020/11/21 01:22:01 [INFO] [example.com] acme: Obtaining bundled SAN certificate
2020/11/21 01:22:01 [INFO] [example.com] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/666666666
2020/11/21 01:22:01 [INFO] [example.com] acme: authorization already valid; skipping challenge
2020/11/21 01:22:01 [INFO] [example.com] acme: Validations succeeded; requesting certificates
2020/11/21 01:22:03 [INFO] [example.com] Server responded with a certificate for the preferred certificate chains "Fake LE Root X2".
```


Related to #1227