### PR TITLE
Route 53: Update IAM policy example to grant least privilege access

### DIFF
--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -82,32 +82,51 @@ See also:
 
 ## Policy
 
-The following AWS IAM policy document describes the permissions required for lego to complete the DNS challenge.
+The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name.
 
 ```json
 {
-   "Version": "2012-10-17",
-   "Statement": [
-       {
-           "Sid": "",
-           "Effect": "Allow",
-           "Action": [
-               "route53:GetChange",
-               "route53:ChangeResourceRecordSets",
-               "route53:ListResourceRecordSets"
-           ],
-           "Resource": [
-               "arn:aws:route53:::hostedzone/*",
-               "arn:aws:route53:::change/*"
-           ]
-       },
-       {
-           "Sid": "",
-           "Effect": "Allow",
-           "Action": "route53:ListHostedZonesByName",
-           "Resource": "*"
-       }
-   ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "route53:GetChange",
+      "Resource": "arn:aws:route53:::change/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZonesByName",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/Z11111112222222333333"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/Z11111112222222333333"
+      ],
+      "Condition": {
+        "ForAllValues:StringEquals": {
+          "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+            "_acme-challenge.example.com"
+          ],
+          "route53:ChangeResourceRecordSetsRecordTypes": [
+            "TXT"
+          ]
+        }
+      }
+    }
+  ]
 }
 ```
 

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -161,6 +161,8 @@ The following AWS IAM policy document describes least privilege permissions requ
 }
 ```
 
+
+
 ## More information
 
 - [API documentation](https://docs.aws.amazon.com/Route53/latest/APIReference/API_Operations_Amazon_Route_53.html)

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -84,7 +84,10 @@ See also:
 
 ### Broad privileges for testing purposes
 
-The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge. A word of caution: These permissions grant write access to any DNS record in any hosted zone, so it is recommended to narrow them down as much as possible if you are using this policy in production.
+The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge.
+A word of caution:
+These permissions grant write access to any DNS record in any hosted zone,
+so it is recommended to narrow them down as much as possible if you are using this policy in production.
 
 ```json
 {
@@ -113,7 +116,9 @@ The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/acce
 
 ### Least privilege policy for production purposes
 
-The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
+The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge.
+Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`.
+Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
 
 ```json
 {

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -80,9 +80,40 @@ See also:
 - [Setting AWS Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
 - [Setting AWS Region](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-the-region)
 
-## Policy
+## IAM Policy Examples
 
-The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name.
+### Broad privileges for testing purposes
+
+The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge. A word of caution: These permissions grant write access to any DNS record in any hosted zone, so it is recommended to narrow them down as much as possible if you are using this policy in production.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetChange",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/*",
+        "arn:aws:route53:::change/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZonesByName",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Least privilege policy for production purposes
+
+The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
 
 ```json
 {
@@ -129,9 +160,6 @@ The following AWS IAM policy document describes least privilege permissions requ
   ]
 }
 ```
-
-
-
 
 ## More information
 

--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -28,37 +28,86 @@ See also:
 - [Setting AWS Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
 - [Setting AWS Region](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-the-region)
 
-## Policy
+## IAM Policy Examples
 
-The following AWS IAM policy document describes the permissions required for lego to complete the DNS challenge.
+### Broad privileges for testing purposes
+
+The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge. A word of caution: These permissions grant write access to any DNS record in any hosted zone, so it is recommended to narrow them down as much as possible if you are using this policy in production.
 
 ```json
 {
-   "Version": "2012-10-17",
-   "Statement": [
-       {
-           "Sid": "",
-           "Effect": "Allow",
-           "Action": [
-               "route53:GetChange",
-               "route53:ChangeResourceRecordSets",
-               "route53:ListResourceRecordSets"
-           ],
-           "Resource": [
-               "arn:aws:route53:::hostedzone/*",
-               "arn:aws:route53:::change/*"
-           ]
-       },
-       {
-           "Sid": "",
-           "Effect": "Allow",
-           "Action": "route53:ListHostedZonesByName",
-           "Resource": "*"
-       }
-   ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetChange",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/*",
+        "arn:aws:route53:::change/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZonesByName",
+      "Resource": "*"
+    }
+  ]
 }
 ```
 
+### Least privilege policy for production purposes
+
+The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "route53:GetChange",
+      "Resource": "arn:aws:route53:::change/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZonesByName",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/Z11111112222222333333"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/Z11111112222222333333"
+      ],
+      "Condition": {
+        "ForAllValues:StringEquals": {
+          "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+            "_acme-challenge.example.com"
+          ],
+          "route53:ChangeResourceRecordSetsRecordTypes": [
+            "TXT"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
 '''
 
 [Configuration]

--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -32,7 +32,10 @@ See also:
 
 ### Broad privileges for testing purposes
 
-The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge. A word of caution: These permissions grant write access to any DNS record in any hosted zone, so it is recommended to narrow them down as much as possible if you are using this policy in production.
+The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) document grants access to the required APIs needed by lego to complete the DNS challenge.
+A word of caution:
+These permissions grant write access to any DNS record in any hosted zone,
+so it is recommended to narrow them down as much as possible if you are using this policy in production.
 
 ```json
 {
@@ -61,7 +64,9 @@ The following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/acce
 
 ### Least privilege policy for production purposes
 
-The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge. Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`. Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
+The following AWS IAM policy document describes least privilege permissions required for lego to complete the DNS challenge.
+Write access is limited to a specified hosted zone's DNS TXT records with a key of `_acme-challenge.example.com`.
+Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with your domain name to use this policy.
 
 ```json
 {


### PR DESCRIPTION
[AWS recently released new IAM permission conditions](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-route-53-support-dns-resource-record-set-permissions/) to restrict access to Route 53 beyond the scope of a hosted zone down to individual records. This makes it possible to finally create least privilege IAM policies for restricting access to only the [specific DNS TXT record](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) required. I have [written a blog post](https://paulgalow.com/aws-route-53-iam-policy-letsencrypt-dns) with more context and examples.

I'd like to propose an updated IAM policy which takes into account the new capabilities to lock down access as much as possible. I have successfully tested this policy with Traefik.

One downside I see with the example at hand is that users will now need to provide more information in their IAM policies, i.e. their hosted zone ID and their domain name.

Curious to hear your thoughts.