### PR TITLE
Add a --user-agent flag to lego-cli

### DIFF
--- a/cmd/accounts_storage.go
+++ b/cmd/accounts_storage.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -227,7 +226,7 @@ func tryRecoverRegistration(ctx *cli.Context, privateKey crypto.PrivateKey) (*re
 	// couldn't load account but got a key. Try to look the account up.
 	config := lego.NewConfig(&Account{key: privateKey})
 	config.CADirURL = ctx.String("server")
-	config.UserAgent = fmt.Sprintf("lego-cli/%s", ctx.App.Version)
+	config.UserAgent = getUserAgent(ctx)
 
 	client, err := lego.NewClient(config)
 	if err != nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -132,5 +132,9 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Usage: "Set the certificate timeout value to a specific value in seconds. Only used when obtaining certificates.",
 			Value: 30,
 		},
+		&cli.StringFlag{
+			Name:  "user-agent",
+			Usage: "Add to the user-agent sent to the CA to identify an application embedding lego-cli",
+		},
 	}
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -41,7 +41,7 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 		KeyType: keyType,
 		Timeout: time.Duration(ctx.Int("cert.timeout")) * time.Second,
 	}
-	config.UserAgent = fmt.Sprintf("lego-cli/%s", ctx.App.Version)
+	config.UserAgent = getUserAgent(ctx)
 
 	if ctx.IsSet("http-timeout") {
 		config.HTTPClient.Timeout = time.Duration(ctx.Int("http-timeout")) * time.Second
@@ -85,6 +85,10 @@ func getEmail(ctx *cli.Context) string {
 		log.Fatal("You have to pass an account (email address) to the program using --email or -m")
 	}
 	return email
+}
+
+func getUserAgent(ctx *cli.Context) string {
+	return strings.TrimSpace(fmt.Sprintf("%s lego-cli/%s", ctx.String("user-agent"), ctx.App.Version))
 }
 
 func createNonExistingFolder(path string) error {


### PR DESCRIPTION
This allows applications which embed lego-cli to identify themselves,
which will assist the CA in operations and identifying issues.
 
Fixes #1663 