### PR TITLE
chore: update Pebble

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,8 +54,11 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
           golangci-lint --version
 
-      - name: Install Pebble and challtestsrv
-        run: GO111MODULE=off go get -u github.com/letsencrypt/pebble/...
+      - name: Install Pebble
+        run: go install github.com/letsencrypt/pebble/v2/cmd/pebble@main
+
+      - name: Install challtestsrv
+        run: go install github.com/letsencrypt/pebble/v2/cmd/pebble-challtestsrv@main
 
       - name: Set up a Memcached server
         uses: niden/actions-memcached@v7

--- a/e2e/readme.md
+++ b/e2e/readme.md
@@ -13,7 +13,8 @@ How to run:
 
 - Install [Pebble](https://github.com/letsencrypt/pebble):
 ```bash
-go get -u github.com/letsencrypt/pebble/...
+go install github.com/letsencrypt/pebble/v2/cmd/pebble@main
+go install github.com/letsencrypt/pebble/v2/cmd/pebble-challtestsrv@main
 ```
 
 - Launch tests:


### PR DESCRIPTION
- use `go install` instead of `go get`
- use main branch of pebble