### PR TITLE
Always return CSR as part of Resource

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -273,6 +273,7 @@ func (c *Certifier) getForCSR(domains []string, order acme.ExtendedOrder, bundle
 		Domain:     commonName,
 		CertURL:    respOrder.Certificate,
 		PrivateKey: privateKeyPem,
+		CSR:        csr,
 	}
 
 	if respOrder.Status == acme.StatusValid {

--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -232,7 +232,7 @@ func TestChallengeHTTP_Client_Obtain(t *testing.T) {
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)
 	assert.NotEmpty(t, resource.IssuerCertificate)
-	assert.Empty(t, resource.CSR)
+	assert.NotEmpty(t, resource.CSR)
 }
 
 func TestChallengeHTTP_Client_Registration_QueryRegistration(t *testing.T) {
@@ -307,7 +307,7 @@ func TestChallengeTLS_Client_Obtain(t *testing.T) {
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)
 	assert.NotEmpty(t, resource.IssuerCertificate)
-	assert.Empty(t, resource.CSR)
+	assert.NotEmpty(t, resource.CSR)
 }
 
 func TestChallengeTLS_Client_ObtainForCSR(t *testing.T) {

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -121,7 +121,7 @@ func TestChallengeDNS_Client_Obtain(t *testing.T) {
 	assert.Regexp(t, `https://localhost:15000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)
 	assert.NotEmpty(t, resource.IssuerCertificate)
-	assert.Empty(t, resource.CSR)
+	assert.NotEmpty(t, resource.CSR)
 }
 
 type fakeUser struct {


### PR DESCRIPTION
Return the generated CSR in the certificate `Resource` after an `Obtain` or `ObtainForCSR`.

There are cases where users of this library will like to perform some additional operations with the generated CSR after an obtain was run, for example: submitting the CSR to an external tool that monitors certificate-transparency logs, in order to make sure the certificate issued by the library is legitimate.

I am not very familiar with this codebase so I might've missed something. I updated existing tests to make sure the CSR in Resource exists.

Please let me know if there's anything else I can do to speed up this work (or if there's something terribly wrong with my approach).

Thank you.