### PR TITLE
Add AlwaysDeactivateAuthorizations flag to ObtainRequest

### DIFF
--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -60,19 +60,17 @@ func (c *Certifier) getAuthorizations(order acme.ExtendedOrder) ([]acme.Authoriz
 	return responses, nil
 }
 
-func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder, skipValid bool) {
+func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder, force bool) {
 	for _, authzURL := range order.Authorizations {
-		if skipValid {
-			auth, err := c.core.Authorizations.Get(authzURL)
-			if err != nil {
-				log.Infof("Unable to get the authorization for: %s", authzURL)
-				continue
-			}
+		auth, err := c.core.Authorizations.Get(authzURL)
+		if err != nil {
+			log.Infof("Unable to get the authorization for: %s", authzURL)
+			continue
+		}
 
-			if auth.Status == acme.StatusValid {
-				log.Infof("Skipping deactivating of valid auth: %s", authzURL)
-				continue
-			}
+		if auth.Status == acme.StatusValid && !force {
+			log.Infof("Skipping deactivating of valid auth: %s", authzURL)
+			continue
 		}
 
 		log.Infof("Deactivating auth: %s", authzURL)

--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -60,17 +60,19 @@ func (c *Certifier) getAuthorizations(order acme.ExtendedOrder) ([]acme.Authoriz
 	return responses, nil
 }
 
-func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder) {
+func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder, skipValid bool) {
 	for _, authzURL := range order.Authorizations {
-		auth, err := c.core.Authorizations.Get(authzURL)
-		if err != nil {
-			log.Infof("Unable to get the authorization for: %s", authzURL)
-			continue
-		}
+		if skipValid {
+			auth, err := c.core.Authorizations.Get(authzURL)
+			if err != nil {
+				log.Infof("Unable to get the authorization for: %s", authzURL)
+				continue
+			}
 
-		if auth.Status == acme.StatusValid {
-			log.Infof("Skipping deactivating of valid auth: %s", authzURL)
-			continue
+			if auth.Status == acme.StatusValid {
+				log.Infof("Skipping deactivating of valid auth: %s", authzURL)
+				continue
+			}
 		}
 
 		log.Infof("Deactivating auth: %s", authzURL)

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -49,10 +49,10 @@ type Resource struct {
 // If you do not want that you can supply your own private key in the privateKey parameter.
 // If this parameter is non-nil it will be used instead of generating a new one.
 //
-// If bundle is true, the []byte contains both the issuer certificate and your issued certificate as a bundle.
+// If `Bundle` is true, the `[]byte` contains both the issuer certificate and your issued certificate as a bundle.
 //
-// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished
-// if the obtain request was successful. See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
+// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished if the obtain request was successful.
+// See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
 type ObtainRequest struct {
 	Domains                        []string
 	Bundle                         bool
@@ -64,10 +64,10 @@ type ObtainRequest struct {
 
 // ObtainForCSRRequest The request to obtain a certificate matching the CSR passed into it.
 //
-// If bundle is true, the []byte contains both the issuer certificate and your issued certificate as a bundle.
+// If `Bundle` is true, the `[]byte` contains both the issuer certificate and your issued certificate as a bundle.
 //
-// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished
-// if the obtain request was successful. See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
+// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished if the obtain request was successful.
+// See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
 type ObtainForCSRRequest struct {
 	CSR                            *x509.CertificateRequest
 	Bundle                         bool
@@ -147,7 +147,7 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 	}
 
 	if request.AlwaysDeactivateAuthorizations {
-		c.deactivateAuthorizations(order, false)
+		c.deactivateAuthorizations(order, true)
 	}
 
 	// Do not return an empty failures map, because
@@ -212,7 +212,7 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 	}
 
 	if request.AlwaysDeactivateAuthorizations {
-		c.deactivateAuthorizations(order, false)
+		c.deactivateAuthorizations(order, true)
 	}
 
 	if cert != nil {

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -125,14 +125,14 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 	authz, err := c.getAuthorizations(order)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order, true)
+		c.deactivateAuthorizations(order, request.AlwaysDeactivateAuthorizations)
 		return nil, err
 	}
 
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order, true)
+		c.deactivateAuthorizations(order, request.AlwaysDeactivateAuthorizations)
 		return nil, err
 	}
 
@@ -190,14 +190,14 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 	authz, err := c.getAuthorizations(order)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order, true)
+		c.deactivateAuthorizations(order, request.AlwaysDeactivateAuthorizations)
 		return nil, err
 	}
 
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order, true)
+		c.deactivateAuthorizations(order, request.AlwaysDeactivateAuthorizations)
 		return nil, err
 	}
 

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -50,21 +50,29 @@ type Resource struct {
 // If this parameter is non-nil it will be used instead of generating a new one.
 //
 // If bundle is true, the []byte contains both the issuer certificate and your issued certificate as a bundle.
+//
+// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished
+// if the obtain request was successful. See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
 type ObtainRequest struct {
-	Domains        []string
-	Bundle         bool
-	PrivateKey     crypto.PrivateKey
-	MustStaple     bool
-	PreferredChain string
+	Domains                        []string
+	Bundle                         bool
+	PrivateKey                     crypto.PrivateKey
+	MustStaple                     bool
+	PreferredChain                 string
+	AlwaysDeactivateAuthorizations bool
 }
 
 // ObtainForCSRRequest The request to obtain a certificate matching the CSR passed into it.
 //
 // If bundle is true, the []byte contains both the issuer certificate and your issued certificate as a bundle.
+//
+// If `AlwaysDeactivateAuthorizations` is true, the authorizations are also relinquished
+// if the obtain request was successful. See https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2.
 type ObtainForCSRRequest struct {
-	CSR            *x509.CertificateRequest
-	Bundle         bool
-	PreferredChain string
+	CSR                            *x509.CertificateRequest
+	Bundle                         bool
+	PreferredChain                 string
+	AlwaysDeactivateAuthorizations bool
 }
 
 type resolver interface {
@@ -117,14 +125,14 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 	authz, err := c.getAuthorizations(order)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order)
+		c.deactivateAuthorizations(order, true)
 		return nil, err
 	}
 
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order)
+		c.deactivateAuthorizations(order, true)
 		return nil, err
 	}
 
