### PR TITLE
docs: fixed invalid environment parameter name in example

### DIFF
--- a/docs/content/dns/zz_gen_liquidweb.md
+++ b/docs/content/dns/zz_gen_liquidweb.md
@@ -28,7 +28,7 @@ Here is an example bash command using the Liquid Web provider:
 ```bash
 LIQUID_WEB_USERNAME=someuser \
 LIQUID_WEB_PASSWORD=somepass \
-LIQUID_ZONE=tacoman.com.net \
+LIQUID_WEB_ZONE=tacoman.com.net \
 lego --email you@example.com --dns liquidweb --domains my.example.org run
 ```
 

--- a/docs/content/dns/zz_gen_liquidweb.md
+++ b/docs/content/dns/zz_gen_liquidweb.md
@@ -28,7 +28,7 @@ Here is an example bash command using the Liquid Web provider:
 ```bash
 LIQUID_WEB_USERNAME=someuser \
 LIQUID_WEB_PASSWORD=somepass \
-LIQUID_WEB_ZONE=tacoman.com.net \
+LIQUID_ZONE=tacoman.com.net \
 lego --email you@example.com --dns liquidweb --domains my.example.org run
 ```
 

--- a/providers/dns/liquidweb/liquidweb.toml
+++ b/providers/dns/liquidweb/liquidweb.toml
@@ -7,7 +7,7 @@ Since = "v3.1.0"
 Example = '''
 LIQUID_WEB_USERNAME=someuser \
 LIQUID_WEB_PASSWORD=somepass \
-LIQUID_ZONE=tacoman.com.net \
+LIQUID_WEB_ZONE=tacoman.com.net \
 lego --email you@example.com --dns liquidweb --domains my.example.org run
 '''
 


### PR DESCRIPTION
Fixed little typo in liquidweb example