### PR TITLE
Increase HTTP client timeouts

### DIFF
--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -64,6 +64,7 @@ type CertificateConfig struct {
 // based on the caCertificatesEnvVar environment variable (see the `initCertPool` function).
 func createDefaultHTTPClient() *http.Client {
 	return &http.Client{
+		Timeout: 2 * time.Minute,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
@@ -72,7 +73,6 @@ func createDefaultHTTPClient() *http.Client {
 			}).DialContext,
 			TLSHandshakeTimeout:   30 * time.Second,
 			ResponseHeaderTimeout: 30 * time.Second,
-			ExpectContinueTimeout: 30 * time.Second,
 			TLSClientConfig: &tls.Config{
 				ServerName: os.Getenv(caServerNameEnvVar),
 				RootCAs:    initCertPool(),

--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -70,9 +70,9 @@ func createDefaultHTTPClient() *http.Client {
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
-			TLSHandshakeTimeout:   15 * time.Second,
-			ResponseHeaderTimeout: 15 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 30 * time.Second,
 			TLSClientConfig: &tls.Config{
 				ServerName: os.Getenv(caServerNameEnvVar),
 				RootCAs:    initCertPool(),


### PR DESCRIPTION
Let's Encrypt's API is sometimes slow:

~~~
2021/01/28 09:48:33 Could not obtain certificates:
        error: one or more domains had a problem:
[*.mydomain.dev] Post "https://acme-v02.api.letsencrypt.org/acme/finalize/105472891/7570478847": net/http: timeout awaiting response headers
[mydomain.dev] Post "https://acme-v02.api.letsencrypt.org/acme/finalize/105472891/7570478847": net/http: timeout awaiting response headers
Certificate generation failed.
~~~

This prevents problems by waiting a little longer for a response.