### PR TITLE
tencentcloud: support punycode domain

### DIFF
--- a/providers/dns/tencentcloud/client.go
+++ b/providers/dns/tencentcloud/client.go
@@ -38,7 +38,8 @@ func (d *DNSProvider) getHostedZone(domain string) (*dnspod.DomainListItem, erro
 
 	var hostedZone *dnspod.DomainListItem
 	for _, zone := range domains {
-		if *zone.Name == dns01.UnFqdn(authZone) {
+		unfqdn := dns01.UnFqdn(authZone)
+		if *zone.Name == unfqdn || *zone.Punycode == unfqdn {
 			hostedZone = zone
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/go-acme/lego/discussions/1787

https://github.com/go-acme/lego/blob/6695fcc87344a920efcf0a504f299913a7869b54/providers/dns/tencentcloud/client.go#L20-L23
https://github.com/go-acme/lego/blob/6695fcc87344a920efcf0a504f299913a7869b54/providers/dns/tencentcloud/client.go#L39-L44

The tencent cloud sdk `DescribeDomainList` api.

The `Name` fields returned by `DescribeDomainList` api will not be converted into punycode format, can use `Punycode` field.
