### PR TITLE
autodns: fixes wrong zone in api call if CNAME is used

### DIFF
--- a/providers/dns/autodns/autodns.go
+++ b/providers/dns/autodns/autodns.go
@@ -122,8 +122,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		Value: info.Value,
 	}}
 
-	// TODO(ldez) replace domain by FQDN to follow CNAME.
-	_, err := d.client.AddTxtRecords(context.Background(), domain, records)
+	_, err := d.client.AddTxtRecords(context.Background(), info.EffectiveFQDN, records)
 	if err != nil {
 		return fmt.Errorf("autodns: %w", err)
 	}
@@ -142,8 +141,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		Value: info.Value,
 	}}
 
-	// TODO(ldez) replace domain by FQDN to follow CNAME.
-	if err := d.client.RemoveTXTRecords(context.Background(), domain, records); err != nil {
+	if err := d.client.RemoveTXTRecords(context.Background(), info.EffectiveFQDN, records); err != nil {
 		return fmt.Errorf("autodns: %w", err)
 	}
 


### PR DESCRIPTION
This fixes the problem that lego doesn't use the resolved FQDN from the CNAME in the API calls to AutoDNS.

Tested with CNAME, without CNAME on subdomans and root domains.