### PR TITLE
rimuhosting: fix API base URL

### DIFF
--- a/providers/dns/internal/rimuhosting/client.go
+++ b/providers/dns/internal/rimuhosting/client.go
@@ -14,7 +14,7 @@ import (
 // Base URL for the RimuHosting DNS services.
 const (
 	DefaultZonomiBaseURL      = "https://zonomi.com/app/dns/dyndns.jsp"
-	DefaultRimuHostingBaseURL = "https://rimuhosting.com/app/dns/dyndns.jsp"
+	DefaultRimuHostingBaseURL = "https://rimuhosting.com/dns/dyndns.jsp"
 )
 
 // Action names.


### PR DESCRIPTION
The base URL seems to have changed or the URL was wrong since the creation of the provider.

https://rimuhosting.com/dns/dyndns.jsp

fixes #1880
