### PR TITLE
namecheap: unify documentation to other providers

### DIFF
--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -2,11 +2,11 @@ Name = "Namecheap"
 URL = "https://www.namecheap.com"
 Code = "namecheap"
 Since = "v0.3.0"
-Description = '''
 
-Configuration for [Namecheap](https://www.namecheap.com).
+Additional = '''
+## Description
 
-**To enable API access on the Namecheap production environment, some opaque requirements must be met.** More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation. (2020-08: Account balance of $50+, 20+ domains in your account, or purchases totaling $50+ within the last 2 years.)
+To enable API access on the Namecheap production environment, some opaque requirements must be met. More information in the section [Enabling API Access](https://www.namecheap.com/support/api/intro/) of the Namecheap documentation. (2020-08: Account balance of $50+, 20+ domains in your account, or purchases totaling $50+ within the last 2 years.)
 '''
 
 Example = '''


### PR DESCRIPTION
Namecheap is only one provider which list provider restriction on provider list: https://go-acme.github.io/lego/dns/

I think this information fits more into the "Additional" section, similar to AWS Route53 (https://go-acme.github.io/lego/dns/route53/). I can see that this is a bit subjective, but I am bringing it to your consideration.