### PR TITLE
Update for go1.16

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.14, 1.15, 1.x ]
+        go-version: [ 1.15, 1.16, 1.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     name: Main Process
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: 1.15
+      GO_VERSION: 1.16
       GOLANGCI_LINT_VERSION: v1.36.0
       HUGO_VERSION: 0.54.0
       SEIHON_VERSION: v0.5.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ owners to license your work under the terms of the [MIT License](LICENSE).
 
 Requirements:
 
-- `go` v1.14+
+- `go` v1.15+
 - environment variable: `GO111MODULE=on`
 
 First, you have to install [GoLang](https://golang.org/doc/install) and [golangci-lint](https://github.com/golangci/golangci-lint#install).

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -42,7 +42,7 @@ pkg install lego
 
 Requirements:
 
-- `go` v1.14+
+- `go` v1.15+
 - environment variable: `GO111MODULE=on`
 
 To install the latest development version from sources, just run:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-acme/lego/v4
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.54.0


### PR DESCRIPTION
- update go version in the CI
- update documentation

I didn't replace `ioutil` to keep the compatibility with go1.15