### PR TITLE
ibmcloud: add support for subdomains

### DIFF
--- a/providers/dns/ibmcloud/internal/wrapper.go
+++ b/providers/dns/ibmcloud/internal/wrapper.go
@@ -79,17 +79,6 @@ func getDomainID(service services.Dns_Domain, domain string) (*int, error) {
 	return getDomainID(service, parent)
 }
 
-func getParentDomain(domainParts []string) string {
-	numParts := len(domainParts)
-	var sb strings.Builder
-	for i := 1; i < numParts; i++ {
-		sb.WriteString(domainParts[i])
-		if i < numParts-1 {
-			sb.WriteString(".")
-		}
-	}
-	return sb.String()
-}
 
 func findTxtRecords(service services.Dns_Domain, fqdn string) ([]datatypes.Dns_Domain_ResourceRecord, error) {
 	var results []datatypes.Dns_Domain_ResourceRecord

--- a/providers/dns/ibmcloud/internal/wrapper.go
+++ b/providers/dns/ibmcloud/internal/wrapper.go
@@ -72,13 +72,12 @@ func getDomainID(service services.Dns_Domain, domain string) (*int, error) {
 	// So in case a subdomain like `sub.toplevel.tld` was used try again using the parent domain
 	// (strip the first part in the domain string -> `toplevel.tld`).
 	_, parent, found := strings.Cut(domain, ".")
-	if !found || strings.Index(parent, ".") == -1 {
+	if !found || !strings.Contains(parent, ".") {
 		return nil, fmt.Errorf("no data found for domain: %s", domain)
 	}
 
 	return getDomainID(service, parent)
 }
-
 
 func findTxtRecords(service services.Dns_Domain, fqdn string) ([]datatypes.Dns_Domain_ResourceRecord, error) {
 	var results []datatypes.Dns_Domain_ResourceRecord

--- a/providers/dns/ibmcloud/internal/wrapper.go
+++ b/providers/dns/ibmcloud/internal/wrapper.go
@@ -40,7 +40,7 @@ func (w Wrapper) CleanupTXTRecord(fqdn, domain string) error {
 
 	domainID, err := getDomainID(service, domain)
 	if err != nil {
-		return fmt.Errorf("failed to get domain ID for domain: %w", err)
+		return fmt.Errorf("failed to get domain ID: %w", err)
 	}
 
 	service.Options.Id = domainID

--- a/providers/dns/ibmcloud/internal/wrapper.go
+++ b/providers/dns/ibmcloud/internal/wrapper.go
@@ -71,12 +71,12 @@ func getDomainID(service services.Dns_Domain, domain string) (*int, error) {
 	// For subdomains this is not unusual in softlayer.
 	// So in case a subdomain like `sub.toplevel.tld` was used try again using the parent domain
 	// (strip the first part in the domain string -> `toplevel.tld`).
-	domainParts := strings.Split(domain, ".")
-	if len(domainParts) > 2 {
-		return getDomainID(service, getParentDomain(domainParts))
-	} else {
+	_, parent, found := strings.Cut(domain, ".")
+	if !found || strings.Index(parent, ".") == -1 {
 		return nil, fmt.Errorf("no data found for domain: %s", domain)
 	}
+
+	return getDomainID(service, parent)
 }
 
 func getParentDomain(domainParts []string) string {

--- a/providers/dns/ibmcloud/internal/wrapper.go
+++ b/providers/dns/ibmcloud/internal/wrapper.go
@@ -67,9 +67,10 @@ func getDomainID(service services.Dns_Domain, domain string) (*int, error) {
 		return r.Id, nil
 	}
 
-	// The domain was not found by name. For subdomains this is not unusal in softlayer.
-	// So in case a subdomain like sub.toplevel.domain was used try again using the
-	// parent domain (strip the first part in the domain string -> toplevel.domain).
+	// The domain was not found by name.
+	// For subdomains this is not unusual in softlayer.
+	// So in case a subdomain like `sub.toplevel.tld` was used try again using the parent domain
+	// (strip the first part in the domain string -> `toplevel.tld`).
 	domainParts := strings.Split(domain, ".")
 	if len(domainParts) > 2 {
 		return getDomainID(service, getParentDomain(domainParts))


### PR DESCRIPTION
I noticed that requesting wildcard certificates for subdomains does not work for the ibmcloud (softlayer) dns solver.
The problem is that the softlayer API getDomainID is used and the domain name is passed as an argument.
For wildcard certificates for subdomains this argument will be the subdomain. The subdomain is not a separate entity in softlayer DNS so no record and thus no domain ID is found.

This change will try to find the "parent" of the subdomain in case the domain that was used to find the domain ID has more than two parts.
When the parent can be found the correct acme challenge entries will be made and a wildcard certificate for a subdomain will be created successfully.

I did live tests with one of my domains in softlayer and with the change I am able to retrieve the wildcard cert for the subdomain(s). I tried:
- `*.toplevel.domain`
- `*.1.toplevel.domain`
- `*.1.2.toplevel.domain`
- `toplevel.domain`
- `2.toplevel.domain`
- `2.3.toplevel.domain`

I am a golang beginner so in case something is wrong with the code please tell me. 
Thanks.