### PR TITLE
chore: migrate RFC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Let's Encrypt client and ACME library written in Go.
 
 ## Features
 
-- ACME v2 [RFC 8555](https://tools.ietf.org/html/rfc8555) 
+- ACME v2 [RFC 8555](https://www.rfc-editor.org/rfc/rfc8555.html)
 - Register with CA
 - Obtain certificates, both from scratch or with an existing CSR
 - Renew certificates

--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -70,7 +70,7 @@ func (a *Core) post(uri string, reqBody, response interface{}) (*http.Response, 
 }
 
 // postAsGet performs an HTTP POST ("POST-as-GET") request.
-// https://tools.ietf.org/html/rfc8555#section-6.3
+// https://www.rfc-editor.org/rfc/rfc8555.html#section-6.3
 func (a *Core) postAsGet(uri string, response interface{}) (*http.Response, error) {
 	return a.retrievablePost(uri, []byte{}, response)
 }

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -39,7 +39,7 @@ func (c *CertificateService) GetAll(certURL string, bundle bool) (map[string]*ac
 	certs := map[string]*acme.RawCertificate{certURL: cert}
 
 	// URLs of "alternate" link relation
-	// - https://tools.ietf.org/html/rfc8555#section-7.4.2
+	// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2
 	alts := getLinks(headers, "alternate")
 
 	for _, alt := range alts {
@@ -92,7 +92,7 @@ func (c *CertificateService) getCertificateChain(cert []byte, headers http.Heade
 
 	// The issuer certificate link may be supplied via an "up" link
 	// in the response headers of a new certificate.
-	// See https://tools.ietf.org/html/rfc8555#section-7.4.2
+	// See https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2
 	up := getLink(headers, "up")
 
 	issuer, err := c.getIssuerFromLink(up)

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -1,5 +1,5 @@
 // Package acme contains all objects related the ACME endpoints.
-// https://tools.ietf.org/html/rfc8555
+// https://www.rfc-editor.org/rfc/rfc8555.html
 package acme
 
 import (
@@ -8,7 +8,7 @@ import (
 )
 
 // ACME status values of Account, Order, Authorization and Challenge objects.
-// See https://tools.ietf.org/html/rfc8555#section-7.1.6 for details.
+// See https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.6 for details.
 const (
 	StatusDeactivated = "deactivated"
 	StatusExpired     = "expired"
@@ -37,7 +37,7 @@ const (
 )
 
 // Directory the ACME directory object.
-// - https://tools.ietf.org/html/rfc8555#section-7.1.1
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.1
 type Directory struct {
 	NewNonceURL   string `json:"newNonce"`
 	NewAccountURL string `json:"newAccount"`
@@ -49,7 +49,7 @@ type Directory struct {
 }
 
 // Meta the ACME meta object (related to Directory).
-// - https://tools.ietf.org/html/rfc8555#section-7.1.1
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.1
 type Meta struct {
 	// termsOfService (optional, string):
 	// A URL identifying the current terms of service.
@@ -82,8 +82,8 @@ type ExtendedAccount struct {
 }
 
 // Account the ACME account Object.
-// - https://tools.ietf.org/html/rfc8555#section-7.1.2
-// - https://tools.ietf.org/html/rfc8555#section-7.3
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.2
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.3
 type Account struct {
 	// status (required, string):
 	// The status of this account.
@@ -129,7 +129,7 @@ type ExtendedOrder struct {
 }
 
 // Order the ACME order Object.
-// - https://tools.ietf.org/html/rfc8555#section-7.1.3
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.3
 type Order struct {
 	// status (required, string):
 	// The status of this order.
@@ -182,7 +182,7 @@ type Order struct {
 }
 
 // Authorization the ACME authorization object.
-// - https://tools.ietf.org/html/rfc8555#section-7.1.4
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.4
 type Authorization struct {
 	// status (required, string):
 	// The status of this authorization.
@@ -224,8 +224,8 @@ type ExtendedChallenge struct {
 }
 
 // Challenge the ACME challenge object.
-// - https://tools.ietf.org/html/rfc8555#section-7.1.5
-// - https://tools.ietf.org/html/rfc8555#section-8
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.5
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-8
 type Challenge struct {
 	// type (required, string):
 	// The type of challenge encoded in the object.
@@ -258,23 +258,23 @@ type Challenge struct {
 	// It MUST NOT contain any characters outside the base64url alphabet,
 	// and MUST NOT include base64 padding characters ("=").
 	// See [RFC4086] for additional information on randomness requirements.
-	// https://tools.ietf.org/html/rfc8555#section-8.3
-	// https://tools.ietf.org/html/rfc8555#section-8.4
+	// https://www.rfc-editor.org/rfc/rfc8555.html#section-8.3
+	// https://www.rfc-editor.org/rfc/rfc8555.html#section-8.4
 	Token string `json:"token"`
 
-	// https://tools.ietf.org/html/rfc8555#section-8.1
+	// https://www.rfc-editor.org/rfc/rfc8555.html#section-8.1
 	KeyAuthorization string `json:"keyAuthorization"`
 }
 
 // Identifier the ACME identifier object.
-// - https://tools.ietf.org/html/rfc8555#section-9.7.7
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-9.7.7
 type Identifier struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
 }
 
 // CSRMessage Certificate Signing Request.
-// - https://tools.ietf.org/html/rfc8555#section-7.4
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4
 type CSRMessage struct {
 	// csr (required, string):
 	// A CSR encoding the parameters for the certificate being requested [RFC2986].
@@ -284,8 +284,8 @@ type CSRMessage struct {
 }
 
 // RevokeCertMessage a certificate revocation message.
-// - https://tools.ietf.org/html/rfc8555#section-7.6
-// - https://tools.ietf.org/html/rfc5280#section-5.3.1
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.6
+// - https://www.rfc-editor.org/rfc/rfc5280.html#section-5.3.1
 type RevokeCertMessage struct {
 	// certificate (required, string):
 	// The certificate to be revoked, in the base64url-encoded version of the DER format.

--- a/acme/errors.go
+++ b/acme/errors.go
@@ -11,8 +11,8 @@ const (
 )
 
 // ProblemDetails the problem details object.
-// - https://tools.ietf.org/html/rfc7807#section-3.1
-// - https://tools.ietf.org/html/rfc8555#section-7.3.3
+// - https://www.rfc-editor.org/rfc/rfc7807.html#section-3.1
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.3.3
 type ProblemDetails struct {
 	Type        string       `json:"type,omitempty"`
 	Detail      string       `json:"detail,omitempty"`
@@ -26,7 +26,7 @@ type ProblemDetails struct {
 }
 
 // SubProblem a "subproblems".
-// - https://tools.ietf.org/html/rfc8555#section-6.7.1
+// - https://www.rfc-editor.org/rfc/rfc8555.html#section-6.7.1
 type SubProblem struct {
 	Type       string     `json:"type,omitempty"`
 	Detail     string     `json:"detail,omitempty"`

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -241,7 +241,7 @@ func (c *Certifier) getForOrder(domains []string, order acme.ExtendedOrder, bund
 	commonName := domains[0]
 
 	// RFC8555 Section 7.4 "Applying for Certificate Issuance"
-	// https://tools.ietf.org/html/rfc8555#section-7.4
+	// https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4
 	// says:
 	//   Clients SHOULD NOT make any assumptions about the sort order of
 	//   "identifiers" or "authorizations" elements in the returned order
@@ -583,11 +583,11 @@ func checkOrderStatus(order acme.ExtendedOrder) (bool, error) {
 	}
 }
 
-// https://tools.ietf.org/html/rfc8555#section-7.1.4
+// https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.4
 // The domain name MUST be encoded in the form in which it would appear in a certificate.
 // That is, it MUST be encoded according to the rules in Section 7 of [RFC5280].
 //
-// https://tools.ietf.org/html/rfc5280#section-7
+// https://www.rfc-editor.org/rfc/rfc5280.html#section-7
 func sanitizeDomain(domains []string) []string {
 	var sanitizedDomains []string
 	for _, domain := range domains {

--- a/challenge/challenges.go
+++ b/challenge/challenges.go
@@ -10,15 +10,15 @@ import (
 type Type string
 
 const (
-	// HTTP01 is the "http-01" ACME challenge https://tools.ietf.org/html/rfc8555#section-8.3
+	// HTTP01 is the "http-01" ACME challenge https://www.rfc-editor.org/rfc/rfc8555.html#section-8.3
 	// Note: ChallengePath returns the URL path to fulfill this challenge.
 	HTTP01 = Type("http-01")
 
-	// DNS01 is the "dns-01" ACME challenge https://tools.ietf.org/html/rfc8555#section-8.4
+	// DNS01 is the "dns-01" ACME challenge https://www.rfc-editor.org/rfc/rfc8555.html#section-8.4
 	// Note: GetRecord returns a DNS record which will fulfill this challenge.
 	DNS01 = Type("dns-01")
 
-	// TLSALPN01 is the "tls-alpn-01" ACME challenge https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-07
+	// TLSALPN01 is the "tls-alpn-01" ACME challenge https://www.rfc-editor.org/rfc/rfc8737.html
 	TLSALPN01 = Type("tls-alpn-01")
 )
 

--- a/challenge/http01/domain_matcher.go
+++ b/challenge/http01/domain_matcher.go
@@ -23,7 +23,7 @@ import (
 // RFC7239 has standardized the different forwarding headers into a single header named Forwarded.
 // The header value has a different format, so you should use forwardedMatcher
 // when the http01.ProviderServer operates behind a RFC7239 compatible proxy.
-// https://tools.ietf.org/html/rfc7239
+// https://www.rfc-editor.org/rfc/rfc7239.html
 //
 // Note: RFC7239 also reminds us, "that an HTTP list [...] may be split over multiple header fields" (section 7.1),
 // meaning that
@@ -66,7 +66,7 @@ func (m arbitraryMatcher) matches(r *http.Request, domain string) bool {
 }
 
 // forwardedMatcher checks whether the Forwarded header contains a "host" element starting with a domain name.
-// See https://tools.ietf.org/html/rfc7239 for details.
+// See https://www.rfc-editor.org/rfc/rfc7239.html for details.
 type forwardedMatcher struct{}
 
 func (m *forwardedMatcher) name() string {

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -69,7 +69,7 @@ func (s *ProviderServer) CleanUp(domain, token, keyAuth string) error {
 //
 // The exact behavior depends on the value of headerName:
 // - "" (the empty string) and "Host" will restore the default and only check the Host header
-// - "Forwarded" will look for a Forwarded header, and inspect it according to https://tools.ietf.org/html/rfc7239
+// - "Forwarded" will look for a Forwarded header, and inspect it according to https://www.rfc-editor.org/rfc/rfc7239.html
 // - any other value will check the header value with the same name.
 func (s *ProviderServer) SetProxyHeader(headerName string) {
 	switch h := textproto.CanonicalMIMEHeaderKey(headerName); h {

--- a/challenge/tlsalpn01/tls_alpn_challenge.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge.go
@@ -16,7 +16,7 @@ import (
 )
 
 // idPeAcmeIdentifierV1 is the SMI Security for PKIX Certification Extension OID referencing the ACME extension.
-// Reference: https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-07#section-6.1
+// Reference: https://www.rfc-editor.org/rfc/rfc8737.html#section-6.1
 var idPeAcmeIdentifierV1 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
 type ValidateFunc func(core *api.Core, domain string, chlng acme.Challenge) error
@@ -83,7 +83,7 @@ func ChallengeBlocks(domain, keyAuth string) ([]byte, []byte, error) {
 
 	// Add the keyAuth digest as the acmeValidation-v1 extension
 	// (marked as critical such that it won't be used by non-ACME software).
-	// Reference: https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-07#section-3
+	// Reference: https://www.rfc-editor.org/rfc/rfc8737.html#section-3
 	extensions := []pkix.Extension{
 		{
 			Id:       idPeAcmeIdentifierV1,

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -61,7 +61,7 @@ func (s *ProviderServer) Present(domain, token, keyAuth string) error {
 
 	// We must set that the `acme-tls/1` application level protocol is supported
 	// so that the protocol negotiation can succeed. Reference:
-	// https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-07#section-6.2
+	// https://www.rfc-editor.org/rfc/rfc8737.html#section-6.2
 	tlsConf.NextProtos = []string{ACMETLS1Protocol}
 
 	// Create the listener with the created tls.Config.

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -18,7 +18,7 @@ func createRevoke() cli.Command {
 			},
 			cli.UintFlag{
 				Name:  "reason",
-				Usage: "Identifies the reason for the certificate revocation. See https://tools.ietf.org/html/rfc5280#section-5.3.1. 0(unspecified),1(keyCompromise),2(cACompromise),3(affiliationChanged),4(superseded),5(cessationOfOperation),6(certificateHold),8(removeFromCRL),9(privilegeWithdrawn),10(aACompromise)",
+				Usage: "Identifies the reason for the certificate revocation. See https://www.rfc-editor.org/rfc/rfc5280.html#section-5.3.1. 0(unspecified),1(keyCompromise),2(cACompromise),3(affiliationChanged),4(superseded),5(cessationOfOperation),6(certificateHold),8(removeFromCRL),9(privilegeWithdrawn),10(aACompromise)",
 				Value: acme.CRLReasonUnspecified,
 			},
 		},

--- a/docs/content/dns/zz_gen_rfc2136.md
+++ b/docs/content/dns/zz_gen_rfc2136.md
@@ -11,7 +11,7 @@ slug: rfc2136
 
 Since: v0.3.0
 
-Configuration for [RFC2136](https://tools.ietf.org/html/rfc2136).
+Configuration for [RFC2136](https://www.rfc-editor.org/rfc/rfc2136.html).
 
 
 <!--more-->
@@ -72,7 +72,7 @@ More information [here](/lego/dns/#configuration-and-credentials).
 
 ## More information
 
-- [API documentation](https://tools.ietf.org/html/rfc2136)
+- [API documentation](https://www.rfc-editor.org/rfc/rfc2136.html)
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 <!-- providers/dns/rfc2136/rfc2136.toml -->

--- a/providers/dns/rfc2136/rfc2136.toml
+++ b/providers/dns/rfc2136/rfc2136.toml
@@ -1,6 +1,6 @@
 Name = "RFC2136"
 Description = ''''''
-URL = "https://tools.ietf.org/html/rfc2136"
+URL = "https://www.rfc-editor.org/rfc/rfc2136.html"
 Code = "rfc2136"
 Since = "v0.3.0"
 
@@ -36,4 +36,4 @@ lego --email myemail@example.com --dns rfc2136 --domains my.example.org run
     RFC2136_SEQUENCE_INTERVAL = "Time between sequential requests"
 
 [Links]
-  API = "https://tools.ietf.org/html/rfc2136"
+  API = "https://www.rfc-editor.org/rfc/rfc2136.html"


### PR DESCRIPTION
As per [announcement][1] ([reminder][2]), tools.ietf.org is going to shut down in the near future.

This updates the links to the referenced RFCs to their new location, as per the [transition plan][3].

[1]: https://mailarchive.ietf.org/arch/msg/ietf/0n-6EXEmkTp3Uv_vj-5Vnm3o0bo/
[2]: https://mailarchive.ietf.org/arch/msg/ietf-announce/xKzJZIyanPCclTd7DU9PxBAbwhA/
[3]: https://github.com/ietf-tools/tools-transition-plan#new-service-locations