### PR TITLE
fix: flaky tests

### DIFF
--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -263,8 +263,8 @@ func TestChallengeHTTP_Client_Registration_QueryRegistration(t *testing.T) {
 	require.NotNil(t, resource)
 
 	assert.Equal(t, "valid", resource.Body.Status)
-	assert.Regexp(t, `https://localhost:14000/list-orderz/\d+`, resource.Body.Orders)
-	assert.Regexp(t, `https://localhost:14000/my-account/\d+`, resource.URI)
+	assert.Regexp(t, `https://localhost:14000/list-orderz/[\w\d]+`, resource.Body.Orders)
+	assert.Regexp(t, `https://localhost:14000/my-account/[\w\d]+`, resource.URI)
 }
 
 func TestChallengeTLS_Client_Obtain(t *testing.T) {


### PR DESCRIPTION
```
2022/08/22 15:12:00 [INFO] acme: Querying account for https://localhost:14000/my-account/b846792c3124aa5
challenges_test.go:266:
Error Trace:	/home/runner/work/lego/lego/e2e/challenges_test.go:266
Error:      	Expect "https://localhost:14000/list-orderz/b846792c3124aa5" to match "https://localhost:14000/list-orderz/\d+"
Test:       	TestChallengeHTTP_Client_Registration_QueryRegistration
challenges_test.go:267:
Error Trace:	/home/runner/work/lego/lego/e2e/challenges_test.go:267
Error:      	Expect "https://localhost:14000/my-account/b846792c3124aa5" to match "https://localhost:14000/my-account/\d+"
Test:       	TestChallengeHTTP_Client_Registration_QueryRegistration
```

https://github.com/go-acme/lego/runs/7954912813?check_suite_focus=true
