### PR TITLE
feat: add LEGO_CERT_PEM_PATH and LEGO_CERT_PFX_PATH to run hook

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -105,6 +105,8 @@ func run(ctx *cli.Context) error {
 		renewEnvCertDomain:   cert.Domain,
 		renewEnvCertPath:     certsStorage.GetFileName(cert.Domain, ".crt"),
 		renewEnvCertKeyPath:  certsStorage.GetFileName(cert.Domain, ".key"),
+		renewEnvCertPEMPath:  certsStorage.GetFileName(cert.Domain, ".pem"),
+		renewEnvCertPFXPath:  certsStorage.GetFileName(cert.Domain, ".pfx"),
 	}
 
 	return launchHook(ctx.String("run-hook"), meta)


### PR DESCRIPTION
Currently only the renew hook gets these variables set, this makes the behavior consistant for run hooks as well.

Fixes #1906