### PR TITLE
Remove RSA 8192 - which LetsEncrypt does not support.

### DIFF
--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -25,8 +25,8 @@ const (
 	EC256   = KeyType("P256")
 	EC384   = KeyType("P384")
 	RSA2048 = KeyType("2048")
+	RSA3072 = KeyType("3072")
 	RSA4096 = KeyType("4096")
-	RSA8192 = KeyType("8192")
 )
 
 const (
@@ -121,10 +121,10 @@ func GeneratePrivateKey(keyType KeyType) (crypto.PrivateKey, error) {
 		return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	case RSA2048:
 		return rsa.GenerateKey(rand.Reader, 2048)
+	case RSA3072:
+		return rsa.GenerateKey(rand.Reader, 3072)
 	case RSA4096:
 		return rsa.GenerateKey(rand.Reader, 4096)
-	case RSA8192:
-		return rsa.GenerateKey(rand.Reader, 8192)
 	}
 
 	return nil, fmt.Errorf("invalid KeyType: %s", keyType)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -50,7 +50,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Name:    "key-type",
 			Aliases: []string{"k"},
 			Value:   "ec256",
-			Usage:   "Key type to use for private keys. Supported: rsa2048, rsa4096, rsa8192, ec256, ec384.",
+			Usage:   "Key type to use for private keys. Supported: rsa2048, rsa3072, rsa4096, ec256, ec384.",
 		},
 		&cli.StringFlag{
 			Name:  "filename",

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -65,10 +65,10 @@ func getKeyType(ctx *cli.Context) certcrypto.KeyType {
 	switch strings.ToUpper(keyType) {
 	case "RSA2048":
 		return certcrypto.RSA2048
+	case "RSA3072":
+		return certcrypto.RSA3072
 	case "RSA4096":
 		return certcrypto.RSA4096
-	case "RSA8192":
-		return certcrypto.RSA8192
 	case "EC256":
 		return certcrypto.EC256
 	case "EC384":

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -38,7 +38,7 @@ GLOBAL OPTIONS:
    --http.port value                                            Set the port and interface to use for HTTP based challenges to listen on.Supported: interface:port or :port. (default: ":80")
    --http.proxy-header value                                    Validate against this HTTP header when solving HTTP based challenges behind a reverse proxy. (default: "Host")
    --http.webroot value                                         Set the webroot folder to use for HTTP based challenges to write directly in a file in .well-known/acme-challenge. This disables the built-in server and expects the given directory to be publicly served with access to .well-known/acme-challenge
-   --key-type value, -k value                                   Key type to use for private keys. Supported: rsa2048, rsa4096, rsa8192, ec256, ec384. (default: "ec256")
+   --key-type value, -k value                                   Key type to use for private keys. Supported: rsa2048, rsa3072, rsa4096, ec256, ec384. (default: "ec256")
    --kid value                                                  Key identifier from External CA. Used for External Account Binding.
    --path value                                                 Directory to use for storing the data. (default: "./.lego") [$LEGO_PATH]
    --pem                                                        Generate a .pem file by concatenating the .key and .crt files together. (default: false)


### PR DESCRIPTION
Add RSA 3072 - which LetsEncrypt does support.

It seems safe to remove RSA8192 - even modified LEGO binaries for use with e.g. ZeroSSL cannot go above 3072. ZeroSSL supports max RSA3072.

Should fix issue #1854