### PR TITLE
hurricane: fix CNAME support

### DIFF
--- a/providers/dns/hurricane/hurricane.go
+++ b/providers/dns/hurricane/hurricane.go
@@ -86,9 +86,9 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 // Present updates a TXT record to fulfill the dns-01 challenge.
 func (d *DNSProvider) Present(domain, _, keyAuth string) error {
-	resolvedDomain, txtRecord := dns01.GetRecord(domain, keyAuth)
+	fqdn, txtRecord := dns01.GetRecord(domain, keyAuth)
 
-	err := d.client.UpdateTxtRecord(context.Background(), domain, resolvedDomain, txtRecord)
+	err := d.client.UpdateTxtRecord(context.Background(), dns01.UnFqdn(fqdn), txtRecord)
 	if err != nil {
 		return fmt.Errorf("hurricane: %w", err)
 	}
@@ -98,9 +98,9 @@ func (d *DNSProvider) Present(domain, _, keyAuth string) error {
 
 // CleanUp updates the TXT record matching the specified parameters.
 func (d *DNSProvider) CleanUp(domain, _, keyAuth string) error {
-	resolvedDomain, _ := dns01.GetRecord(domain, keyAuth)
+	fqdn, _ := dns01.GetRecord(domain, keyAuth)
 
-	err := d.client.UpdateTxtRecord(context.Background(), domain, resolvedDomain, ".")
+	err := d.client.UpdateTxtRecord(context.Background(), dns01.UnFqdn(fqdn), ".")
 	if err != nil {
 		return fmt.Errorf("hurricane: %w", err)
 	}

--- a/providers/dns/hurricane/internal/client_test.go
+++ b/providers/dns/hurricane/internal/client_test.go
@@ -75,7 +75,7 @@ func TestClient_UpdateTxtRecord(t *testing.T) {
 			client := NewClient(map[string]string{"example.com": "secret"})
 			client.baseURL = server.URL
 
-			err := client.UpdateTxtRecord(context.Background(), "example.com", "_acme-challenge.example.com", "foo")
+			err := client.UpdateTxtRecord(context.Background(), "_acme-challenge.example.com", "foo")
 			test.expected(t, err)
 		})
 	}


### PR DESCRIPTION
I've made a start with fixing up the Hurricane Electric DNS provider. It will now resolve the CNAME with `dns01.GetRecord` and then use the result as `hostname` to the DynDNS API of Hurricane Electric. To my understanding this is how it should work.

Feedback is appreciated and thank you. 😄 