### PR TITLE
Fallback to TCP DNS challenge if UDP fails

### DIFF
--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -253,7 +253,7 @@ func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
 	udp := &dns.Client{Net: "udp", Timeout: dnsTimeout}
 	in, _, err := udp.Exchange(m, ns)
 
-	if in != nil && in.Truncated {
+	if err != nil || (in != nil && in.Truncated) {
 		tcp := &dns.Client{Net: "tcp", Timeout: dnsTimeout}
 		// If the TCP request succeeds, the err will reset to nil
 		in, _, err = tcp.Exchange(m, ns)


### PR DESCRIPTION
I'm currently in network where UDP DNS query doesn't work. Would be nice if library would fallback to TCP in this case. Or if we could configure it. Other people would appreciate this feature as well https://github.com/go-acme/lego/issues/1323#issuecomment-751387236