### PR TITLE
route53: Allow static credentials to be supplied

### DIFF
--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -37,6 +38,13 @@ const (
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
+	// Static credential chain. These are not set via environment for the time
+	// being and are only used if they are explicitly provided.
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Region          string
+
 	HostedZoneID  string
 	MaxRetries    int
 	AssumeRoleArn string
@@ -301,10 +309,23 @@ func (d *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 }
 
 func createSession(config *Config) (*session.Session, error) {
+	if err := createSessionCheckParams(config); err != nil {
+		return nil, err
+	}
+
 	retry := customRetryer{}
 	retry.NumMaxRetries = config.MaxRetries
 
-	sessionCfg := request.WithRetryer(aws.NewConfig(), retry)
+	awsConfig := aws.NewConfig()
+	if config.AccessKeyID != "" && config.SecretAccessKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(config.AccessKeyID, config.SecretAccessKey, config.SessionToken))
+	}
+
+	if config.Region != "" {
+		awsConfig = awsConfig.WithRegion(config.Region)
+	}
+
+	sessionCfg := request.WithRetryer(awsConfig, retry)
 
 	sess, err := session.NewSessionWithOptions(session.Options{Config: *sessionCfg})
 	if err != nil {
@@ -319,4 +340,20 @@ func createSession(config *Config) (*session.Session, error) {
 		Region:      sess.Config.Region,
 		Credentials: stscreds.NewCredentials(sess, config.AssumeRoleArn),
 	})
+}
+
+func createSessionCheckParams(config *Config) error {
+	if config == nil {
+		return errors.New("config is nil")
+	}
+
+	switch {
+	case config.SessionToken != "" && config.AccessKeyID == "" && config.SecretAccessKey == "":
+		return errors.New("SessionToken must be supplied with AccessKeyID and SecretAccessKey")
+
+	case config.AccessKeyID == "" && config.SecretAccessKey != "" || config.AccessKeyID != "" && config.SecretAccessKey == "":
+		return errors.New("AccessKeyID and SecretAccessKey must be supplied together")
+	}
+
+	return nil
 }

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -29,17 +29,17 @@ const (
 	EnvRegion          = envNamespace + "REGION"
 	EnvHostedZoneID    = envNamespace + "HOSTED_ZONE_ID"
 	EnvMaxRetries      = envNamespace + "MAX_RETRIES"
+	EnvAssumeRoleArn   = envNamespace + "ASSUME_ROLE_ARN"
 
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
-	EnvAssumeRoleArn      = envNamespace + "ASSUME_ROLE_ARN"
 )
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
-	// Static credential chain. These are not set via environment for the time
-	// being and are only used if they are explicitly provided.
+	// Static credential chain.
+	// These are not set via environment for the time being and are only used if they are explicitly provided.
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -177,3 +177,133 @@ func TestDNSProvider_Present(t *testing.T) {
 	err := provider.Present(domain, "", keyAuth)
 	require.NoError(t, err, "Expected Present to return no error")
 }
+
+func TestCreateSession(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		env              map[string]string
+		config           *Config
+		wantCreds        credentials.Value
+		wantDefaultChain bool
+		wantRegion       string
+		wantErr          string
+	}{
+		{
+			desc:    "config is nil",
+			wantErr: "config is nil",
+		},
+		{
+			desc:    "session token without access key id or secret access key",
+			config:  &Config{SessionToken: "foo"},
+			wantErr: "SessionToken must be supplied with AccessKeyID and SecretAccessKey",
+		},
+		{
+			desc:    "access key id without secret access key",
+			config:  &Config{AccessKeyID: "foo"},
+			wantErr: "AccessKeyID and SecretAccessKey must be supplied together",
+		},
+		{
+			desc:    "access key id without secret access key",
+			config:  &Config{SecretAccessKey: "foo"},
+			wantErr: "AccessKeyID and SecretAccessKey must be supplied together",
+		},
+		{
+			desc:             "credentials from default chain",
+			config:           &Config{},
+			wantDefaultChain: true,
+		},
+		{
+			desc: "static credentials",
+			config: &Config{
+				AccessKeyID:     "one",
+				SecretAccessKey: "two",
+			},
+			wantCreds: credentials.Value{
+				AccessKeyID:     "one",
+				SecretAccessKey: "two",
+				SessionToken:    "",
+				ProviderName:    credentials.StaticProviderName,
+			},
+		},
+		{
+			desc: "static credentials with session token",
+			config: &Config{
+				AccessKeyID:     "one",
+				SecretAccessKey: "two",
+				SessionToken:    "three",
+			},
+			wantCreds: credentials.Value{
+				AccessKeyID:     "one",
+				SecretAccessKey: "two",
+				SessionToken:    "three",
+				ProviderName:    credentials.StaticProviderName,
+			},
+		},
+		{
+			desc:   "region from env",
+			config: &Config{},
+			env: map[string]string{
+				"AWS_REGION": "foo",
+			},
+			wantDefaultChain: true,
+			wantRegion:       "foo",
+		},
+		{
+			desc: "static region",
+			config: &Config{
+				Region: "one",
+			},
+			env: map[string]string{
+				"AWS_REGION": "foo",
+			},
+			wantDefaultChain: true,
+			wantRegion:       "one",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			defer envTest.RestoreEnv()
+			envTest.ClearEnv()
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+
+			sess, err := createSession(tc.config)
+			if errOk := testAssertErr(t, err, tc.wantErr); errOk {
+				return
+			}
+
+			gotCreds, err := sess.Config.Credentials.Get()
+			switch {
+			case !tc.wantDefaultChain:
+				require.NoError(t, err)
+				require.Equal(t, tc.wantCreds, gotCreds)
+
+			default:
+				require.NotEqual(t, credentials.StaticProviderName, gotCreds.ProviderName)
+			}
+
+			if tc.wantRegion != "" {
+				require.Equal(t, tc.wantRegion, aws.StringValue(sess.Config.Region))
+			}
+		})
+	}
+}
+
+func testAssertErr(t *testing.T, err error, wantErr string) bool {
+	t.Helper()
+	switch {
+	case err != nil && wantErr == "":
+		require.FailNow(t, err.Error())
+
+	case err == nil && wantErr != "":
+		require.FailNow(t, "expected error, got none")
+
+	case err != nil && wantErr != "":
+		require.EqualError(t, err, wantErr)
+
+		return true
+	}
+
+	return false
+}

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -269,7 +269,11 @@ func TestCreateSession(t *testing.T) {
 			envTest.Apply(test.env)
 
 			sess, err := createSession(test.config)
-			assertErr(t, err, test.wantErr)
+			requireErr(t, err, test.wantErr)
+
+			if err != nil {
+				return
+			}
 
 			gotCreds, err := sess.Config.Credentials.Get()
 
@@ -287,15 +291,17 @@ func TestCreateSession(t *testing.T) {
 	}
 }
 
-func assertErr(t *testing.T, err error, wantErr string) {
+func requireErr(t *testing.T, err error, wantErr string) {
 	t.Helper()
 
 	switch {
 	case err != nil && wantErr == "":
+		// force the assertion error.
 		require.NoError(t, err)
 
 	case err == nil && wantErr != "":
-		require.Error(t, nil)
+		// force the assertion error.
+		require.EqualError(t, err, wantErr)
 
 	case err != nil && wantErr != "":
 		require.EqualError(t, err, wantErr)


### PR DESCRIPTION
This is incremental progress to implementing #1736, the first part being porting over certain providers (specifically route53 and lightsail) to use static credentials not derived from the environment.

This specifically adds support for the static chain where an access key ID, secret access key, and (optionally) a session token can be supplied manually.