### PR TITLE
powerdns: several improvements

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1480,6 +1480,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln(`	- "PDNS_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "PDNS_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "PDNS_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
+		ew.writeln(`	- "PDNS_SERVER_NAME":	Name of the server in the URL, 'localhost' by default`)
 		ew.writeln(`	- "PDNS_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_pdns.md
+++ b/docs/content/dns/zz_gen_pdns.md
@@ -47,6 +47,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 | `PDNS_HTTP_TIMEOUT` | API request timeout |
 | `PDNS_POLLING_INTERVAL` | Time between DNS propagation check |
 | `PDNS_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `PDNS_SERVER_NAME` | Name of the server in the URL, 'localhost' by default |
 | `PDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -39,7 +39,7 @@ type rrSet struct {
 	Type       string   `json:"type"`
 	Kind       string   `json:"kind"`
 	ChangeType string   `json:"changetype"`
-	Records    []Record `json:"records"`
+	Records    []Record `json:"records,omitempty"`
 	TTL        int      `json:"ttl,omitempty"`
 }
 

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -66,7 +66,7 @@ func (d *DNSProvider) getHostedZone(fqdn string) (*hostedZone, error) {
 		return nil, err
 	}
 
-	p := path.Join("/servers/localhost/zones/", dns.Fqdn(authZone))
+	p := path.Join("/servers", d.config.ServerName, "/zones/", dns.Fqdn(authZone))
 
 	result, err := d.sendRequest(http.MethodGet, p, nil)
 	if err != nil {

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -151,7 +151,7 @@ func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawM
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusUnprocessableEntity && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
-		return nil, fmt.Errorf("unexpected HTTP status code %d when fetching '%s'", resp.StatusCode, req.URL)
+		return nil, fmt.Errorf("unexpected HTTP status code %d when %sing '%s'", resp.StatusCode, req.Method, req.URL)
 	}
 
 	var msg json.RawMessage

--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -198,5 +198,9 @@ func (d *DNSProvider) makeRequest(method, uri string, body io.Reader) (*http.Req
 
 	req.Header.Set("X-API-Key", d.config.APIKey)
 
+	if method != http.MethodGet && method != http.MethodDelete {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
 	return req, nil
 }

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -26,12 +26,14 @@ const (
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+	EnvServerName         = envNamespace + "SERVER_NAME"
 )
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
 	APIKey             string
 	Host               *url.URL
+	ServerName         string
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
 	TTL                int
@@ -44,6 +46,7 @@ func NewDefaultConfig() *Config {
 		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
+		ServerName:         env.GetOrDefaultString(EnvServerName, "localhost"),
 		HTTPClient: &http.Client{
 			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
 		},

--- a/providers/dns/pdns/pdns.toml
+++ b/providers/dns/pdns/pdns.toml
@@ -29,6 +29,7 @@ PowerDNS Notes:
     PDNS_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     PDNS_TTL = "The TTL of the TXT record used for the DNS challenge"
     PDNS_HTTP_TIMEOUT = "API request timeout"
+    PDNS_SERVER_NAME = "Name of the server in the URL, 'localhost' by default"
 
 [Links]
   API = "https://doc.powerdns.com/md/httpapi/README/"


### PR DESCRIPTION
Hi folks,

This PR has several improvements to the PowerDNS DNS Provider.

### Server name
The PowerDNS API allows for a `server_name` other than 'localhost'. The auth server itself does not use it, but proxies that have multiple backends can. We are running such a proxy. The first commit in this series adds the `PDNS_SERVER_NAME` option to set this. The default remains the same.

### content-type in PATCH requests
Some proxies require the Content-Type header to be set. The second commit sets this header to 'application/json' when the method is not DELETE or GET.

### 'records' can be omitted in rrset
The API allows the 'records' field to be omitted in the request when the `changetype` is 'DELETE'. The third commit implements this omission.

### Error reporting
I was confused by an error report that had the word 'fetch' hardcoded. The last commit changes this to the HTTP Method used.


If there is anything you need more in this PR, let me know.

Cheers,

Pieter Lexis
PowerDNS