### PR TITLE
pdns: notify secondary servers after updates

### DIFF
--- a/providers/dns/pdns/client.go
+++ b/providers/dns/pdns/client.go
@@ -137,6 +137,17 @@ func (d *DNSProvider) getAPIVersion() (int, error) {
 	return latestVersion, err
 }
 
+func (d *DNSProvider) notify(zoneURL string) error {
+	if d.apiVersion >= 1 {
+		p := path.Join(zoneURL, "/notify")
+		_, err := d.sendRequest(http.MethodPut, p, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *DNSProvider) sendRequest(method, uri string, body io.Reader) (json.RawMessage, error) {
 	req, err := d.makeRequest(method, uri, body)
 	if err != nil {

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -174,13 +173,15 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("pdns: %w", err)
 	}
 
-	if d.apiVersion >= 1 {
-		p := path.Join(zone.URL, "/notify")
-		_, err = d.sendRequest(http.MethodPut, p, nil)
-		if err != nil {
-			return fmt.Errorf("pdns: %w", err)
-		}
+	if d.apiVersion < 1 {
+		return nil
 	}
+
+	err = d.notify(zone.URL)
+	if err != nil {
+		return fmt.Errorf("pdns: %w", err)
+	}
+
 	return nil
 }
 
@@ -220,12 +221,14 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("pdns: %w", err)
 	}
 
-	if d.apiVersion >= 1 {
-		p := path.Join(zone.URL, "/notify")
-		_, err = d.sendRequest(http.MethodPut, p, nil)
-		if err != nil {
-			return fmt.Errorf("pdns: %w", err)
-		}
+	if d.apiVersion < 1 {
+		return nil
 	}
+
+	err = d.notify(zone.URL)
+	if err != nil {
+		return fmt.Errorf("pdns: %w", err)
+	}
+
 	return nil
 }

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -172,6 +173,14 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	if err != nil {
 		return fmt.Errorf("pdns: %w", err)
 	}
+
+	if d.apiVersion >= 1 {
+		p := path.Join(zone.URL, "/notify")
+		_, err = d.sendRequest(http.MethodPut, p, nil)
+		if err != nil {
+			return fmt.Errorf("pdns: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -209,6 +218,14 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	_, err = d.sendRequest(http.MethodPatch, zone.URL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("pdns: %w", err)
+	}
+
+	if d.apiVersion >= 1 {
+		p := path.Join(zone.URL, "/notify")
+		_, err = d.sendRequest(http.MethodPut, p, nil)
+		if err != nil {
+			return fmt.Errorf("pdns: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This change addresses the PowerDNS DNS provider.

When using the API with a setup where there is not only the primary but also some secondary servers, the secondary servers were not sent a `NOTIFY` and would not initiate an AXFR transfer.

Thus, the challenge would not propagate to all DNS servers which would in return cause failed verifications.

This change uses the [`/notify`](https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id-notify) endpoint of the PowerDNS API to notify the secondaries.