### PR TITLE
vultr: bump client from 2.7.1 to 2.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/transip/gotransip/v6 v6.6.1
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/vinyldns/go-vinyldns v0.9.16
-	github.com/vultr/govultr/v2 v2.7.1
+	github.com/vultr/govultr/v2 v2.16.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
@@ -87,7 +87,7 @@ require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/jarcoal/httpmock v1.0.6 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,9 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -480,8 +481,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vinyldns/go-vinyldns v0.9.16 h1:GZJStDkcCk1F1AcRc64LuuMh+ENL8pHA0CVd4ulRMcQ=
 github.com/vinyldns/go-vinyldns v0.9.16/go.mod h1:5qIJOdmzAnatKjurI+Tl4uTus7GJKJxb+zitufjHs3Q=
-github.com/vultr/govultr/v2 v2.7.1 h1:uF9ERet++Gb+7Cqs3p1P6b6yebeaZqVd7t5P2uZCaJU=
-github.com/vultr/govultr/v2 v2.7.1/go.mod h1:BvOhVe6/ZpjwcoL6/unkdQshmbS9VGbowI4QT+3DGVU=
+github.com/vultr/govultr/v2 v2.16.0 h1:2Wa8znp9FrKLBCA5mp1XOk65k2g60uKnmaqO4z3ERtU=
+github.com/vultr/govultr/v2 v2.16.0/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
I noticed that GoVultr hasn't been updated in a while so I went ahead and bumped to the latest version 2.16.0. No major changes have been made to DNS so behavior has stayed the same.

Some test output

```console
$  lego [vultr-updates] make build
BIN_OUTPUT: dist/lego
rm -rf dist/ builds/ cover.out
Version: a77d023488dac3abc6bc9cbdf5850d51d88e2f55
go build -trimpath -ldflags '-X "main.version=a77d023488dac3abc6bc9cbdf5850d51d88e2f55"' -o  dist/lego ./cmd/lego/


$  dist [vultr-updates] ./lego -m your@email.com --dns vultr -d '*.dymko.dev' -d 'dymko.dev' --dns-timeout 100 -s https://acme-staging-v02.api.letsencrypt.org/directory  run
2022/05/07 12:07:02 [INFO] [*.dymko.dev, dymko.dev] acme: Obtaining bundled SAN certificate
2022/05/07 12:07:03 [INFO] [*.dymko.dev] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/2387104594
2022/05/07 12:07:03 [INFO] [dymko.dev] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/2387104604
2022/05/07 12:07:03 [INFO] [*.dymko.dev] acme: use dns-01 solver
2022/05/07 12:07:03 [INFO] [dymko.dev] acme: Could not find solver for: tls-alpn-01
2022/05/07 12:07:03 [INFO] [dymko.dev] acme: Could not find solver for: http-01
2022/05/07 12:07:03 [INFO] [dymko.dev] acme: use dns-01 solver
2022/05/07 12:07:03 [INFO] [*.dymko.dev] acme: Preparing to solve DNS-01
2022/05/07 12:07:03 [INFO] [dymko.dev] acme: Preparing to solve DNS-01
2022/05/07 12:07:03 [INFO] [*.dymko.dev] acme: Trying to solve DNS-01
2022/05/07 12:07:03 [INFO] [*.dymko.dev] acme: Checking DNS record propagation using [8.8.8.8:53]
2022/05/07 12:07:05 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
2022/05/07 12:07:05 [INFO] [*.dymko.dev] acme: Waiting for DNS record propagation.
2022/05/07 12:07:20 [INFO] [*.dymko.dev] The server validated our request
2022/05/07 12:07:20 [INFO] [dymko.dev] acme: Trying to solve DNS-01
2022/05/07 12:07:20 [INFO] [dymko.dev] acme: Checking DNS record propagation using [8.8.8.8:53]
2022/05/07 12:07:22 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
2022/05/07 12:07:34 [INFO] [dymko.dev] The server validated our request
2022/05/07 12:07:34 [INFO] [*.dymko.dev] acme: Cleaning DNS-01 challenge
2022/05/07 12:07:34 [INFO] [dymko.dev] acme: Cleaning DNS-01 challenge
2022/05/07 12:07:34 [INFO] [*.dymko.dev, dymko.dev] acme: Validations succeeded; requesting certificates
2022/05/07 12:07:34 [INFO] [*.dymko.dev] Server responded with a certificate.
```

