### PR TITLE
Typo issue in ArvanCloud configuration sample

### DIFF
--- a/docs/content/dns/zz_gen_arvancloud.md
+++ b/docs/content/dns/zz_gen_arvancloud.md
@@ -21,7 +21,7 @@ Configuration for [ArvanCloud](https://arvancloud.com).
 Here is an example bash command using the ArvanCloud provider:
 
 ```bash
-ARVANCLOUD_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+ARVANCLOUD_API_KEY="Apikey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
 lego --email myemail@example.com --dns arvancloud --domains my.example.org run
 ```
 

--- a/providers/dns/arvancloud/arvancloud.toml
+++ b/providers/dns/arvancloud/arvancloud.toml
@@ -11,7 +11,7 @@ lego --email myemail@example.com --dns arvancloud --domains my.example.org run
 
 [Configuration]
   [Configuration.Credentials]
-    ARVANCLOUD_API_KEY = "Apikey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    ARVANCLOUD_API_KEY = "API key"
   [Configuration.Additional]
     ARVANCLOUD_POLLING_INTERVAL = "Time between DNS propagation check"
     ARVANCLOUD_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"

--- a/providers/dns/arvancloud/arvancloud.toml
+++ b/providers/dns/arvancloud/arvancloud.toml
@@ -5,13 +5,13 @@ Code = "arvancloud"
 Since = "v3.8.0"
 
 Example = '''
-ARVANCLOUD_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+ARVANCLOUD_API_KEY="Apikey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
 lego --email myemail@example.com --dns arvancloud --domains my.example.org run
 '''
 
 [Configuration]
   [Configuration.Credentials]
-    ARVANCLOUD_API_KEY = "API key"
+    ARVANCLOUD_API_KEY = "Apikey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   [Configuration.Additional]
     ARVANCLOUD_POLLING_INTERVAL = "Time between DNS propagation check"
     ARVANCLOUD_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"


### PR DESCRIPTION
It has to be also changed in below page:
https://go-acme.github.io/lego/dns/arvancloud/#additional-configuration