### PR TITLE
desec: fix error with default TTL

### DIFF
--- a/providers/dns/desec/desec.go
+++ b/providers/dns/desec/desec.go
@@ -24,6 +24,10 @@ const (
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
 )
 
+// https://github.com/desec-io/desec-stack/issues/216
+// https://desec.readthedocs.io/_/downloads/en/latest/pdf/
+const defaultTTL int = 3600
+
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
 	Token              string
@@ -36,7 +40,7 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 3600),
+		TTL:                env.GetOrDefaultInt(EnvTTL, defaultTTL),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{

--- a/providers/dns/desec/desec.go
+++ b/providers/dns/desec/desec.go
@@ -36,7 +36,7 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
 	return &Config{
-		TTL:                env.GetOrDefaultInt(EnvTTL, 300),
+		TTL:                env.GetOrDefaultInt(EnvTTL, 3600),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{


### PR DESCRIPTION
When I do not specify "DESEC_TTL=3600" the default behavior is this error. 

```
acme: error presenting token: desec: failed to create records: domainName=, recordName=_acme-challenge: 400: body: {"ttl":["Ensure this value is greater than or equal to 3600."]}
```

desec.io only allows TTL below 3600 if you contact there support and they approve this on your account. So the default behavior is always resulting in an error unless you contact support. 

See: 
https://desec.readthedocs.io/_/downloads/en/latest/pdf/
https://github.com/desec-io/desec-stack/issues/216

This PR set's the TTL to 3600 so there are no longer any errors.