### PR TITLE
Cleanup stale records

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -177,7 +177,13 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	recordID, ok := d.recordIDs[token]
 	d.recordIDsMu.Unlock()
 	if !ok {
-		return fmt.Errorf("cloudflare: unknown record ID for '%s'", fqdn)
+		recs, err := d.client.DNSRecords(zoneID, cloudflare.DNSRecord{Name: dns01.UnFqdn(fqdn), Type: "TXT"})
+		if err != nil || len(recs) < 1 {
+			return fmt.Errorf("cloudflare: unknown record ID for '%s'", fqdn)
+		} else if len(recs) > 1 {
+			return fmt.Errorf("cloudflare: multiple records for '%s'", fqdn)
+		}
+		recordID = recs[0].ID
 	}
 
 	err = d.client.DeleteDNSRecord(zoneID, recordID)

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -177,8 +177,8 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	recordID, ok := d.recordIDs[token]
 	d.recordIDsMu.Unlock()
 	if !ok {
-		recs, err := d.client.DNSRecords(zoneID, cloudflare.DNSRecord{Name: dns01.UnFqdn(fqdn), Type: "TXT"})
-		if err != nil || len(recs) < 1 {
+		recs, errDNSRecords := d.client.DNSRecords(zoneID, cloudflare.DNSRecord{Name: dns01.UnFqdn(fqdn), Type: "TXT"})
+		if errDNSRecords != nil || len(recs) < 1 {
 			return fmt.Errorf("cloudflare: unknown record ID for '%s'", fqdn)
 		} else if len(recs) > 1 {
 			return fmt.Errorf("cloudflare: multiple records for '%s'", fqdn)


### PR DESCRIPTION
The record ID is only available when cleaning up our own records and in the same run, this change cleans up stale records from previously failed or third party runs by looking up the record ID.