### PR TITLE
auroradns: fix AuthenticationFailedError

### DIFF
--- a/providers/dns/auroradns/auroradns.go
+++ b/providers/dns/auroradns/auroradns.go
@@ -18,9 +18,9 @@ const defaultBaseURL = "https://api.auroradns.eu"
 const (
 	envNamespace = "AURORA_"
 
-	EnvUserID   = envNamespace + "USER_ID"
-	EnvKey      = envNamespace + "KEY"
-	EnvEndpoint = envNamespace + "ENDPOINT"
+	EnvApiKey    = envNamespace + "API_KEY"
+	EnvSecretKey = envNamespace + "SECRET_KEY"
+	EnvEndpoint  = envNamespace + "ENDPOINT"
 
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
@@ -30,8 +30,8 @@ const (
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
 	BaseURL            string
-	UserID             string
-	Key                string
+	ApiKey             string
+	SecretKey          string
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
 	TTL                int
@@ -56,17 +56,17 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for AuroraDNS.
 // Credentials must be passed in the environment variables:
-// AURORA_USER_ID and AURORA_KEY.
+// AURORA_API_KEY and AURORA_SECRET_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvUserID, EnvKey)
+	values, err := env.Get(EnvApiKey, EnvSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("aurora: %w", err)
 	}
 
 	config := NewDefaultConfig()
 	config.BaseURL = env.GetOrFile(EnvEndpoint)
-	config.UserID = values[EnvUserID]
-	config.Key = values[EnvKey]
+	config.ApiKey = values[EnvApiKey]
+	config.SecretKey = values[EnvSecretKey]
 
 	return NewDNSProviderConfig(config)
 }
@@ -77,7 +77,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("aurora: the configuration of the DNS provider is nil")
 	}
 
-	if config.UserID == "" || config.Key == "" {
+	if config.ApiKey == "" || config.SecretKey == "" {
 		return nil, errors.New("aurora: some credentials information are missing")
 	}
 
@@ -85,7 +85,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		config.BaseURL = defaultBaseURL
 	}
 
-	tr, err := auroradns.NewTokenTransport(config.UserID, config.Key)
+	tr, err := auroradns.NewTokenTransport(config.ApiKey, config.SecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("aurora: %w", err)
 	}

--- a/providers/dns/auroradns/auroradns.toml
+++ b/providers/dns/auroradns/auroradns.toml
@@ -1,19 +1,19 @@
 Name = "Aurora DNS"
 Description = ''''''
-URL = "https://www.pcextreme.com/aurora/dns"
+URL = "https://www.pcextreme.com/dns-health-checks"
 Code = "auroradns"
 Since = "v0.4.0"
 
 Example = '''
-AURORA_USER_ID=xxxxx \
-AURORA_KEY=yyyyyy \
+AURORA_API_KEY=xxxxx \
+AURORA_SECRET_KEY=yyyyyy \
 lego --email you@example.com --dns auroradns --domains my.example.org run
 '''
 
 [Configuration]
   [Configuration.Credentials]
-    AURORA_USER_ID = "User ID"
-    AURORA_KEY = "User API key"
+    AURORA_API_KEY = "API key"
+    AURORA_SECRET_KEY = "Secret key"
   [Configuration.Additional]
     AURORA_ENDPOINT = "API endpoint URL"
     AURORA_POLLING_INTERVAL = "Time between DNS propagation check"

