### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: 1.16
-      GOLANGCI_LINT_VERSION: v1.39.0
+      GOLANGCI_LINT_VERSION: v1.40.1
       HUGO_VERSION: 0.54.0
       SEIHON_VERSION: v0.8.3
       CGO_ENABLED: 0

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -39,6 +39,7 @@
       "rangeValCopy",
       "octalLiteral",
       "ptrToRefParam",
+      "appendAssign",
     ]
 
 [linters]
@@ -47,6 +48,7 @@
     "interfacer", # deprecated
     "maligned", # deprecated
     "scopelint", # deprecated
+    "golint", # deprecated
     "cyclop", # duplicate of gocyclo
     "lll",
     "gosec",
@@ -69,6 +71,7 @@
     "forbidigo", # not relevant
     "noctx",
     "forcetypeassert",
+    "tagliatelle",
   ]
 
 [issues]


### PR DESCRIPTION
Update golangci-lint to v1.40.1.