### PR TITLE
deps: update cpu/goacmedns to v0.1.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.20
 	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/cloudflare/cloudflare-go v0.13.2
-	github.com/cpu/goacmedns v0.0.3
+	github.com/cpu/goacmedns v0.1.1
 	github.com/dnsimple/dnsimple-go v0.63.0
 	github.com/exoscale/egoscale v0.23.0
 	github.com/google/go-querystring v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.13.2 h1:bhMGoNhAg21DuqJjU9jQepRRft6vYfo6pejT3NN4V6A=
 github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlKDg4bd8LWlu7oKeZvM=
-github.com/cpu/goacmedns v0.0.3 h1:QOeMpIEsIdm1LSASSswjaTf8CXmzcrgy5OeCfHjppA4=
-github.com/cpu/goacmedns v0.0.3/go.mod h1:4MipLkI+qScwqtVxcNO6okBhbgRrr7/tKXUSgSL0teQ=
+github.com/cpu/goacmedns v0.1.1 h1:DM3H2NiN2oam7QljgGY5ygy4yDXhK5Z4JUnqaugs2C4=
+github.com/cpu/goacmedns v0.1.1/go.mod h1:MuaouqEhPAHxsbqjgnck5zeghuwBP1dLnPoobeGqugQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -107,6 +107,11 @@ func (m mockStorage) Fetch(domain string) (goacmedns.Account, error) {
 	return goacmedns.Account{}, goacmedns.ErrDomainNotFound
 }
 
+// FetchAll returns all of m.accounts.
+func (m mockStorage) FetchAll() map[string]goacmedns.Account {
+	return m.accounts
+}
+
 // errorPutStorage is a mock implementing the goacmedns.Storage interface that
 // always returns errors from Put.
 type errorPutStorage struct {
@@ -138,6 +143,11 @@ type errorFetchStorage struct {
 // Fetch always errors.
 func (e errorFetchStorage) Fetch(_ string) (goacmedns.Account, error) {
 	return goacmedns.Account{}, errorStorageErr
+}
+
+// FetchAll is a nop for errorFetchStorage.
+func (e errorFetchStorage) FetchAll() map[string]goacmedns.Account {
+	return nil
 }
 
 // TestPresent tests that the ACME-DNS Present function for updating a DNS-01


### PR DESCRIPTION
This commit updates the `github.com/cpu/goacmedns` dependency to the latest tagged release at the time of writing, [v0.1.1](https://github.com/cpu/goacmedns/releases/tag/v0.1.1).

Since v0.0.3 there have been [two](https://github.com/cpu/goacmedns/commit/41bdb34639cc9ccf8f39fafde9a802731eeab86e) [small](https://github.com/cpu/goacmedns/commit/745426768bae5f19dd10e50fa340bba52e2da6ae) changes to the storage interface. Both are backwards compatible.