### PR TITLE
Increase INWX propagation timeout to 360s to improve robustness

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -981,7 +981,7 @@ func displayDNSHelp(name string) error {
 
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "INWX_POLLING_INTERVAL":	Time between DNS propagation check`)
-		ew.writeln(`	- "INWX_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
+		ew.writeln(`	- "INWX_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation (default 360s)`)
 		ew.writeln(`	- "INWX_SANDBOX":	Activate the sandbox (boolean)`)
 		ew.writeln(`	- "INWX_SHARED_SECRET":	shared secret related to 2FA`)
 		ew.writeln(`	- "INWX_TTL":	The TTL of the TXT record used for the DNS challenge`)

--- a/docs/content/dns/zz_gen_inwx.md
+++ b/docs/content/dns/zz_gen_inwx.md
@@ -51,7 +51,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
 | `INWX_POLLING_INTERVAL` | Time between DNS propagation check |
-| `INWX_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `INWX_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation (default 360s) |
 | `INWX_SANDBOX` | Activate the sandbox (boolean) |
 | `INWX_SHARED_SECRET` | shared secret related to 2FA |
 | `INWX_TTL` | The TTL of the TXT record used for the DNS challenge |

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -41,7 +41,7 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
+		TTL: env.GetOrDefaultInt(EnvTTL, 300),
 		// INWX has rather unstable propagation delays, thus using a larger default value
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 360*time.Second),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -42,7 +42,8 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		// INWX has rather unstable propagation delays, thus using a larger default value
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 360*time.Second),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		Sandbox:            env.GetOrDefaultBool(EnvSandbox, false),
 	}

--- a/providers/dns/inwx/inwx.toml
+++ b/providers/dns/inwx/inwx.toml
@@ -23,7 +23,7 @@ lego --email myemail@example.com --dns inwx --domains my.example.org run
   [Configuration.Additional]
     INWX_SHARED_SECRET = "shared secret related to 2FA"
     INWX_POLLING_INTERVAL = "Time between DNS propagation check"
-    INWX_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
+    INWX_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation (default 360s)"
     INWX_TTL = "The TTL of the TXT record used for the DNS challenge"
     INWX_SANDBOX = "Activate the sandbox (boolean)"
 


### PR DESCRIPTION
INWX has rather unstable propagation delays. Users reported that the
robustness of the DNS challenge improves with a longer timeout, thus instead
of using the default, hardcode a larger default. Six minutes seems to work
fine so far.

Fixes #1297