### PR TITLE
Extend validity of TLS-ALPN-01 certificates to 365 days

### DIFF
--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -261,7 +261,7 @@ func generateDerCert(privateKey *rsa.PrivateKey, expiration time.Time, domain st
 	}
 
 	if expiration.IsZero() {
-		expiration = time.Now().Add(365)
+		expiration = time.Now().AddDate(1, 0, 0)
 	}
 
 	template := x509.Certificate{


### PR DESCRIPTION
I am using lego to implement the TLS-ALPN-01 challenge using Amazon Certificate Manager (ACM). Currently, the certificates generated by certcrypto.GeneratePemCert only last for 365 nanoseconds which is not long enough for me to upload the cert to ACM. This PR extends the validity period to 365 days since that seems like it may have been the original intent.

Fixes #1533

