### PR TITLE
hyperone: Minor tweaks of documentation

### DIFF
--- a/docs/content/dns/zz_gen_hyperone.md
+++ b/docs/content/dns/zz_gen_hyperone.md
@@ -58,14 +58,16 @@ h1 sa credential generate --name my-passport --sa <sa ID> --passport-output-file
 
 ### Required permissions
 
-Depending of environment variables usage, the application requires different permissions:
--  `dns/zone/list` if `HYPERONE_ZONE_URI` is not specified
+The application requires following permissions:
+-  `dns/zone/list`
 -  `dns/zone.recordset/list`
 -  `dns/zone.recordset/create`
 -  `dns/zone.recordset/delete`
 -  `dns/zone.record/create`
 -  `dns/zone.record/list`
 -  `dns/zone.record/delete`
+
+All required permissions are available via platform role `tool.lego`.
 
 
 

--- a/docs/content/dns/zz_gen_hyperone.md
+++ b/docs/content/dns/zz_gen_hyperone.md
@@ -53,7 +53,7 @@ just a passport file in `~/.h1/passport.json` location.
 To use this application you have to generate passport file for `sa`:
 
 ```
-h1 sa credential generate --name my-passport --sa <sa ID> --passport-output-file ~/.h1/passport.json
+h1 iam project sa credential generate --name my-passport --project <project ID> --sa <sa ID> --passport-output-file ~/.h1/passport.json
 ```
 
 ### Required permissions

--- a/providers/dns/hyperone/hyperone.toml
+++ b/providers/dns/hyperone/hyperone.toml
@@ -19,7 +19,7 @@ just a passport file in `~/.h1/passport.json` location.
 To use this application you have to generate passport file for `sa`:
 
 ```
-h1 sa credential generate --name my-passport --sa <sa ID> --passport-output-file ~/.h1/passport.json
+h1 iam project sa credential generate --name my-passport --project <project ID> --sa <sa ID> --passport-output-file ~/.h1/passport.json
 ```
 
 ### Required permissions

--- a/providers/dns/hyperone/hyperone.toml
+++ b/providers/dns/hyperone/hyperone.toml
@@ -24,14 +24,16 @@ h1 sa credential generate --name my-passport --sa <sa ID> --passport-output-file
 
 ### Required permissions
 
-Depending of environment variables usage, the application requires different permissions:
--  `dns/zone/list` if `HYPERONE_ZONE_URI` is not specified
+The application requires following permissions:
+-  `dns/zone/list`
 -  `dns/zone.recordset/list`
 -  `dns/zone.recordset/create`
 -  `dns/zone.recordset/delete`
 -  `dns/zone.record/create`
 -  `dns/zone.record/list`
 -  `dns/zone.record/delete`
+
+All required permissions are available via platform role `tool.lego`.
 '''
 
 [Configuration]


### PR DESCRIPTION
I am responsible at HyperOne for maintaining Lego integration.

`HYPERONE_ZONE_URI` env is not implemented.