### PR TITLE
nifcloud: Add a NIFCLOUD_HOSTED_ZONE parameter

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1344,6 +1344,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "NIFCLOUD_HOSETD_ZONE":	Hosted zone name`)
 		ew.writeln(`	- "NIFCLOUD_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "NIFCLOUD_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "NIFCLOUD_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)

--- a/docs/content/dns/zz_gen_nifcloud.md
+++ b/docs/content/dns/zz_gen_nifcloud.md
@@ -44,6 +44,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `NIFCLOUD_HOSETD_ZONE` | Hosted zone name |
 | `NIFCLOUD_HTTP_TIMEOUT` | API request timeout |
 | `NIFCLOUD_POLLING_INTERVAL` | Time between DNS propagation check |
 | `NIFCLOUD_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -21,6 +21,7 @@ const (
 	EnvSecretAccessKey = envNamespace + "SECRET_ACCESS_KEY"
 	EnvDNSEndpoint     = envNamespace + "DNS_ENDPOINT"
 
+	EnvHostedZone         = envNamespace + "HOSTED_ZONE"
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
@@ -152,7 +153,8 @@ func (d *DNSProvider) changeRecord(action, fqdn, value, domain string, ttl int) 
 		},
 	}
 
-	resp, err := d.client.ChangeResourceRecordSets(domain, reqParams)
+	hostedZoneID := env.GetOrDefaultString(EnvHostedZone, domain)
+	resp, err := d.client.ChangeResourceRecordSets(hostedZoneID, reqParams)
 	if err != nil {
 		return fmt.Errorf("failed to change NIFCLOUD record set: %w", err)
 	}

--- a/providers/dns/nifcloud/nifcloud.toml
+++ b/providers/dns/nifcloud/nifcloud.toml
@@ -15,6 +15,7 @@ lego --email myemail@example.com --dns nifcloud --domains my.example.org run
     NIFCLOUD_ACCESS_KEY_ID = "Access key"
     NIFCLOUD_SECRET_ACCESS_KEY = "Secret access key"
   [Configuration.Additional]
+    NIFCLOUD_HOSETD_ZONE = "Hosted zone name"
     NIFCLOUD_POLLING_INTERVAL = "Time between DNS propagation check"
     NIFCLOUD_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     NIFCLOUD_TTL = "The TTL of the TXT record used for the DNS challenge"


### PR DESCRIPTION
I updated dns nifcloud provider. If NIFCLOUD_HOSTED_ZONE is set, preferentially use it as the zone name, otherwise use the domain value as the zone name.

ex)

```
NIFCLOUD_HOSTED_ZONE=your.hosted.zone \
NIFCLOUD_ACCESS_KEY_ID=xxxxxxx \
NIFCLOUD_SECRET_ACCESS_KEY=xxxxxxx \
lego --email your-name@mail.domain --dns nifcloud --domains *.sub.your.hosted.zone --accept-tos run
```