### PR TITLE
errors: Fix instance not being printed

### DIFF
--- a/acme/errors.go
+++ b/acme/errors.go
@@ -44,7 +44,7 @@ func (p ProblemDetails) Error() string {
 		msg += fmt.Sprintf(", problem: %q :: %s", sub.Type, sub.Detail)
 	}
 
-	if len(p.Instance) == 0 {
+	if len(p.Instance) != 0 {
 		msg += ", url: " + p.Instance
 	}
 


### PR DESCRIPTION
The condition so far printed it only when it was known to be empty.

Found in https://github.com/NixOS/nixpkgs/issues/101445#issuecomment-757352452