### PR TITLE
route53: minor correction to documentation

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2075,7 +2075,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "AWS_ACCESS_KEY_ID":	Managed by the AWS client. Access key ID ('AWS_ACCESS_KEY_ID_FILE' is not supported, use 'AWS_SHARED_CREDENTIALS_FILE' instead)`)
-		ew.writeln(`	- "AWS_ASSUME_ROLE_ARN":	Managed by the AWS Role ARN ('AWS_ASSUME_ROLE_ARN' is not supported)`)
+		ew.writeln(`	- "AWS_ASSUME_ROLE_ARN":	Managed by the AWS Role ARN ('AWS_ASSUME_ROLE_ARN_FILE' is not supported)`)
 		ew.writeln(`	- "AWS_HOSTED_ZONE_ID":	Override the hosted zone ID.`)
 		ew.writeln(`	- "AWS_PROFILE":	Managed by the AWS client ('AWS_PROFILE_FILE' is not supported)`)
 		ew.writeln(`	- "AWS_REGION":	Managed by the AWS client ('AWS_REGION_FILE' is not supported)`)

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -41,7 +41,7 @@ AWS_HOSTED_ZONE_ID=your_hosted_zone_id \
 | Environment Variable Name | Description |
 |-----------------------|-------------|
 | `AWS_ACCESS_KEY_ID` | Managed by the AWS client. Access key ID (`AWS_ACCESS_KEY_ID_FILE` is not supported, use `AWS_SHARED_CREDENTIALS_FILE` instead) |
-| `AWS_ASSUME_ROLE_ARN` | Managed by the AWS Role ARN (`AWS_ASSUME_ROLE_ARN` is not supported) |
+| `AWS_ASSUME_ROLE_ARN` | Managed by the AWS Role ARN (`AWS_ASSUME_ROLE_ARN_FILE` is not supported) |
 | `AWS_HOSTED_ZONE_ID` | Override the hosted zone ID. |
 | `AWS_PROFILE` | Managed by the AWS client (`AWS_PROFILE_FILE` is not supported) |
 | `AWS_REGION` | Managed by the AWS client (`AWS_REGION_FILE` is not supported) |

--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -129,7 +129,7 @@ Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with 
     AWS_HOSTED_ZONE_ID = "Override the hosted zone ID."
     AWS_PROFILE = "Managed by the AWS client (`AWS_PROFILE_FILE` is not supported)"
     AWS_SDK_LOAD_CONFIG = "Managed by the AWS client. Retrieve the region from the CLI config file (`AWS_SDK_LOAD_CONFIG_FILE` is not supported)"
-    AWS_ASSUME_ROLE_ARN = "Managed by the AWS Role ARN (`AWS_ASSUME_ROLE_ARN` is not supported)"
+    AWS_ASSUME_ROLE_ARN = "Managed by the AWS Role ARN (`AWS_ASSUME_ROLE_ARN_FILE` is not supported)"
   [Configuration.Additional]
     AWS_SHARED_CREDENTIALS_FILE = "Managed by the AWS client. Shared credentials file."
     AWS_MAX_RETRIES = "The number of maximum returns the service will use to make an individual API request"


### PR DESCRIPTION
Looks like the section that details the use of `AWS_ASSUME_ROLE_ARN` mentions that it can't be used in the configuration file, but it incorrectly repeats `AWS_ASSUME_ROLE_ARN` instead of mentioning `AWS_ASSUME_ROLE_ARN_FILE`.