### PR TITLE
Log reason for propagation check failure

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -130,6 +130,9 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 	err = wait.For("propagation", timeout, interval, func() (bool, error) {
 		stop, errP := c.preCheck.call(domain, fqdn, value)
+		if errP != nil {
+			log.Infof("[%s] acme: Propagation check failed: %s", domain, errP)
+		}
 		if !stop || errP != nil {
 			log.Infof("[%s] acme: Waiting for DNS record propagation.", domain)
 		}


### PR DESCRIPTION
I had trouble diagnosing an issue where the authoritative nameserver was set incorrectly, but the challenge record resolved without issues.  This wasn't clear until I added some logging to clarify the reason for the propagation check failing.

I believe this would be helpful for others trying to troubleshoot the same issue.