### PR TITLE
hetzner: set min TTL to 60s

### DIFF
--- a/providers/dns/hetzner/hetzner.go
+++ b/providers/dns/hetzner/hetzner.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/hetzner/internal"
 )
 
-const minTTL = 600
+const minTTL = 60
 
 // Environment variables names.
 const (

--- a/providers/dns/hetzner/hetzner_test.go
+++ b/providers/dns/hetzner/hetzner_test.go
@@ -74,8 +74,8 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		{
 			desc:     "invalid TTL",
 			apiKey:   "123",
-			ttl:      60,
-			expected: "hetzner: invalid TTL, TTL (60) must be greater than 600",
+			ttl:      10,
+			expected: "hetzner: invalid TTL, TTL (10) must be greater than 60",
 		},
 	}
 


### PR DESCRIPTION
Hetzner (now) allows a min TTL of 60.
![grafik](https://user-images.githubusercontent.com/1394374/176630483-004a7946-07dc-4ee0-8065-8f876dafd0e0.png)
