### PR TITLE
Fix missing preferred chain param for renew request

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -439,6 +439,7 @@ func (c *Certifier) Renew(certRes Resource, bundle, mustStaple bool, preferredCh
 		Bundle:     bundle,
 		PrivateKey: privateKey,
 		MustStaple: mustStaple,
+		PreferredChain: preferredChain,
 	}
 	return c.Obtain(query)
 }


### PR DESCRIPTION
### Description

This PR adds the missing `preferredChain` parameter in the `ObtainRequest` structure used for certificate renewal.