### PR TITLE
gcloud: add CLI example

### DIFF
--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -23,9 +23,16 @@ Configuration for [Google Cloud](https://cloud.google.com).
 - Since: v0.3.0
 
 
-{{% notice note %}}
-_Please contribute by adding a CLI example._
-{{% /notice %}}
+Here is an example bash command using the Google Cloud provider:
+
+```bash
+GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" lego \
+    --email="abc@email.com" \
+    --domains="example.com" \
+    --dns="gcloud" \
+    --path="${HOME}/.lego" \
+    run
+```
 
 
 

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -23,10 +23,15 @@ Configuration for [Google Cloud](https://cloud.google.com).
 - Since: v0.3.0
 
 
-{{% notice note %}}
-_Please contribute by adding a CLI example._
-{{% /notice %}}
-
+Here is an example bash command using the gcloud provider:
+```
+GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" lego \
+    --email="abc@email.com" \
+    --domains="example.com" \
+    --dns="gcloud" \
+    --path="${HOME}/.lego" \
+    run
+```
 
 
 

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -23,15 +23,10 @@ Configuration for [Google Cloud](https://cloud.google.com).
 - Since: v0.3.0
 
 
-Here is an example bash command using the gcloud provider:
-```
-GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" lego \
-    --email="abc@email.com" \
-    --domains="example.com" \
-    --dns="gcloud" \
-    --path="${HOME}/.lego" \
-    run
-```
+{{% notice note %}}
+_Please contribute by adding a CLI example._
+{{% /notice %}}
+
 
 
 

--- a/providers/dns/gcloud/gcloud.toml
+++ b/providers/dns/gcloud/gcloud.toml
@@ -4,7 +4,14 @@ URL = "https://cloud.google.com"
 Code = "gcloud"
 Since = "v0.3.0"
 
-Example = ''''''
+Example = '''
+GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" lego \
+    --email="abc@email.com" \
+    --domains="example.com" \
+    --dns="gcloud" \
+    --path="${HOME}/.lego" \
+    run
+'''
 
 [Configuration]
   [Configuration.Credentials]


### PR DESCRIPTION
[Document](https://go-acme.github.io/lego/dns/gcloud/) has note to add CLI example for provider: `glcoud` 

Adding example with this PR.