### PR TITLE
rackspace: change zone ID to string

### DIFF
--- a/providers/dns/rackspace/rackspace.go
+++ b/providers/dns/rackspace/rackspace.go
@@ -135,7 +135,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("rackspace: %w", err)
 	}
 
-	_, err = d.makeRequest(http.MethodPost, fmt.Sprintf("/domains/%d/records", zoneID), bytes.NewReader(body))
+	_, err = d.makeRequest(http.MethodPost, fmt.Sprintf("/domains/%s/records", zoneID), bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("rackspace: %w", err)
 	}
@@ -156,7 +156,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("rackspace: %w", err)
 	}
 
-	_, err = d.makeRequest(http.MethodDelete, fmt.Sprintf("/domains/%d/records?id=%s", zoneID, record.ID), nil)
+	_, err = d.makeRequest(http.MethodDelete, fmt.Sprintf("/domains/%s/records?id=%s", zoneID, record.ID), nil)
 	if err != nil {
 		return fmt.Errorf("rackspace: %w", err)
 	}

--- a/providers/dns/rackspace/rackspace_mock_test.go
+++ b/providers/dns/rackspace/rackspace_mock_test.go
@@ -31,7 +31,7 @@ const zoneDetailsMock = `
   "domains": [
     {
       "name": "example.com",
-      "id": 112233,
+      "id": "112233",
       "emailAddress": "hostmaster@example.com",
       "updated": "1970-01-01T00:00:00.000+0000",
       "created": "1970-01-01T00:00:00.000+0000"


### PR DESCRIPTION
Attempting a DNS challenge request with the Rackspace provider fails with an error in the following form:
```
2021/10/11 21:07:31 Could not obtain certificates:
        error: one or more domains had a problem:
[example.com] [example.com] acme: error presenting token: rackspace: json: cannot unmarshal string into Go struct field HostedZone.domains.id of type int
```

Querying https://dns.api.rackspacecloud.com/v1.0/account/domains?name=example.com shows that the domains.id field is now being returned as a string, rather than an int:
```
{"totalEntries":1,"domains":[{"id":"123456", ...}]}
```

This commit accordingly changes HostedZone and depending code to expect a string rather than an int.