### PR TITLE
doc: remove landing page button.

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -45,6 +45,7 @@ pygmentsUseClasses = true
 #  ordersectionsby = "weight"
   # Change default color scheme with a variant one. Can be "red", "blue", "green".
   themeVariant = "blue"
+  disableLandingPageButton = true
 
 [Languages]
 [Languages.en]


### PR DESCRIPTION
Because of the update of the theme, a button "Home" appeared but the URL (related to this button) doesn't fit our doc system.

<details>
<summary>before</summary>

![Screenshot_2020-11-28 DNS Providers Let’s Encrypt client and ACME library written in Go ](https://user-images.githubusercontent.com/5674651/100524613-e70c8400-31b9-11eb-9590-e72188ab326c.png)

</details>

<details>
<summary>after</summary>

![Screenshot_2020-11-28 Examples Let’s Encrypt client and ACME library written in Go ](https://user-images.githubusercontent.com/5674651/100524612-e70c8400-31b9-11eb-8530-bd822779754e.png)

</details>