### PR TITLE
gcore: change dns api url

### DIFF
--- a/providers/dns/gcore/internal/client.go
+++ b/providers/dns/gcore/internal/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://dnsapi.gcorelabs.com"
+	defaultBaseURL = "https://api.gcorelabs.com/dns"
 	tokenHeader    = "APIKey"
 	txtRecordType  = "TXT"
 )


### PR DESCRIPTION
Hi, this PR for https://gcorelabs.com/dns/
We moved our DNS API to new URL