### PR TITLE
Add -4 and -6 flags

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -125,7 +125,7 @@
     text = "(tlsFeatureExtensionOID|ocspMustStapleFeature) is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/dns01/nameserver.go"
-    text = "(defaultNameservers|recursiveNameservers|fqdnSoaCache|muFqdnSoaCache) is a global variable"
+    text = "(defaultNameservers|recursiveNameservers|currentNetworkStack|fqdnSoaCache|muFqdnSoaCache) is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/dns01/nameserver_.+.go"
     text = "dnsTimeout is a global variable"

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -125,13 +125,16 @@
     text = "(tlsFeatureExtensionOID|ocspMustStapleFeature) is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/dns01/nameserver.go"
-    text = "(defaultNameservers|recursiveNameservers|currentNetworkStack|fqdnSoaCache|muFqdnSoaCache) is a global variable"
+    text = "(defaultNameservers|recursiveNameservers|fqdnSoaCache|muFqdnSoaCache) is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/dns01/nameserver_.+.go"
     text = "dnsTimeout is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/dns01/nameserver_test.go"
     text = "findXByFqdnTestCases is a global variable"
+  [[issues.exclude-rules]]
+    path = "challenge/dns01/network.go"
+    text = "currentNetworkStack is a global variable"
   [[issues.exclude-rules]]
     path = "challenge/http01/domain_matcher.go"
     text = "string `Host` has \\d occurrences, make it a constant"

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -26,24 +26,6 @@ var defaultNameservers = []string{
 // recursiveNameservers are used to pre-check DNS propagation.
 var recursiveNameservers = getNameservers(defaultResolvConf, defaultNameservers)
 
-// NetworkStack is used to indicate which IP stack should be used for DNS
-// queries. Valid values are DefaultNetworkStack, IPv4Only, and IPv6Only.
-type NetworkStack int
-
-const (
-	// DefaultNetworkStack indicates that both IPv4 and IPv6 should be allowed.
-	// This setting lets the OS determine which IP stack to use.
-	DefaultNetworkStack NetworkStack = iota
-	// IPv4Only forces DNS queries to only happen over the IPv4 stack.
-	IPv4Only
-	// IPv6Only forces DNS queries to only happen over the IPv6 stack.
-	IPv6Only
-)
-
-// currentNetworkStack is used to define which IP stack will be used. The default is
-// both IPv4 and IPv6. Set to IPv4Only or IPv6Only to select either version.
-var currentNetworkStack = DefaultNetworkStack
-
 // soaCacheEntry holds a cached SOA record (only selected fields).
 type soaCacheEntry struct {
 	zone      string    // zone apex (a domain name)
@@ -83,11 +65,6 @@ func AddRecursiveNameservers(nameservers []string) ChallengeOption {
 		recursiveNameservers = ParseNameservers(nameservers)
 		return nil
 	}
-}
-
-// SetNetworkStack defines the IP stack that will be used for DNS queries.
-func SetNetworkStack(network NetworkStack) {
-	currentNetworkStack = network
 }
 
 // getNameservers attempts to get systems nameservers before falling back to the defaults.
@@ -272,28 +249,12 @@ func createDNSMsg(fqdn string, rtype uint16, recursive bool) *dns.Msg {
 	return m
 }
 
-// getNetwork interprets the NetworkStack setting in relation to the desired
-// protocol. The proto value should be either "udp" or "tcp".
-func getNetwork(proto string) string {
-	// The dns client passes whatever value is set in [dns.Client.Net] to
-	// the [net.Dialer] (https://github.com/miekg/dns/blob/fe20d5d/client.go#L119-L141).
-	// And the [net.Dialer] accepts strings such as "udp4" or "tcp6"
-	// (https://cs.opensource.google/go/go/+/refs/tags/go1.18.9:src/net/dial.go;l=167-182).
-	if currentNetworkStack == IPv4Only {
-		return proto + "4"
-	}
-	if currentNetworkStack == IPv6Only {
-		return proto + "6"
-	}
-	return proto
-}
-
 func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
-	network := getNetwork("udp")
+	network := currentNetworkStack.Network("udp")
 	udp := &dns.Client{Net: network, Timeout: dnsTimeout}
 	in, _, err := udp.Exchange(m, ns)
 
-	network = getNetwork("tcp")
+	network = currentNetworkStack.Network("tcp")
 	// We can encounter a net.OpError if the nameserver is not listening
 	// on UDP at all, i.e. net.Dial could not make a connection.
 	var opErr *net.OpError

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -296,8 +296,8 @@ func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
 	network = getNetwork("tcp")
 	// We can encounter a net.OpError if the nameserver is not listening
 	// on UDP at all, i.e. net.Dial could not make a connection.
-	_, isOpErr := err.(*net.OpError)
-	if (in != nil && in.Truncated) || isOpErr {
+	var opErr *net.OpError
+	if (in != nil && in.Truncated) || errors.As(err, &opErr) {
 		tcp := &dns.Client{Net: network, Timeout: dnsTimeout}
 		// If the TCP request succeeds, the err will reset to nil
 		in, _, err = tcp.Exchange(m, ns)

--- a/challenge/dns01/nameserver_test.go
+++ b/challenge/dns01/nameserver_test.go
@@ -91,7 +91,7 @@ func TestSendDNSQuery(t *testing.T) {
 		recursiveNameservers = ParseNameservers([]string{addr})
 		msg := createDNSMsg("example.com.", dns.TypeA, true)
 		result, queryError := sendDNSQuery(msg, addr)
-		assert.NoError(t, queryError)
+		require.NoError(t, queryError)
 		assert.Equal(t, result.Answer[0].(*dns.A).A.String(), "127.0.0.1")
 	})
 
@@ -102,7 +102,7 @@ func TestSendDNSQuery(t *testing.T) {
 		recursiveNameservers = ParseNameservers([]string{addr})
 		msg := createDNSMsg("example.com.", dns.TypeA, true)
 		result, queryError := sendDNSQuery(msg, addr)
-		assert.NoError(t, queryError)
+		require.NoError(t, queryError)
 		assert.Equal(t, result.Answer[0].(*dns.A).A.String(), "127.0.0.1")
 	})
 
@@ -116,14 +116,14 @@ func TestSendDNSQuery(t *testing.T) {
 		recursiveNameservers = ParseNameservers([]string{addr6})
 		msg := createDNSMsg("example.com.", dns.TypeA, true)
 		result, queryError := sendDNSQuery(msg, addr6)
-		assert.NoError(t, queryError)
+		require.NoError(t, queryError)
 		assert.Equal(t, result.Answer[0].(*dns.A).A.String(), "127.0.0.1")
 
 		addr4 := net.JoinHostPort("127.0.0.1", port)
 		recursiveNameservers = ParseNameservers([]string{addr4})
 		msg = createDNSMsg("example.com.", dns.TypeA, true)
 		result, queryError = sendDNSQuery(msg, addr4)
-		assert.NoError(t, queryError)
+		require.NoError(t, queryError)
 		assert.Equal(t, result.Answer[0].(*dns.A).A.String(), "127.0.0.1")
 	})
 }

