### PR TITLE
Experimental option to force DNS queries to use TCP

### DIFF
--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -250,6 +252,13 @@ func createDNSMsg(fqdn string, rtype uint16, recursive bool) *dns.Msg {
 }
 
 func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
+	if ok, _ := strconv.ParseBool(os.Getenv("LEGO_TCP_DNS_QUERY")); ok {
+		tcp := &dns.Client{Net: "tcp", Timeout: dnsTimeout}
+		in, _, err := tcp.Exchange(m, ns)
+
+		return in, err
+	}
+
 	udp := &dns.Client{Net: "udp", Timeout: dnsTimeout}
 	in, _, err := udp.Exchange(m, ns)
 

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -252,7 +252,7 @@ func createDNSMsg(fqdn string, rtype uint16, recursive bool) *dns.Msg {
 }
 
 func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
-	if ok, _ := strconv.ParseBool(os.Getenv("LEGO_TCP_DNS_QUERY")); ok {
+	if ok, _ := strconv.ParseBool(os.Getenv("LEGO_EXPERIMENTAL_DNS_TCP_ONLY")); ok {
 		tcp := &dns.Client{Net: "tcp", Timeout: dnsTimeout}
 		in, _, err := tcp.Exchange(m, ns)
 


### PR DESCRIPTION
Some networks block UDP packets. The ability to switch to TCP-only DNS queries will help a lot here.

`LEGO_EXPERIMENTAL_DNS_TCP_ONLY=true` to use TCP

https://community.traefik.io/t/docker-traefik-route53-dns-01-challenge-not-renewing-certificates/17463