### PR TITLE
Fix panic in certcrypto.ParsePEMPrivateKey

### DIFF
--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -85,6 +85,9 @@ func ParsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 // https://github.com/golang/go/blob/693748e9fa385f1e2c3b91ca9acbb6c0ad2d133d/src/crypto/tls/tls.go#L238)
 func ParsePEMPrivateKey(key []byte) (crypto.PrivateKey, error) {
 	keyBlockDER, _ := pem.Decode(key)
+	if keyBlockDER == nil {
+		return nil, fmt.Errorf("invalid PEM block")
+	}
 
 	if keyBlockDER.Type != "PRIVATE KEY" && !strings.HasSuffix(keyBlockDER.Type, " PRIVATE KEY") {
 		return nil, fmt.Errorf("unknown PEM header %q", keyBlockDER.Type)


### PR DESCRIPTION
If ParsePEMPrivateKey is called with input that is not actually
a valid PEM block (e.g. because a file got corrupted), pem.Decode
will return a nil block which is immediately dereferenced causing
a panic.

Guard against this case returning an error, and add some tests
to validate.