### PR TITLE
doc: Fix typo in env var name in Mythic Beasts usage example

### DIFF
--- a/docs/content/dns/zz_gen_mythicbeasts.md
+++ b/docs/content/dns/zz_gen_mythicbeasts.md
@@ -21,7 +21,7 @@ Configuration for [MythicBeasts](https://www.mythic-beasts.com/).
 Here is an example bash command using the MythicBeasts provider:
 
 ```bash
-MYTHICBEASTS_USER_NAME=myuser \
+MYTHICBEASTS_USERNAME=myuser \
 MYTHICBEASTS_PASSWORD=mypass \
 lego --email myemail@example.com --dns mythicbeasts --domains my.example.org run
 ```

--- a/providers/dns/mythicbeasts/mythicbeasts.toml
+++ b/providers/dns/mythicbeasts/mythicbeasts.toml
@@ -5,7 +5,7 @@ Code = "mythicbeasts"
 Since = "v0.3.7"
 
 Example = '''
-MYTHICBEASTS_USER_NAME=myuser \
+MYTHICBEASTS_USERNAME=myuser \
 MYTHICBEASTS_PASSWORD=mypass \
 lego --email myemail@example.com --dns mythicbeasts --domains my.example.org run
 '''


### PR DESCRIPTION
Fixes #1355