### PR TITLE
dnsimple: add debug option

### DIFF
--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -21,6 +21,7 @@ const (
 
 	EnvOAuthToken = envNamespace + "OAUTH_TOKEN"
 	EnvBaseURL    = envNamespace + "BASE_URL"
+	EnvDebug      = envNamespace + "DEBUG"
 
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
@@ -29,6 +30,7 @@ const (
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
+	Debug              bool
 	AccessToken        string
 	BaseURL            string
 	PropagationTimeout time.Duration
@@ -40,6 +42,7 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
+		Debug:              env.GetOrDefaultBool(EnvDebug, false),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 	}

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -84,6 +84,8 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		client.BaseURL = config.BaseURL
 	}
 
+	client.Debug = config.Debug
+
 	return &DNSProvider{client: client, config: config}, nil
 }
 


### PR DESCRIPTION
Allow for passing DNSIMPLE_DEBUG to the environment; based on other providers I found
similar: https://github.com/go-acme/lego/blob/83c626d9a1889fa499bc9c97bc2fdea965307002/providers/dns/joker/joker.go
reference file: https://github.com/dnsimple/dnsimple-go/blob/af9daf7e8d193d83b06b323f792d8afe66ddae83/dnsimple/dnsimple.go#L69