### PR TITLE
route53: pass ExternalID property to STS:AssumeRole API operation

### DIFF
--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -130,6 +130,7 @@ Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with 
     AWS_PROFILE = "Managed by the AWS client (`AWS_PROFILE_FILE` is not supported)"
     AWS_SDK_LOAD_CONFIG = "Managed by the AWS client. Retrieve the region from the CLI config file (`AWS_SDK_LOAD_CONFIG_FILE` is not supported)"
     AWS_ASSUME_ROLE_ARN = "Managed by the AWS Role ARN (`AWS_ASSUME_ROLE_ARN_FILE` is not supported)"
+    AWS_EXTERNAL_ID = "Managed by STS AssumeRole API operation (`AWS_EXTERNAL_ID_FILE` is not supported)"
   [Configuration.Additional]
     AWS_SHARED_CREDENTIALS_FILE = "Managed by the AWS client. Shared credentials file."
     AWS_MAX_RETRIES = "The number of maximum returns the service will use to make an individual API request"


### PR DESCRIPTION
External ID property is useful when granting access to AWS resources to a third party : https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

Fixes #1919