### PR TITLE
tencentcloud: fix InvalidParameter.DomainInvalid error when using DNS challenges

### DIFF
--- a/providers/dns/tencentcloud/client.go
+++ b/providers/dns/tencentcloud/client.go
@@ -20,7 +20,7 @@ func getDomainData(fqdn string) (*domainData, error) {
 	}
 
 	return &domainData{
-		domain:    zone,
+		domain:    dns01.UnFqdn(zone),
 		subDomain: dns01.UnFqdn(strings.TrimSuffix(fqdn, zone)),
 	}, nil
 }


### PR DESCRIPTION
In #1527, there is [a comment](https://github.com/go-acme/lego/pull/1527#issuecomment-1035876292) saying he encountered InvalidParameter.DomainInvalid when using DNS challenges with Tencent Cloud DNS.

This PR fixes that.

#### How:
Using FQDN as `request.Domain` will cause problems with Tencent SDK and `InvalidParameter.DomainInvalid` will be returned.
UnFQDN the domain name will solve it.

Formatting, linters, tests, and compiling have all passed.