### PR TITLE
chore: update linter.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -41,6 +41,7 @@
     "nlreturn", # not relevant
     "wrapcheck",
     "tparallel", # not relevant
+    "paralleltest", # not relevant
     "exhaustivestruct", # too many false-positive
   ]
 

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Challenge statuses
+// Challenge statuses.
 // https://tools.ietf.org/html/rfc8555#section-7.1.6
 const (
 	StatusPending     = "pending"
@@ -256,7 +256,7 @@ type Identifier struct {
 	Value string `json:"value"`
 }
 
-// CSRMessage Certificate Signing Request
+// CSRMessage Certificate Signing Request.
 // - https://tools.ietf.org/html/rfc8555#section-7.4
 type CSRMessage struct {
 	// csr (required, string):
@@ -266,7 +266,7 @@ type CSRMessage struct {
 	Csr string `json:"csr"`
 }
 
-// RevokeCertMessage a certificate revocation message
+// RevokeCertMessage a certificate revocation message.
 // - https://tools.ietf.org/html/rfc8555#section-7.6
 // - https://tools.ietf.org/html/rfc5280#section-5.3.1
 type RevokeCertMessage struct {

--- a/acme/errors.go
+++ b/acme/errors.go
@@ -10,7 +10,7 @@ const (
 	BadNonceErr = errNS + "badNonce"
 )
 
-// ProblemDetails the problem details object
+// ProblemDetails the problem details object.
 // - https://tools.ietf.org/html/rfc7807#section-3.1
 // - https://tools.ietf.org/html/rfc8555#section-7.3.3
 type ProblemDetails struct {
@@ -25,7 +25,7 @@ type ProblemDetails struct {
 	URL    string `json:"url,omitempty"`
 }
 
-// SubProblem a "subproblems"
+// SubProblem a "subproblems".
 // - https://tools.ietf.org/html/rfc8555#section-6.7.1
 type SubProblem struct {
 	Type       string     `json:"type,omitempty"`

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -561,9 +561,8 @@ func checkOrderStatus(order acme.ExtendedOrder) (bool, error) {
 }
 
 // https://tools.ietf.org/html/rfc8555#section-7.1.4
-// The domain name MUST be encoded
-//   in the form in which it would appear in a certificate.  That is, it
-//   MUST be encoded according to the rules in Section 7 of [RFC5280].
+// The domain name MUST be encoded in the form in which it would appear in a certificate.
+// That is, it MUST be encoded according to the rules in Section 7 of [RFC5280].
 //
 // https://tools.ietf.org/html/rfc5280#section-7
 func sanitizeDomain(domains []string) []string {

--- a/platform/config/env/env.go
+++ b/platform/config/env/env.go
@@ -32,22 +32,24 @@ func Get(names ...string) (map[string]string, error) {
 	return values, nil
 }
 
-// GetWithFallback Get environment variable values
-// The first name in each group is use as key in the result map
+// GetWithFallback Get environment variable values.
+// The first name in each group is use as key in the result map.
+//
+// case 1:
 //
 //	// LEGO_ONE="ONE"
 //	// LEGO_TWO="TWO"
 //	env.GetWithFallback([]string{"LEGO_ONE", "LEGO_TWO"})
 //	// => "LEGO_ONE" = "ONE"
 //
-// ----
+// case 2:
 //
 //	// LEGO_ONE=""
 //	// LEGO_TWO="TWO"
 //	env.GetWithFallback([]string{"LEGO_ONE", "LEGO_TWO"})
 //	// => "LEGO_ONE" = "TWO"
 //
-// ----
+// case 3:
 //
 //	// LEGO_ONE=""
 //	// LEGO_TWO=""

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -15,7 +15,7 @@ const (
 	// envNamespace is the prefix for ACME-DNS environment variables.
 	envNamespace = "ACME_DNS_"
 
-	// EnvAPIBase is the environment variable name for the ACME-DNS API address
+	// EnvAPIBase is the environment variable name for the ACME-DNS API address.
 	// (e.g. https://acmedns.your-domain.com).
 	EnvAPIBase = envNamespace + "API_BASE"
 	// EnvStoragePath is the environment variable name for the ACME-DNS JSON account data file.

--- a/providers/dns/netcup/internal/client.go
+++ b/providers/dns/netcup/internal/client.go
@@ -54,7 +54,7 @@ type UpdateDNSRecordsRequest struct {
 }
 
 // DNSRecordSet as specified in netcup WSDL.
-// needed in UpdateDNSRecordsRequest
+// needed in UpdateDNSRecordsRequest.
 // https://ccp.netcup.net/run/webservice/servers/endpoint.php#Dnsrecordset
 type DNSRecordSet struct {
 	DNSRecords []DNSRecord `json:"dnsrecords"`


### PR DESCRIPTION
Update golangci-lint to v1.33.0.

The version is defined in the Travis settings.