### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: 1.17
-      GOLANGCI_LINT_VERSION: v1.43.0
+      GOLANGCI_LINT_VERSION: v1.44.0
       HUGO_VERSION: 0.54.0
       SEIHON_VERSION: v0.8.3
       CGO_ENABLED: 0

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -82,6 +82,7 @@
     "forcetypeassert",
     "tagliatelle",
     "errname",
+    "errchkjson",
   ]
 
 [issues]
@@ -95,7 +96,7 @@
   ]
   [[issues.exclude-rules]]
     path = "(.+)_test.go"
-    linters = ["funlen", "goconst"]
+    linters = ["funlen", "goconst", "maintidx"]
   [[issues.exclude-rules]]
     path = "providers/dns/dns_providers.go"
     linters = ["gocyclo"]
@@ -180,3 +181,6 @@
   [[issues.exclude-rules]]
     path = "challenge/http01/domain_matcher.go"
     text = "yodaStyleExpr"
+  [[issues.exclude-rules]]
+    path = "providers/dns/dns_providers.go"
+    text = "Function name: NewDNSChallengeProviderByName,"


### PR DESCRIPTION
Update golangci-lint to v1.44.0