--- a/challenge/dns01/network.go
+++ b/challenge/dns01/network.go
@@ -1,0 +1,41 @@
+package dns01
+
+// networkStack is used to indicate which IP stack should be used for DNS queries.
+type networkStack int
+
+const (
+	dualStack networkStack = iota
+	ipv4only
+	ipv6only
+)
+
+// currentNetworkStack is used to define which IP stack will be used. The default is
+// both IPv4 and IPv6. Set to IPv4Only or IPv6Only to select either version.
+var currentNetworkStack = dualStack
+
+// Network interprets the NetworkStack setting in relation to the desired
+// protocol. The proto value should be either "udp" or "tcp".
+func (s networkStack) Network(proto string) string {
+	// The DNS client passes whatever value is set in (*dns.Client).Net to
+	// the [net.Dialer](https://github.com/miekg/dns/blob/fe20d5d/client.go#L119-L141).
+	// And the net.Dialer accepts strings such as "udp4" or "tcp6"
+	// (https://cs.opensource.google/go/go/+/refs/tags/go1.18.9:src/net/dial.go;l=167-182).
+	switch s {
+	case ipv4only:
+		return proto + "4"
+	case ipv6only:
+		return proto + "6"
+	default:
+		return proto
+	}
+}
+
+// SetIPv4Only forces DNS queries to only happen over the IPv4 stack.
+func SetIPv4Only() { currentNetworkStack = ipv4only }
+
+// SetIPv6Only forces DNS queries to only happen over the IPv6 stack.
+func SetIPv6Only() { currentNetworkStack = ipv6only }
+
+// SetDualStack indicates that both IPv4 and IPv6 should be allowed.
+// This setting lets the OS determine which IP stack to use.
+func SetDualStack() { currentNetworkStack = dualStack }

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -12,6 +12,14 @@ import (
 	"github.com/go-acme/lego/v4/log"
 )
 
