### PR TITLE
mythicbeasts: update API Auth endpoint in documentation

### DIFF
--- a/providers/dns/mythicbeasts/mythicbeasts.toml
+++ b/providers/dns/mythicbeasts/mythicbeasts.toml
@@ -30,4 +30,4 @@ Your API key name is not needed to operate lego.
 
 [Links]
   API = "https://www.mythic-beasts.com/support/api/dnsv2"
-  APIAuth = "https://www.mythic-beasts.com/support/api/auth"
+  APIAuth = "https://auth.mythic-beasts.com/login"


### PR DESCRIPTION
I have had a support ticket open with Mythic Beasts, as TLD cert requests were failing.
I have been advised that https://www.mythic-beasts.com/support/api/auth should change to https://auth.mythic-beasts.com/login
I have made that change and my requests now work, so am updating this page for others :)