--- a/providers/dns/auroradns/auroradns_test.go
+++ b/providers/dns/auroradns/auroradns_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var envTest = tester.NewEnvTest(
-	EnvUserID,
-	EnvKey)
+	EnvApiKey,
+	EnvSecretKey)
 
 func setupTest(t *testing.T) (*DNSProvider, *http.ServeMux) {
 	t.Helper()
@@ -24,8 +24,8 @@ func setupTest(t *testing.T) (*DNSProvider, *http.ServeMux) {
 	t.Cleanup(server.Close)
 
 	config := NewDefaultConfig()
-	config.UserID = "asdf1234"
-	config.Key = "key"
+	config.ApiKey = "asdf1234"
+	config.SecretKey = "key"
 	config.BaseURL = server.URL
 
 	provider, err := NewDNSProviderConfig(config)
@@ -43,33 +43,33 @@ func TestNewDNSProvider(t *testing.T) {
 		{
 			desc: "success",
 			envVars: map[string]string{
-				EnvUserID: "123",
-				EnvKey:    "456",
+				EnvApiKey:    "123",
+				EnvSecretKey: "456",
 			},
 		},
 		{
 			desc: "missing credentials",
 			envVars: map[string]string{
-				EnvUserID: "",
-				EnvKey:    "",
+				EnvApiKey:    "",
+				EnvSecretKey: "",
 			},
-			expected: "aurora: some credentials information are missing: AURORA_USER_ID,AURORA_KEY",
+			expected: "aurora: some credentials information are missing: AURORA_API_KEY,AURORA_SECRET_KEY",
 		},
 		{
-			desc: "missing user id",
+			desc: "missing api key",
 			envVars: map[string]string{
-				EnvUserID: "",
-				EnvKey:    "456",
+				EnvApiKey:    "",
+				EnvSecretKey: "456",
 			},
 			expected: "aurora: some credentials information are missing: AURORA_USER_ID",
 		},
 		{
-			desc: "missing key",
+			desc: "missing secret key",
 			envVars: map[string]string{
-				EnvUserID: "123",
-				EnvKey:    "",
+				EnvApiKey:    "123",
+				EnvSecretKey: "",
 			},
-			expected: "aurora: some credentials information are missing: AURORA_KEY",
+			expected: "aurora: some credentials information are missing: AURORA_SECRET_KEY",
 		},
 	}
 
@@ -96,41 +96,41 @@ func TestNewDNSProvider(t *testing.T) {
 
 func TestNewDNSProviderConfig(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		userID   string
-		key      string
-		expected string
+		desc      string
+		apiKey    string
+		secretKey string
+		expected  string
 	}{
 		{
-			desc:   "success",
-			userID: "123",
-			key:    "456",
+			desc:      "success",
+			apiKey:    "123",
+			secretKey: "456",
 		},
 		{
-			desc:     "missing credentials",
-			userID:   "",
-			key:      "",
-			expected: "aurora: some credentials information are missing",
+			desc:      "missing credentials",
+			apiKey:    "",
+			secretKey: "",
+			expected:  "aurora: some credentials information are missing",
 		},
 		{
-			desc:     "missing user id",
-			userID:   "",
-			key:      "456",
-			expected: "aurora: some credentials information are missing",
+			desc:      "missing user id",
+			apiKey:    "",
+			secretKey: "456",
+			expected:  "aurora: some credentials information are missing",
 		},
 		{
-			desc:     "missing key",
-			userID:   "123",
-			key:      "",
-			expected: "aurora: some credentials information are missing",
+			desc:      "missing key",
+			apiKey:    "123",
+			secretKey: "",
+			expected:  "aurora: some credentials information are missing",
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			config := NewDefaultConfig()
-			config.UserID = test.userID
-			config.Key = test.key
+			config.apiKey = test.apiKey
+			config.secretKey = test.secretKey
 
 			p, err := NewDNSProviderConfig(config)
 


### PR DESCRIPTION
The Aurora DNS Provider produces an `AuthenticationFailedError` if you use the API as documented in LEGO. The `UserID` has been replaced by an API key, while the `key` now listens to a Secret Key. The [API documentation](https://libcloud.readthedocs.io/en/latest/dns/drivers/auroradns.html#api-docs) confirms this.

This Pull Request corrects the documentation and uses the correct parameter names and descriptions for the API Key and Secret Key to remove any confusion about its usage.

I have also opened a Pull Request for the Go client library for accessing the Aurora DNS API. https://github.com/nrdcg/auroradns/pull/1