### PR TITLE
lightsail: wrong Region env var name

### DIFF
--- a/providers/dns/lightsail/lightsail.go
+++ b/providers/dns/lightsail/lightsail.go
@@ -24,7 +24,7 @@ const (
 const (
 	envNamespace = "LIGHTSAIL_"
 
-	EnvRegion  = envNamespace + "LIGHTSAIL_REGION"
+	EnvRegion  = envNamespace + "REGION"
 	EnvDNSZone = "DNS_ZONE"
 
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"


### PR DESCRIPTION
"LIGHTSAIL_" was mentioned two times in the key for lightsail provider