### PR TITLE
hurricane: documentation typo in domain name

### DIFF
--- a/docs/content/dns/zz_gen_hurricane.md
+++ b/docs/content/dns/zz_gen_hurricane.md
@@ -67,7 +67,7 @@ HURRICANE_TOKENS=example.org:token
 
 ## More information
 
-- [API documentation](https://dns.he.org/)
+- [API documentation](https://dns.he.net/)
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 <!-- providers/dns/hurricane/hurricane.toml -->

--- a/providers/dns/hurricane/hurricane.toml
+++ b/providers/dns/hurricane/hurricane.toml
@@ -45,4 +45,4 @@ HURRICANE_TOKENS=example.org:token
     HURRICANE_HTTP_TIMEOUT = "API request timeout"
 
 [Links]
-  API = "https://dns.he.org/"
+  API = "https://dns.he.net/"


### PR DESCRIPTION
Hurricane Electric's domain is `he.net`, not `he.org`.

Sorry for being pedantic :-)