### PR TITLE
Option to entirely disable DNS01 propagation check

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -141,7 +141,6 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	chlng.KeyAuthorization = keyAuth

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -31,6 +31,8 @@ func DisableCompletePropagationRequirement() ChallengeOption {
 }
 
 type preCheck struct {
+	// entirely disables DNS propagation check
+	disabled bool
 	// checks DNS propagation before notifying ACME that the DNS challenge is ready.
 	checkFunc WrapPreCheckFunc
 	// require the TXT record to be propagated to all authoritative name servers
@@ -107,4 +109,14 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 	}
 
 	return true, nil
+}
+
+//DisablePropagationCheck is a challenge option to entirely skip after the DNS01 challenge has
+//been presented by the DNS provider. This option should only be used by DNS providers
+//guaranteeing that the challenge is present at their authoritative nameservers after returning.
+func DisablePropagationCheck() ChallengeOption {
+	return func(chlg *Challenge) error {
+		chlg.preCheck.disabled = true
+		return nil
+	}
 }

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -111,10 +111,10 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 	return true, nil
 }
 
-//DisablePropagationCheck is a challenge option to entirely skip the propagation check after
-//the DNS01 challenge has been presented by the DNS provider. This option should only be used
-//by DNS providers guaranteeing that the challenge is present at their authoritative
-//nameservers after returning from the Present(..) function.
+// DisablePropagationCheck is a challenge option to entirely skip the propagation check after
+// the DNS01 challenge has been presented by the DNS provider. This option should only be used
+// by DNS providers guaranteeing that the challenge is present at their authoritative
+// nameservers after returning from the Present(..) function.
 func DisablePropagationCheck() ChallengeOption {
 	return func(chlg *Challenge) error {
 		chlg.preCheck.disabled = true

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -111,9 +111,10 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 	return true, nil
 }
 
-//DisablePropagationCheck is a challenge option to entirely skip after the DNS01 challenge has
-//been presented by the DNS provider. This option should only be used by DNS providers
-//guaranteeing that the challenge is present at their authoritative nameservers after returning.
+//DisablePropagationCheck is a challenge option to entirely skip the propagation check after
+//the DNS01 challenge has been presented by the DNS provider. This option should only be used
+//by DNS providers guaranteeing that the challenge is present at their authoritative
+//nameservers after returning from the Present(..) function.
 func DisablePropagationCheck() ChallengeOption {
 	return func(chlg *Challenge) error {
 		chlg.preCheck.disabled = true

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lnobach/acme-lego
+module github.com/go-acme/lego/v4
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-acme/lego/v4
+module github.com/lnobach/acme-lego
 
 go 1.18
 


### PR DESCRIPTION
Here is a challenge option to entirely skip the propagation check after the DNS01 challenge has been presented by the DNS provider. This option should only be used by DNS providers guaranteeing that the challenge is present at their authoritative
nameservers after returning from the Present(..) function.

## Motivation

Needed by (almost) air-gapped platforms running lego which
- are not able to reach the authoritative nameserves of the domains (timeout or no route to host),
- are not able to check the TXT record over their resolver (propagation too slow despite low TTL),
- instead have another provider-specific method ensuring propagation.
 
## Example usage

```go
myprovider = GetMyProviderEnsuringPropagation()
err = client.Challenge.SetDNS01Provider(myprovider, dns01.DisablePropagationCheck())
if err != nil {
	return err
}
```