+type ProviderNetwork string
+
+const (
+	DefaultNetwork = "tcp"
+	Tcp4Network    = "tcp4"
+	Tcp6Network    = "tcp6"
+)
+
 // ProviderServer implements ChallengeProvider for `http-01` challenge.
 // It may be instantiated without using the NewProviderServer function if
 // you want only to use the default values.
@@ -29,12 +37,15 @@ type ProviderServer struct {
 // NewProviderServer creates a new ProviderServer on the selected interface and port.
 // Setting iface and / or port to an empty string will make the server fall back to
 // the "any" interface and port 80 respectively.
-func NewProviderServer(iface, port string) *ProviderServer {
+func NewProviderServer(iface, port string, network ProviderNetwork) *ProviderServer {
 	if port == "" {
 		port = "80"
 	}
+	if network == "" {
+		network = DefaultNetwork
+	}
 
-	return &ProviderServer{network: "tcp", address: net.JoinHostPort(iface, port), matcher: &hostMatcher{}}
+	return &ProviderServer{network: string(network), address: net.JoinHostPort(iface, port), matcher: &hostMatcher{}}
 }
 
 func NewUnixProviderServer(socketPath string, mode fs.FileMode) *ProviderServer {

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -12,12 +12,16 @@ import (
 	"github.com/go-acme/lego/v4/log"
 )
 
+// ProviderNetwork indicates with network stack , IPv4, IPv6, or both, to use.
 type ProviderNetwork string
 
 const (
+	// DefaultNetwork indicates both IPv4 and IPv6.
 	DefaultNetwork = "tcp"
-	Tcp4Network    = "tcp4"
-	Tcp6Network    = "tcp6"
+	// TCP4Network indicates IPv4 only.
+	TCP4Network = "tcp4"
+	// TCP6Network indicates IPv6 only.
+	TCP6Network = "tcp6"
 )
 
 // ProviderServer implements ChallengeProvider for `http-01` challenge.

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -41,19 +41,19 @@ type ProviderServer struct {
 // NewProviderServer creates a new ProviderServer on the selected interface and port.
 // Setting iface and / or port to an empty string will make the server fall back to
 // the "any" interface and port 80 respectively.
-func NewProviderServer(iface, port string, network ProviderNetwork) *ProviderServer {
+func NewProviderServer(iface, port string) *ProviderServer {
 	if port == "" {
 		port = "80"
 	}
-	if network == "" {
-		network = DefaultNetwork
-	}
-
-	return &ProviderServer{network: string(network), address: net.JoinHostPort(iface, port), matcher: &hostMatcher{}}
+	return &ProviderServer{network: DefaultNetwork, address: net.JoinHostPort(iface, port), matcher: &hostMatcher{}}
 }
 
 func NewUnixProviderServer(socketPath string, mode fs.FileMode) *ProviderServer {
 	return &ProviderServer{network: "unix", address: socketPath, socketMode: mode, matcher: &hostMatcher{}}
+}
+
+func (s *ProviderServer) SetNetwork(network ProviderNetwork) {
+	s.network = string(network)
 }
 
 // Present starts a web server and makes the token available at `ChallengePath(token)` for web requests.

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -36,17 +36,27 @@ func TestProviderServer_GetAddress(t *testing.T) {
 	}{
 		{
 			desc:     "TCP default address",
-			server:   NewProviderServer("", ""),
+			server:   NewProviderServer("", "", ""),
 			expected: ":80",
 		},
 		{
 			desc:     "TCP with explicit port",
-			server:   NewProviderServer("", "8080"),
+			server:   NewProviderServer("", "8080", ""),
 			expected: ":8080",
 		},
 		{
 			desc:     "TCP with host and port",
-			server:   NewProviderServer("localhost", "8080"),
+			server:   NewProviderServer("localhost", "8080", ""),
+			expected: "localhost:8080",
+		},
+		{
+			desc:     "TCP4 with host and port",
+			server:   NewProviderServer("localhost", "8080", Tcp4Network),
+			expected: "localhost:8080",
+		},
+		{
+			desc:     "TCP6 with host and port",
+			server:   NewProviderServer("localhost", "8080", Tcp6Network),
 			expected: "localhost:8080",
 		},
 		{
@@ -70,7 +80,7 @@ func TestProviderServer_GetAddress(t *testing.T) {
 func TestChallenge(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	providerServer := NewProviderServer("", "23457")
+	providerServer := NewProviderServer("", "23457", "")
 
 	validate := func(_ *api.Core, _ string, chlng acme.Challenge) error {
 		uri := "http://localhost" + providerServer.GetAddress() + ChallengePath(chlng.Token)
@@ -199,7 +209,7 @@ func TestChallengeInvalidPort(t *testing.T) {
 
 	validate := func(_ *api.Core, _ string, _ acme.Challenge) error { return nil }
 
-	solver := NewChallenge(core, validate, NewProviderServer("", "123456"))
+	solver := NewChallenge(core, validate, NewProviderServer("", "123456", ""))
 
 	authz := acme.Authorization{
 		Identifier: acme.Identifier{
@@ -374,7 +384,7 @@ func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectErro
 
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	providerServer := NewProviderServer("localhost", "23457")
+	providerServer := NewProviderServer("localhost", "23457", "")
 	if header != nil {
 		providerServer.SetProxyHeader(header.name)
 	}

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -51,12 +51,12 @@ func TestProviderServer_GetAddress(t *testing.T) {
 		},
 		{
 			desc:     "TCP4 with host and port",
-			server:   NewProviderServer("localhost", "8080", Tcp4Network),
+			server:   NewProviderServer("localhost", "8080", TCP4Network),
 			expected: "localhost:8080",
 		},
 		{
 			desc:     "TCP6 with host and port",
-			server:   NewProviderServer("localhost", "8080", Tcp6Network),
+			server:   NewProviderServer("localhost", "8080", TCP6Network),
 			expected: "localhost:8080",
 		},
 		{

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -32,7 +32,7 @@ func TestProviderServer_GetAddress(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		server   *ProviderServer
-		network  ProviderNetwork
+		network  func(*ProviderServer)
 		expected string
 	}{
 		{
@@ -53,13 +53,13 @@ func TestProviderServer_GetAddress(t *testing.T) {
 		{
 			desc:     "TCP4 with host and port",
 			server:   NewProviderServer("localhost", "8080"),
-			network:  TCP4Network,
+			network:  func(s *ProviderServer) { s.SetIPv4Only() },
 			expected: "localhost:8080",
 		},
 		{
 			desc:     "TCP6 with host and port",
 			server:   NewProviderServer("localhost", "8080"),
-			network:  TCP6Network,
+			network:  func(s *ProviderServer) { s.SetIPv6Only() },
 			expected: "localhost:8080",
 		},
 		{
@@ -74,8 +74,8 @@ func TestProviderServer_GetAddress(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			if test.network != "" {
-				test.server.SetNetwork(test.network)
+			if test.network != nil {
+				test.network(test.server)
 			}
 
 			address := test.server.GetAddress()

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -11,12 +11,16 @@ import (
 	"github.com/go-acme/lego/v4/log"
 )
 
+// ProviderNetwork indicates with network stack , IPv4, IPv6, or both, to use.
 type ProviderNetwork string
 
 const (
+	// DefaultNetwork indicates both IPv4 and IPv6.
 	DefaultNetwork = "tcp"
-	Tcp4Network    = "tcp4"
-	Tcp6Network    = "tcp6"
+	// TCP4Network indicates IPv4 only.
+	TCP4Network = "tcp4"
+	// TCP6Network indicates IPv6 only.
+	TCP6Network = "tcp6"
 )
 
 const (
@@ -45,7 +49,7 @@ func NewProviderServer(iface, port string, network ProviderNetwork) *ProviderSer
 	if port == "" {
 		port = defaultTLSPort
 	}
-	
+
 	if network == "" {
 		network = DefaultNetwork
 	}

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -11,18 +11,6 @@ import (
 	"github.com/go-acme/lego/v4/log"
 )
 
-// ProviderNetwork indicates with network stack , IPv4, IPv6, or both, to use.
-type ProviderNetwork string
-
-const (
-	// DefaultNetwork indicates both IPv4 and IPv6.
-	DefaultNetwork = "tcp"
-	// TCP4Network indicates IPv4 only.
-	TCP4Network = "tcp4"
-	// TCP6Network indicates IPv6 only.
-	TCP6Network = "tcp6"
-)
-
 const (
 	// ACMETLS1Protocol is the ALPN Protocol ID for the ACME-TLS/1 Protocol.
 	ACMETLS1Protocol = "acme-tls/1"
@@ -49,12 +37,18 @@ func NewProviderServer(iface, port string) *ProviderServer {
 	if port == "" {
 		port = defaultTLSPort
 	}
-	return &ProviderServer{iface: iface, port: port, network: DefaultNetwork}
+	return &ProviderServer{iface: iface, port: port, network: "tcp"}
 }
 
-func (s *ProviderServer) SetNetwork(network ProviderNetwork) {
-	s.network = string(network)
-}
+// SetIPv4Only starts the challenge server on an IPv4 address.
+func (s *ProviderServer) SetIPv4Only() { s.network = "tcp4" }
+
+// SetIPv6Only starts the challenge server on an IPv6 address.
+func (s *ProviderServer) SetIPv6Only() { s.network = "tcp6" }
+
+// SetDualStack indicates that both IPv4 and IPv6 should be allowed.
+// This setting lets the OS determine which IP stack to use for the challenge server.
+func (s *ProviderServer) SetDualStack() { s.network = "tcp" }
 
 func (s *ProviderServer) GetAddress() string {
 	return net.JoinHostPort(s.iface, s.port)

--- a/challenge/tlsalpn01/tls_alpn_challenge_server.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_server.go
@@ -45,16 +45,15 @@ type ProviderServer struct {
 // NewProviderServer creates a new ProviderServer on the selected interface and port.
 // Setting iface and / or port to an empty string will make the server fall back to
 // the "any" interface and port 443 respectively.
-func NewProviderServer(iface, port string, network ProviderNetwork) *ProviderServer {
+func NewProviderServer(iface, port string) *ProviderServer {
 	if port == "" {
 		port = defaultTLSPort
 	}
+	return &ProviderServer{iface: iface, port: port, network: DefaultNetwork}
+}
 
-	if network == "" {
-		network = DefaultNetwork
-	}
-
-	return &ProviderServer{iface: iface, port: port, network: string(network)}
+func (s *ProviderServer) SetNetwork(network ProviderNetwork) {
+	s.network = string(network)
 }
 
 func (s *ProviderServer) GetAddress() string {

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -45,12 +45,12 @@ func TestProviderServer_GetAddress(t *testing.T) {
 		},
 		{
 			desc:     "TCP4 with host and port",
-			server:   NewProviderServer("localhost", "4443", Tcp4Network),
+			server:   NewProviderServer("localhost", "4443", TCP4Network),
 			expected: "localhost:4443",
 		},
 		{
 			desc:     "TCP6 with host and port",
-			server:   NewProviderServer("localhost", "4443", Tcp6Network),
+			server:   NewProviderServer("localhost", "4443", TCP6Network),
 			expected: "localhost:4443",
 		},
 	}
@@ -119,7 +119,7 @@ func TestChallenge(t *testing.T) {
 	solver := NewChallenge(
 		core,
 		mockValidate,
-		&ProviderServer{port: "23457"},
+		&ProviderServer{port: "23457", network: DefaultNetwork},
 	)
 
 	authz := acme.Authorization{
@@ -147,7 +147,7 @@ func TestChallengeInvalidPort(t *testing.T) {
 	solver := NewChallenge(
 		core,
 		func(_ *api.Core, _ string, _ acme.Challenge) error { return nil },
-		&ProviderServer{port: "123456"},
+		&ProviderServer{port: "123456", network: DefaultNetwork},
 	)
 
 	authz := acme.Authorization{

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -26,31 +26,34 @@ func TestProviderServer_GetAddress(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		server   *ProviderServer
+		network  ProviderNetwork
 		expected string
 	}{
 		{
 			desc:     "TCP default address",
-			server:   NewProviderServer("", "", ""),
+			server:   NewProviderServer("", ""),
 			expected: ":443",
 		},
 		{
 			desc:     "TCP with explicit port",
-			server:   NewProviderServer("", "4443", ""),
+			server:   NewProviderServer("", "4443"),
 			expected: ":4443",
 		},
 		{
 			desc:     "TCP with host and port",
-			server:   NewProviderServer("localhost", "4443", ""),
+			server:   NewProviderServer("localhost", "4443"),
 			expected: "localhost:4443",
 		},
 		{
 			desc:     "TCP4 with host and port",
-			server:   NewProviderServer("localhost", "4443", TCP4Network),
+			server:   NewProviderServer("localhost", "4443"),
+			network:  TCP4Network,
 			expected: "localhost:4443",
 		},
 		{
 			desc:     "TCP6 with host and port",
-			server:   NewProviderServer("localhost", "4443", TCP6Network),
+			server:   NewProviderServer("localhost", "4443"),
+			network:  TCP6Network,
 			expected: "localhost:4443",
 		},
 	}
@@ -59,6 +62,10 @@ func TestProviderServer_GetAddress(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
+
+			if test.network != "" {
+				test.server.SetNetwork(test.network)
+			}
 
 			address := test.server.GetAddress()
 			assert.Equal(t, test.expected, address)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -8,6 +8,16 @@ import (
 
 func CreateFlags(defaultPath string) []cli.Flag {
 	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "ipv4only",
+			Aliases: []string{"4"},
+			Usage:   "Use IPv4 only. This flag is ignored if ipv6only is also specified.",
+		},
+		&cli.BoolFlag{
+			Name:    "ipv6only",
+			Aliases: []string{"6"},
+			Usage:   "Use IPv6 only. This flag is ignored if ipv4only is also specified.",
+		},
 		&cli.StringSliceFlag{
 			Name:    "domains",
 			Aliases: []string{"d"},

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -41,16 +41,21 @@ func setupChallenges(ctx *cli.Context, client *lego.Client) {
 	}
 }
 
-func setupHTTPProvider(ctx *cli.Context) challenge.Provider {
+func resolveHTTP01Network(ctx *cli.Context) http01.ProviderNetwork {
 	var network http01.ProviderNetwork
 	switch {
 	case ctx.IsSet("ipv4only") && ctx.IsSet("ipv6only"):
 		network = http01.DefaultNetwork
 	case ctx.IsSet("ipv4only"):
-		network = http01.Tcp4Network
+		network = http01.TCP4Network
 	case ctx.IsSet("ipv6only"):
-		network = http01.Tcp6Network
+		network = http01.TCP6Network
 	}
+	return network
+}
+
+func setupHTTPProvider(ctx *cli.Context) challenge.Provider {
+	network := resolveHTTP01Network(ctx)
 
 	switch {
 	case ctx.IsSet("http.webroot"):
@@ -99,9 +104,9 @@ func setupTLSProvider(ctx *cli.Context) challenge.Provider {
 	case ctx.IsSet("ipv4only") && ctx.IsSet("ipv6only"):
 		network = tlsalpn01.DefaultNetwork
 	case ctx.IsSet("ipv4only"):
-		network = tlsalpn01.Tcp4Network
+		network = tlsalpn01.TCP4Network
 	case ctx.IsSet("ipv6only"):
-		network = tlsalpn01.Tcp6Network
+		network = tlsalpn01.TCP6Network
 	}
 
 	switch {

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -81,13 +81,15 @@ func setupHTTPProvider(ctx *cli.Context) challenge.Provider {
 			log.Fatal(err)
 		}
 
-		srv := http01.NewProviderServer(host, port, network)
+		srv := http01.NewProviderServer(host, port)
+		srv.SetNetwork(network)
 		if header := ctx.String("http.proxy-header"); header != "" {
 			srv.SetProxyHeader(header)
 		}
 		return srv
 	case ctx.Bool("http"):
-		srv := http01.NewProviderServer("", "", network)
+		srv := http01.NewProviderServer("", "")
+		srv.SetNetwork(network)
 		if header := ctx.String("http.proxy-header"); header != "" {
 			srv.SetProxyHeader(header)
 		}
@@ -121,9 +123,13 @@ func setupTLSProvider(ctx *cli.Context) challenge.Provider {
 			log.Fatal(err)
 		}
 
-		return tlsalpn01.NewProviderServer(host, port, network)
+		srv := tlsalpn01.NewProviderServer(host, port)
+		srv.SetNetwork(network)
+		return srv
 	case ctx.Bool("tls"):
-		return tlsalpn01.NewProviderServer("", "", network)
+		srv := tlsalpn01.NewProviderServer("", "")
+		srv.SetNetwork(network)
+		return srv
 	default:
 		log.Fatal("Invalid HTTP challenge options.")
 		return nil

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -38,6 +38,8 @@ GLOBAL OPTIONS:
    --http.port value                                            Set the port and interface to use for HTTP based challenges to listen on.Supported: interface:port or :port. (default: ":80")
    --http.proxy-header value                                    Validate against this HTTP header when solving HTTP based challenges behind a reverse proxy. (default: "Host")
    --http.webroot value                                         Set the webroot folder to use for HTTP based challenges to write directly in a file in .well-known/acme-challenge. This disables the built-in server and expects the given directory to be publicly served with access to .well-known/acme-challenge
+   --ipv4only, -4                                               Use IPv4 only. This flag is ignored if ipv6only is also specified. (default: false)
+   --ipv6only, -6                                               Use IPv6 only. This flag is ignored if ipv4only is also specified. (default: false)
    --key-type value, -k value                                   Key type to use for private keys. Supported: rsa2048, rsa4096, rsa8192, ec256, ec384. (default: "ec256")
    --kid value                                                  Key identifier from External CA. Used for External Account Binding.
    --path value                                                 Directory to use for storing the data. (default: "./.lego") [$LEGO_PATH]

--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -212,7 +212,7 @@ func TestChallengeHTTP_Client_Obtain(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002"))
+	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002", ""))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -250,7 +250,7 @@ func TestChallengeHTTP_Client_Registration_QueryRegistration(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002"))
+	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002", ""))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -282,7 +282,7 @@ func TestChallengeTLS_Client_Obtain(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001"))
+	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001", ""))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -325,7 +325,7 @@ func TestChallengeTLS_Client_ObtainForCSR(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001"))
+	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001", ""))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})

--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -212,7 +212,7 @@ func TestChallengeHTTP_Client_Obtain(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002", ""))
+	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002"))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -250,7 +250,7 @@ func TestChallengeHTTP_Client_Registration_QueryRegistration(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002", ""))
+	err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", "5002"))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -282,7 +282,7 @@ func TestChallengeTLS_Client_Obtain(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001", ""))
+	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001"))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
@@ -325,7 +325,7 @@ func TestChallengeTLS_Client_ObtainForCSR(t *testing.T) {
 	client, err := lego.NewClient(config)
 	require.NoError(t, err)
 
-	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001", ""))
+	err = client.Challenge.SetTLSALPN01Provider(tlsalpn01.NewProviderServer("", "5001"))
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})

--- a/go.mod
+++ b/go.mod
@@ -71,8 +71,6 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
 
-require github.com/jsumners/go-getport v1.0.0
-
 require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/sacloud/iaas-api-go v1.3.2
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9
 	github.com/softlayer/softlayer-go v1.0.6
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.490
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.490
 	github.com/transip/gotransip/v6 v6.17.0
@@ -70,6 +70,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
+
+require github.com/jsumners/go-getport v1.0.0
 
 require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -117,8 +119,8 @@ require (
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 // indirect
 	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
-	github.com/spf13/cast v1.3.1 // indirect
-	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/spf13/cast v1.5.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.22.3 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -308,6 +309,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jsumners/go-getport v1.0.0 h1:d11eDaP25dKKoJRAFeBrchCayceft735pDSTFCEdkb4=
+github.com/jsumners/go-getport v1.0.0/go.mod h1:KpeJgwNSkpuXuoGhJ2Hgl5QJqWbLG1m0jY2rQsYUTIE=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=
@@ -515,8 +518,9 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -526,8 +530,9 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -535,8 +540,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.490 h1:mmz27tVi2r70JYnm5y0Zk8w0Qzsx+vfUw3oqSyrEfP8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.490/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jsumners/go-getport v1.0.0 h1:d11eDaP25dKKoJRAFeBrchCayceft735pDSTFCEdkb4=
-github.com/jsumners/go-getport v1.0.0/go.mod h1:KpeJgwNSkpuXuoGhJ2Hgl5QJqWbLG1m0jY2rQsYUTIE=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=


### PR DESCRIPTION
If completed, this PR will resolve #1801. At the moment I'm opening a draft PR to gauge interest in the overall proposal.

<details><summary>(outdated lint errors)</summary>

I do not understand these lint errors:

```
cmd/flags.go:12: File is not `gci`-ed with --skip-generated -s standard,default (gci)
                        Name: "ipv4only",
cmd/flags.go:14: File is not `gci`-ed with --skip-generated -s standard,default (gci)
                        Usage: "Use IPv4 only. This flag is ignored if ipv6only is also specified.",
cmd/flags.go:17: File is not `gci`-ed with --skip-generated -s standard,default (gci)
                        Name: "ipv6only",
cmd/flags.go:19: File is not `gci`-ed with --skip-generated -s standard,default (gci)
                        Usage: "Use IPv6 only. This flag is ignored if ipv4only is also specified.",
```

I do not know what "gci-ed" means.

I also don't understand this one because `recursiveNameservers` is also a global:

```
challenge/dns01/nameserver.go:31:5: networkStack is a global variable (gochecknoglobals)
var networkStack = "both"
```

I'm open to this not being a global if I can get some guidance on how it should be passed in from the CLI flags processing down to where the DNS query is actually invoked.

</details>

Items that remain:
- [x] Update https://github.com/go-acme/lego/blob/e982d5a77fb5263978eaf7ea2db24b0cb5ce46cf/cmd/setup_challenges.go#L44
- [x] Update https://github.com/go-acme/lego/blob/e982d5a77fb5263978eaf7ea2db24b0cb5ce46cf/cmd/setup_challenges.go#L86
