### PR TITLE
edgedns: fix Present and CleanUp logic

### DIFF
--- a/providers/dns/edgedns/edgedns.go
+++ b/providers/dns/edgedns/edgedns.go
@@ -138,18 +138,18 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		if err != nil {
 			return fmt.Errorf("edgedns: %w", err)
 		}
-	}
+	} else {
+		record = &configdns.RecordBody{
+			Name:       fqdn,
+			RecordType: "TXT",
+			TTL:        d.config.TTL,
+			Target:     []string{`"` + value + `"`},
+		}
 
-	record = &configdns.RecordBody{
-		Name:       fqdn,
-		RecordType: "TXT",
-		TTL:        d.config.TTL,
-		Target:     []string{`"` + value + `"`},
-	}
-
-	err = record.Save(zone)
-	if err != nil {
-		return fmt.Errorf("edgedns: %w", err)
+		err = record.Save(zone)
+		if err != nil {
+			return fmt.Errorf("edgedns: %w", err)
+		}
 	}
 
 	return nil
@@ -200,11 +200,11 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		if err != nil {
 			return fmt.Errorf("edgedns: %w", err)
 		}
-	}
-
-	err = existingRec.Delete(zone)
-	if err != nil {
-		return fmt.Errorf("edgedns: %w", err)
+	} else {
+		err = existingRec.Delete(zone)
+		if err != nil {
+			return fmt.Errorf("edgedns: %w", err)
+		}
 	}
 
 	return nil

--- a/providers/dns/edgedns/edgedns.go
+++ b/providers/dns/edgedns/edgedns.go
@@ -138,18 +138,20 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		if err != nil {
 			return fmt.Errorf("edgedns: %w", err)
 		}
-	} else {
-		record = &configdns.RecordBody{
-			Name:       fqdn,
-			RecordType: "TXT",
-			TTL:        d.config.TTL,
-			Target:     []string{`"` + value + `"`},
-		}
 
-		err = record.Save(zone)
-		if err != nil {
-			return fmt.Errorf("edgedns: %w", err)
-		}
+		return nil
+	}
+
+	record = &configdns.RecordBody{
+		Name:       fqdn,
+		RecordType: "TXT",
+		TTL:        d.config.TTL,
+		Target:     []string{`"` + value + `"`},
+	}
+
+	err = record.Save(zone)
+	if err != nil {
+		return fmt.Errorf("edgedns: %w", err)
 	}
 
 	return nil
@@ -200,11 +202,13 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		if err != nil {
 			return fmt.Errorf("edgedns: %w", err)
 		}
-	} else {
-		err = existingRec.Delete(zone)
-		if err != nil {
-			return fmt.Errorf("edgedns: %w", err)
-		}
+
+		return nil
+	}
+
+	err = existingRec.Delete(zone)
+	if err != nil {
+		return fmt.Errorf("edgedns: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The current Present logic of the EdgeDNS provider tries to create the TXT record even if it has just updated the existing TXT record.
The current CleanUp logic of the EdgeDNS provider deletes the TXT record even if it found that there are still challenges in the TXT record that should remain there.

This commit is to fix these issues.