### PR TITLE
make: fix validate-docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,12 @@ generate-dns:
 	go generate ./...
 
 validate-doc: generate-dns
-ifneq ($(shell git status --porcelain -- ./docs/ ./cmd/ 2>/dev/null),)
-	@echo 'The documentation must be regenerated, please use `make generate-dns`.'
-	@git status --porcelain -- ./docs/ ./cmd/ 2>/dev/null
-	@exit 2
-else
-	@echo 'All documentation changes are done the right way.'
-endif
+validate-doc: DOC_DIRECTORIES := ./docs/ ./cmd/
+validate-doc:
+	if git diff --exit-code --quiet $(DOC_DIRECTORIES) 2>/dev/null; then \
+		echo 'All documentation changes are done the right way.'; \
+	else \
+		echo 'The documentation must be regenerated, please use `make generate-dns`.'; \
+		git status --porcelain -- $(DOC_DIRECTORIES) 2>/dev/null; \
+		exit 2; \
+	fi


### PR DESCRIPTION
In #1374 the PDNS documentation was amended, but the author forgot to re-generate the docs.

We do have a validation check in the main workflow, but it didn't catch the change because the underlying Makefile target was broken.

This commit replaces the Makefile conditional with an equivalent shell conditional.

<details><summary>Explanation</summary>

The conditional checking for a dirty working directory ran before generating the documentation. In effect, `make validate-doc` only
did the right thing on the second invokation.

Consider this simplified Makefile example:

```make
generate:
	aaaa
	
validate: generate
ifneq ($(shell bbbb),)
	cccc
else
	dddd
endif
```

The order of evaluation for `make validate` is:

1. detect `generate` target, no dependencies,
2. set body for `generate` target to `aaaa`,
3. detect `validate` target, with dependency `generate`,
4. execute `bbbb`, compare with empty string,
   - if not empty: set body for `validate` target to `cccc`
   - else: set body for `validate` target to `dddd`
5. invoke `generate` → execute `aaaa` (`generate` is a dependency of `validate`),
6. invoke `validate` → execute `cccc` or `dddd`.

This also means that step 4 is also (unnecessarily) executed when the `validate` target is never invoked.

</details>