### PR TITLE
digitalocean: configurable base URL

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -561,7 +561,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
-		ew.writeln(`	- "DO_API_URL":	The URL of the API (default https://api.digitalocean.com)`)
+		ew.writeln(`	- "DO_API_URL":	The URL of the API`)
 		ew.writeln(`	- "DO_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "DO_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "DO_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -561,6 +561,7 @@ func displayDNSHelp(name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "DO_API_URL":	The URL of the API (default https://api.digitalocean.com)`)
 		ew.writeln(`	- "DO_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "DO_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "DO_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)

--- a/docs/content/dns/zz_gen_digitalocean.md
+++ b/docs/content/dns/zz_gen_digitalocean.md
@@ -47,7 +47,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `DO_API_URL` | The URL of the API (default https://api.digitalocean.com) |
+| `DO_API_URL` | The URL of the API |
 | `DO_HTTP_TIMEOUT` | API request timeout |
 | `DO_POLLING_INTERVAL` | Time between DNS propagation check |
 | `DO_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |

--- a/docs/content/dns/zz_gen_digitalocean.md
+++ b/docs/content/dns/zz_gen_digitalocean.md
@@ -47,6 +47,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `DO_API_URL` | The URL of the API (default https://api.digitalocean.com) |
 | `DO_HTTP_TIMEOUT` | API request timeout |
 | `DO_POLLING_INTERVAL` | Time between DNS propagation check |
 | `DO_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |

--- a/docs/content/dns/zz_gen_yandex.md
+++ b/docs/content/dns/zz_gen_yandex.md
@@ -6,7 +6,7 @@ slug: yandex
 dnsprovider:
   since:    "v3.7.0"
   code:     "yandex"
-  url:      "https://yandex.com/"
+  url:      "https://pdd.yandex.com"
 ---
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
@@ -14,7 +14,7 @@ dnsprovider:
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 
 
-Configuration for [Yandex PDD](https://yandex.com/).
+Configuration for [Yandex PDD](https://pdd.yandex.com).
 
 
 <!--more-->
@@ -60,7 +60,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 ## More information
 
-- [API documentation](https://tech.yandex.com/domain/doc/concepts/api-dns-docpage/)
+- [API documentation](https://yandex.com/dev/domain/doc/concepts/api-dns.html)
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 <!-- providers/dns/yandex/yandex.toml -->

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -17,12 +17,12 @@ const (
 	envNamespace = "DO_"
 
 	EnvAuthToken = envNamespace + "AUTH_TOKEN"
+	EnvAPIUrl    = envNamespace + "API_URL"
 
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
-	EnvAPIUrl             = envNamespace + "API_URL"
 )
 
 // Config is used to configure the creation of the DNSProvider.

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -22,6 +22,7 @@ const (
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+	EnvAPIUrl             = envNamespace + "API_URL"
 )
 
 // Config is used to configure the creation of the DNSProvider.
@@ -37,7 +38,7 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
 	return &Config{
-		BaseURL:            defaultBaseURL,
+		BaseURL:            env.GetOrDefaultString(EnvAPIUrl, defaultBaseURL),
 		TTL:                env.GetOrDefaultInt(EnvTTL, 30),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 60*time.Second),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),

--- a/providers/dns/digitalocean/digitalocean.toml
+++ b/providers/dns/digitalocean/digitalocean.toml
@@ -13,11 +13,11 @@ lego --email you@example.com --dns digitalocean --domains my.example.org run
   [Configuration.Credentials]
     DO_AUTH_TOKEN = "Authentication token"
   [Configuration.Additional]
+    DO_API_URL = "The URL of the API"
     DO_POLLING_INTERVAL = "Time between DNS propagation check"
     DO_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     DO_TTL = "The TTL of the TXT record used for the DNS challenge"
     DO_HTTP_TIMEOUT = "API request timeout"
-    DO_API_URL = "The URL of the API (default https://api.digitalocean.com)"
 
 [Links]
   API = "https://developers.digitalocean.com/documentation/v2/#domain-records"

--- a/providers/dns/digitalocean/digitalocean.toml
+++ b/providers/dns/digitalocean/digitalocean.toml
@@ -17,6 +17,7 @@ lego --email you@example.com --dns digitalocean --domains my.example.org run
     DO_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     DO_TTL = "The TTL of the TXT record used for the DNS challenge"
     DO_HTTP_TIMEOUT = "API request timeout"
+    DO_API_URL = "The URL of the API (default https://api.digitalocean.com)"
 
 [Links]
   API = "https://developers.digitalocean.com/documentation/v2/#domain-records"


### PR DESCRIPTION
I wanted to proxy the calls to DigitalOcean API made for dns ACME challenge, and the go-acme/lego `digitalocean` provider has hardcoded https://api.digitalocean.com, this PR should handle that hopefully. 