### PR TITLE
hurricane: only treat first word of response body as response code

### DIFF
--- a/providers/dns/hurricane/internal/client.go
+++ b/providers/dns/hurricane/internal/client.go
@@ -82,9 +82,6 @@ func (c *Client) UpdateTxtRecord(domain string, txt string) error {
 
 func evaluateBody(body string, hostname string) error {
 	words := strings.SplitN(body, " ", 2)
-	if len(words) == 0 {
-		return fmt.Errorf("attempt to change TXT record %s returned invalid body: %s", hostname, body)
-	}
 
 	switch words[0] {
 	case codeGood:

--- a/providers/dns/hurricane/internal/client.go
+++ b/providers/dns/hurricane/internal/client.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -80,7 +81,12 @@ func (c *Client) UpdateTxtRecord(domain string, txt string) error {
 }
 
 func evaluateBody(body string, hostname string) error {
-	switch body {
+	words := strings.SplitN(body, " ", 2)
+	if len(words) == 0 {
+		return fmt.Errorf("attempt to change TXT record %s returned invalid body: %s", hostname, body)
+	}
+
+	switch words[0] {
 	case codeGood:
 		return nil
 	case codeNoChg:

--- a/providers/dns/hurricane/internal/client_test.go
+++ b/providers/dns/hurricane/internal/client_test.go
@@ -19,7 +19,7 @@ func TestClient_UpdateTxtRecord(t *testing.T) {
 			expected: assert.NoError,
 		},
 		{
-			code:     codeNoChg,
+			code:     codeNoChg + ` "0123456789abcdef"`,
 			expected: assert.NoError,
 		},
 		{


### PR DESCRIPTION
In the hurricane DNS provider, consider only the first word in the response body to be the response code when checking whether the request succeeded; specifically, do not necessarily consider multi-word responses to be indicative of server errors. This corrects the handling of `nochg` responses from he.net's Dynamic DNS service, in which the response code is followed by the unchanged value of the TXT record.


Fixes #1408

----

I've confirmed that this fixes the issue raised in #1408 (domain name redacted):

```
2021/05/23 21:02:01 [INFO] [...] acme: use dns-01 solver
2021/05/23 21:02:01 [INFO] [...] acme: Preparing to solve DNS-01
2021/05/23 21:02:01 nochg "PeBwwj6VsqoP4Y_eUJrSGWi0yNN614vYteNLBTpWfXk": unchanged content written to TXT record _acme-challenge.[...]
2021/05/23 21:02:01 [INFO] [...] acme: Trying to solve DNS-01
2021/05/23 21:02:01 [INFO] [...] acme: Checking DNS record propagation using [ns1.he.net:53]
2021/05/23 21:02:31 [INFO] Wait for propagation [timeout: 5m0s, interval: 30s]
2021/05/23 21:02:35 [INFO] [...] The server validated our request
2021/05/23 21:02:35 [INFO] [...] acme: Cleaning DNS-01 challenge
2021/05/23 21:02:35 [INFO] [...] acme: Validations succeeded; requesting certificates
2021/05/23 21:02:42 [INFO] [...] Server responded with a certificate.
```