### PR TITLE
add recursive CNAME lookup support

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -179,10 +179,16 @@ func GetRecord(domain, keyAuth string) (fqdn, value string) {
 	fqdn = fmt.Sprintf("_acme-challenge.%s.", domain)
 
 	if ok, _ := strconv.ParseBool(os.Getenv("LEGO_EXPERIMENTAL_CNAME_SUPPORT")); ok {
-		r, err := dnsQuery(fqdn, dns.TypeCNAME, recursiveNameservers, true)
-		// Check if the domain has CNAME then return that
-		if err == nil && r.Rcode == dns.RcodeSuccess {
-			fqdn = updateDomainWithCName(r, fqdn)
+		for {
+			// Keep following CNAMEs
+			r, err := dnsQuery(fqdn, dns.TypeCNAME, recursiveNameservers, true)
+			// Check if the domain has CNAME then use that
+			if err == nil && r.Rcode == dns.RcodeSuccess {
+				fqdn = updateDomainWithCName(r, fqdn)
+			} else {
+				// No more CNAME records to follow, exit
+				return
+			}
 		}
 	}
 

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -179,7 +179,8 @@ func GetRecord(domain, keyAuth string) (fqdn, value string) {
 	fqdn = fmt.Sprintf("_acme-challenge.%s.", domain)
 
 	if ok, _ := strconv.ParseBool(os.Getenv("LEGO_EXPERIMENTAL_CNAME_SUPPORT")); ok {
-		for {
+		// recursion counter so it doesn't spin out of control
+		for limit := 0; limit < 50; limit++ {
 			// Keep following CNAMEs
 			r, err := dnsQuery(fqdn, dns.TypeCNAME, recursiveNameservers, true)
 			// Check if the domain has CNAME then use that


### PR DESCRIPTION
Right now the `LEGO_EXPERIMENTAL_CNAME_SUPPORT` only follows one CNAME record. If this CNAME record points to another, then the chain breaks and the DNS record created is incorrect.

This change allows it to keep following CNAME records as long as it continues to find one up to a limit so that CNAME loops don't hang the service.

And thanks for the awesome work on this repo!!