@@ -136,6 +144,10 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 		for _, auth := range authz {
 			failures[challenge.GetTargetedDomain(auth)] = err
 		}
+	}
+
+	if request.AlwaysDeactivateAuthorizations {
+		c.deactivateAuthorizations(order, false)
 	}
 
 	// Do not return an empty failures map, because
@@ -178,14 +190,14 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 	authz, err := c.getAuthorizations(order)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order)
+		c.deactivateAuthorizations(order, true)
 		return nil, err
 	}
 
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
-		c.deactivateAuthorizations(order)
+		c.deactivateAuthorizations(order, true)
 		return nil, err
 	}
 
@@ -197,6 +209,10 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 		for _, auth := range authz {
 			failures[challenge.GetTargetedDomain(auth)] = err
 		}
+	}
+
+	if request.AlwaysDeactivateAuthorizations {
+		c.deactivateAuthorizations(order, false)
 	}
 
 	if cert != nil {

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -62,6 +62,10 @@ func createRenew() cli.Command {
 				Name:  "preferred-chain",
 				Usage: "If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.",
 			},
+			cli.StringFlag{
+				Name:  "always-deactivate-authorizations",
+				Usage: "Force the authorizations to be relinquished even if the certificate request was successful.",
+			},
 		},
 	}
 }
@@ -127,11 +131,12 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 	}
 
 	request := certificate.ObtainRequest{
-		Domains:        merge(certDomains, domains),
-		Bundle:         bundle,
-		PrivateKey:     privateKey,
-		MustStaple:     ctx.Bool("must-staple"),
-		PreferredChain: ctx.String("preferred-chain"),
+		Domains:                        merge(certDomains, domains),
+		Bundle:                         bundle,
+		PrivateKey:                     privateKey,
+		MustStaple:                     ctx.Bool("must-staple"),
+		PreferredChain:                 ctx.String("preferred-chain"),
+		AlwaysDeactivateAuthorizations: ctx.Bool("always-deactivate-authorizations"),
 	}
 	certRes, err := client.Certificate.Obtain(request)
 	if err != nil {
@@ -174,9 +179,10 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 	log.Infof("[%s] acme: Trying renewal with %d hours remaining", domain, int(timeLeft.Hours()))
 
 	certRes, err := client.Certificate.ObtainForCSR(certificate.ObtainForCSRRequest{
-		CSR:            csr,
-		Bundle:         bundle,
-		PreferredChain: ctx.String("preferred-chain"),
+		CSR:                            csr,
+		Bundle:                         bundle,
+		PreferredChain:                 ctx.String("preferred-chain"),
+		AlwaysDeactivateAuthorizations: ctx.Bool("always-deactivate-authorizations"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -47,6 +47,10 @@ func createRun() cli.Command {
 				Name:  "preferred-chain",
 				Usage: "If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.",
 			},
+			cli.StringFlag{
+				Name:  "always-deactivate-authorizations",
+				Usage: "Force the authorizations to be relinquished even if the certificate request was successful.",
+			},
 		},
 	}
 }
@@ -163,10 +167,11 @@ func obtainCertificate(ctx *cli.Context, client *lego.Client) (*certificate.Reso
 	if len(domains) > 0 {
 		// obtain a certificate, generating a new private key
 		request := certificate.ObtainRequest{
-			Domains:        domains,
-			Bundle:         bundle,
-			MustStaple:     ctx.Bool("must-staple"),
-			PreferredChain: ctx.String("preferred-chain"),
+			Domains:                        domains,
+			Bundle:                         bundle,
+			MustStaple:                     ctx.Bool("must-staple"),
+			PreferredChain:                 ctx.String("preferred-chain"),
+			AlwaysDeactivateAuthorizations: ctx.Bool("always-deactivate-authorizations"),
 		}
 		return client.Certificate.Obtain(request)
 	}
@@ -179,8 +184,9 @@ func obtainCertificate(ctx *cli.Context, client *lego.Client) (*certificate.Reso
 
 	// obtain a certificate for this CSR
 	return client.Certificate.ObtainForCSR(certificate.ObtainForCSRRequest{
-		CSR:            csr,
-		Bundle:         bundle,
-		PreferredChain: ctx.String("preferred-chain"),
+		CSR:                            csr,
+		Bundle:                         bundle,
+		PreferredChain:                 ctx.String("preferred-chain"),
+		AlwaysDeactivateAuthorizations: ctx.Bool("always-deactivate-authorizations"),
 	})
 }


### PR DESCRIPTION
After a successful certificate request, the authorizations may be cached by the ACME provider for some time.
For example [Let's encrypt caches them for 30 days](https://letsencrypt.org/docs/faq/#i-successfully-renewed-a-certificate-but-validation-didn-t-happen-this-time-how-is-that-possible)

If the registration account is shared between multiple clients, a client can request a new certificate for domains already requested by the original client without new validation.
To avoid this behaviour, the authorizations must be deactivated explicitly, see [RFC 8555, Deactivating an Authorization](https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.2)

With this PR, a flag `AlwaysDeactivateAuthorizations` is introduced to the `ObtainRequest` and `ObtainForCSRRequest` to enable this deactivation after a successful certificate request optionally. The default behaviour is kept unchanged.
