### PR TITLE
callback dns provider

### DIFF
--- a/providers/dns/callback/callback.go
+++ b/providers/dns/callback/callback.go
@@ -1,0 +1,77 @@
+// Package callback implements a DNS provider for solving the DNS-01 challenge using callback functions.
+package callback
+
+import (
+	"errors"
+	"time"
+
+	"github.com/go-acme/lego/v4/challenge/dns01"
+	"github.com/go-acme/lego/v4/platform/config/env"
+)
+
+// Environment variables names.
+const (
+	envNamespace = "CALLBACK_"
+
+	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
+	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
+)
+
+const (
+	defaultPropagationTimeout = 3 * time.Minute
+	defaultPollInterval       = 15 * time.Second
+)
+
+// Config is used to configure the creation of the DNSProvider.
+type Config struct {
+	presentCallback    func(fqdn, recordBody string) error
+	cleanupCallback    func(fqdn, recordBody string) error
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider.
+func NewDefaultConfig() *Config {
+	return &Config{
+		presentCallback:    func(fqdn, recordBody string) error { return errors.New("not implemented") },
+		cleanupCallback:    func(fqdn, recordBody string) error { return errors.New("not implemented") },
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, defaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, defaultPollInterval),
+	}
+}
+
+// DNSProvider implements the challenge.Provider interface.
+type DNSProvider struct {
+	config *Config
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+// Present creates a TXT record to fulfill the dns-01 challenge.
+func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+	return d.config.presentCallback(dns01.GetRecord(domain, keyAuth))
+}
+
+// CleanUp removes the record matching the specified parameters.
+func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	return d.config.cleanupCallback(dns01.GetRecord(domain, keyAuth))
+}
+
+// NewDNSProvider returns a callback DNSProvider instance.
+func NewDNSProvider(presentCallback, cleanupCallback func(fqdn, recordBody string) error) (*DNSProvider, error) {
+	if presentCallback == nil {
+		return nil, errors.New("callback: got nil presentCallback")
+	}
+	if cleanupCallback == nil {
+		return nil, errors.New("callback: got nil cleanupCallback")
+	}
+
+	config := NewDefaultConfig()
+	config.presentCallback = presentCallback
+	config.cleanupCallback = cleanupCallback
+
+	return &DNSProvider{config: config}, nil
+}

--- a/providers/dns/callback/callback.toml
+++ b/providers/dns/callback/callback.toml
@@ -1,0 +1,25 @@
+Name = "callback"
+Description = '''
+callback provider can be used for custom DNS solutions when lego is used as a library
+'''
+
+Code = "callback"
+Since = "TODO"
+
+Example = '''
+myPresent := func(fqdn, recordBody string) error {
+    // create TXT record for 'fqdn' with contents 'recordBody' in any way you prefer
+}
+myCleanup := func(fqdn, recordBody string) error {
+    // remove TXT record for 'fqdn' with contents 'recordBody' in any way you prefer
+}
+myProvider, err := NewDNSProvider(myPresent, myCleanup)
+if err != nil {
+    // ...
+}
+'''
+
+[Configuration]
+  [Configuration.Additional]
+    CALLBACK_POLLING_INTERVAL = "Time between DNS propagation check. Default: 15 seconds"
+    CALLBACK_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation. Default: 3 minutes"

--- a/providers/dns/callback/callback_test.go
+++ b/providers/dns/callback/callback_test.go
@@ -1,0 +1,46 @@
+package callback
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDNSProvider(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		presentCallback func(fqdn, recordBody string) error
+		cleanupCallback func(fqdn, recordBody string) error
+		expectedError   error
+	}{
+		{
+			desc:            "happy path",
+			presentCallback: func(fqdn, recordBody string) error { return nil },
+			cleanupCallback: func(fqdn, recordBody string) error { return nil },
+			expectedError:   nil,
+		},
+		{
+			desc:            "missing present callback",
+			presentCallback: nil,
+			cleanupCallback: func(fqdn, recordBody string) error { return nil },
+			expectedError:   errors.New("callback: got nil presentCallback"),
+		},
+		{
+			desc:            "happy path",
+			presentCallback: func(fqdn, recordBody string) error { return nil },
+			cleanupCallback: nil,
+			expectedError:   errors.New("callback: got nil cleanupCallback"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			provider, actualError := NewDNSProvider(tc.presentCallback, tc.cleanupCallback)
+			if tc.expectedError == nil {
+				require.NotNil(t, provider)
+			}
+			require.Equal(t, tc.expectedError, actualError)
+		})
+	}
+}


### PR DESCRIPTION
This PR contains a new DNS provider implementation: `callback`.

---

`callback` provider can be used for custom DNS solutions when lego is used as a library. The provider accepts two callback functions:
- one that gets called by `Present()` - the function should take care of registering the TXT records with the provided contents
- one that gets called by `CleanUp()` - the function should take care of deregistering the TXT records with the provided contents

Real world use case:
- in-house DNS solutions (without publicly available APIs)