### PR TITLE
feat: sleep at renewal

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -17,12 +17,16 @@
     min-len = 3.0
     min-occurrences = 3.0
 
+  [linters-settings.funlen]
+    lines = -1
+    statements = 50
+
   [linters-settings.misspell]
     locale = "US"
     ignore-words = ["internetbs"]
 
   [linters-settings.depguard]
-    list-type = "blacklist"
+    list-type = "denylist"
     include-go-root = false
     packages = ["github.com/pkg/errors"]
 

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto"
 	"crypto/x509"
+	"math/rand"
 	"time"
 
 	"github.com/go-acme/lego/v4/certcrypto"
@@ -68,6 +69,10 @@ func createRenew() *cli.Command {
 				Name:  "always-deactivate-authorizations",
 				Usage: "Force the authorizations to be relinquished even if the certificate request was successful.",
 			},
+			&cli.BoolFlag{
+				Name:  "no-random-sleep",
+				Usage: "Do not add a random sleep before the renewal. We do not recommend using this flag if you are doing your renewals in an automated way.",
+			},
 		},
 	}
 }
@@ -130,6 +135,14 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		if errR != nil {
 			return errR
 		}
+	}
+
+	if ctx.Bool("no-random-sleep") {
+		// https://github.com/go-acme/lego/issues/1656
+		// https://github.com/certbot/certbot/blob/284023a1b7672be2bd4018dd7623b3b92197d4b0/certbot/certbot/_internal/renewal.py#L472
+		sleepTime := rand.New(rand.NewSource(time.Now().UnixNano())).Int63n(int64(8 * time.Minute))
+		log.Infof("renewal: random delay of %s", time.Duration(sleepTime))
+		time.Sleep(time.Duration(sleepTime) * time.Second)
 	}
 
 	request := certificate.ObtainRequest{

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -141,12 +141,11 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		// https://github.com/go-acme/lego/issues/1656
 		// https://github.com/certbot/certbot/blob/284023a1b7672be2bd4018dd7623b3b92197d4b0/certbot/certbot/_internal/renewal.py#L472
 		const jitter = 8 * time.Minute
-		rndSource := rand.NewSource(time.Now().UnixNano())
-		rnd := rand.New(rndSource)
+		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 		sleepTime := time.Duration(rnd.Int63n(int64(jitter)))
-		
+
 		log.Infof("renewal: random delay of %s", sleepTime)
-		time.Sleep(time.Duration(sleepTime))
+		time.Sleep(sleepTime)
 	}
 
 	request := certificate.ObtainRequest{


### PR DESCRIPTION
Add a sleep between 0 to 8 minutes during the call of the `renew` command like [certbot](https://github.com/certbot/certbot/blob/284023a1b7672be2bd4018dd7623b3b92197d4b0/certbot/certbot/_internal/renewal.py#L472).

Fixes #1656