### PR TITLE
docs: fix `gdomains`→`googledomains`

### DIFF
--- a/docs/content/dns/zz_gen_googledomains.md
+++ b/docs/content/dns/zz_gen_googledomains.md
@@ -27,7 +27,7 @@ Here is an example bash command using the Google Domains provider:
 
 ```bash
 GOOGLE_DOMAINS_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-lego --email you@example.com --dns gdomains --domains my.example.org run
+lego --email you@example.com --dns googledomains --domains my.example.org run
 ```
 
 

--- a/providers/dns/googledomains/googledomains.toml
+++ b/providers/dns/googledomains/googledomains.toml
@@ -6,7 +6,7 @@ Since = "v4.11.0"
 
 Example = '''
 GOOGLE_DOMAINS_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-lego --email you@example.com --dns gdomains --domains my.example.org run
+lego --email you@example.com --dns googledomains --domains my.example.org run
 '''
 
 [Configuration]


### PR DESCRIPTION
The example for the Google Domains provider refers to a `gdomains` code, but it should be `googledomains`.