### PR TITLE
docs: Add ArchLinux package, fix AUR link

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -18,10 +18,16 @@ docker run goacme/lego -h
 
 ## From package managers
 
-- [ArchLinux (AUR)](https://aur.archlinux.org/packages/lego) (official):
+- [ArchLinux](https://archlinux.org/packages/community/x86_64/lego/) (official):
 
   ```bash
-  yay -S lego
+  pacman -S lego
+  ```
+
+- [ArchLinux (AUR)](https://aur.archlinux.org/packages/lego-bin) (official):
+
+  ```bash
+  yay -S lego-bin
   ```
 
 - [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):


### PR DESCRIPTION
- lego is available in the ArchLinux Community repository
- Updated outdated link to AUR package