### PR TITLE
infomaniak: Make error message more meaningful

### DIFF
--- a/providers/dns/infomaniak/internal/client.go
+++ b/providers/dns/infomaniak/internal/client.go
@@ -153,7 +153,7 @@ func (c *Client) do(req *http.Request) (*APIResponse, error) {
 	}
 
 	if resp.Result != "success" {
-		return nil, fmt.Errorf("unexpected API result (%s): %v", resp.Result, resp.ErrResponse)
+		return nil, fmt.Errorf("unexpected API result (%s): %s (HTTPStatus: %s)", resp.Result, resp.ErrResponse.Description, rawResp.Status)
 	}
 
 	return &resp, nil

--- a/providers/dns/infomaniak/internal/client.go
+++ b/providers/dns/infomaniak/internal/client.go
@@ -153,7 +153,7 @@ func (c *Client) do(req *http.Request) (*APIResponse, error) {
 	}
 
 	if resp.Result != "success" {
-		return nil, fmt.Errorf("unexpected API result (%s): %s (HTTPStatus: %s)", resp.Result, resp.ErrResponse.Description, rawResp.Status)
+		return nil, fmt.Errorf("%d: unexpected API result (%s): %w", rawResp.StatusCode, resp.Result, resp.ErrResponse)
 	}
 
 	return &resp, nil

--- a/providers/dns/infomaniak/internal/models.go
+++ b/providers/dns/infomaniak/internal/models.go
@@ -1,6 +1,9 @@
 package internal
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Record a DNS record.
 type Record struct {
@@ -27,4 +30,8 @@ type APIErrorResponse struct {
 	Description string             `json:"description,omitempty"`
 	Context     map[string]string  `json:"context,omitempty"`
 	Errors      []APIErrorResponse `json:"errors,omitempty"`
+}
+
+func (a APIErrorResponse) Error() string {
+	return fmt.Sprintf("code: %s, description: %s", a.Code, a.Description)
 }


### PR DESCRIPTION
The error message on infomaniak server error is not very verbose and well formated, 
For now,the error code is : 
```
infomaniak: error when calling api to create DNS record: unexpected API result (error): &{unexpected_error An unexpected error occurred map[] []}
```
My proposal gives
```
infomaniak: error when calling api to create DNS record: unexpected API result (error): An unexpected error occurred (HTTPStatus: 500 Internal Server Error)
 (give the error description + http status)
```

I'm unsure if the description field is always filled, so we may prefer this : (give the raw body + https status)
```go
return nil, fmt.Errorf("unexpected API result (%s): %s (HTTPStatus: %s)", resp.Result, string(content), rawResp.Status)
```
```
infomaniak: error when calling api to create DNS record: unexpected API result (error): {"result":"error","error":{"code":"unexpected_error","description":"An unexpected error occurred"}} (HTTPStatus: 500 Internal Server Error)
```
or This : (only adding the http status)
```go
return nil, fmt.Errorf("unexpected API result (%s): %+v (HTTPStatus: %s)", resp.Result, resp.ErrResponse, rawResp.Status)
```
```
infomaniak: error when calling api to create DNS record: unexpected API result (error): &{unexpected_error An unexpected error occurred map[] []} (HTTPStatus: 500 Internal Server Error)
```