### PR TITLE
luadns: removed dot suffix from authzone while searching for zone

### DIFF
--- a/providers/dns/luadns/luadns.go
+++ b/providers/dns/luadns/luadns.go
@@ -124,9 +124,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("luadns: failed to find zone: %w", err)
 	}
 
-	authZone = dns01.UnFqdn(authZone)
-
-	zone := findZone(zones, authZone)
+	zone := findZone(zones, dns01.UnFqdn(authZone))
 	if zone == nil {
 		return fmt.Errorf("luadns: no matching zone found for domain %s", domain)
 	}

--- a/providers/dns/luadns/luadns.go
+++ b/providers/dns/luadns/luadns.go
@@ -124,6 +124,8 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("luadns: failed to find zone: %w", err)
 	}
 
+	authZone = dns01.UnFqdn(authZone)
+
 	zone := findZone(zones, authZone)
 	if zone == nil {
 		return fmt.Errorf("luadns: no matching zone found for domain %s", domain)


### PR DESCRIPTION
Fixes #1795 

The comparison in findZone does not work because authZone has a dot at the end and the entries in zones do not contain a dot.

If the dot is removed with UnFqdn it works for me.

