### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: '1.20'
-      GOLANGCI_LINT_VERSION: v1.52.2
+      GOLANGCI_LINT_VERSION: v1.53.1
       HUGO_VERSION: 0.54.0
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,11 +20,23 @@ linters-settings:
     ignore-words:
       - internetbs
   depguard:
-    list-type: denylist
-    include-go-root: false
-    packages:
-      - github.com/pkg/errors
-      - github.com/instana/testify
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/instana/testify"
+            desc: not allowed
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
+  tagalign:
+    align: false
+    order:
+      - xml
+      - json
+      - yaml
+      - yml
+      - toml
+      - mapstructure
+      - url
   godox:
     keywords:
       - FIXME
@@ -124,6 +136,7 @@ linters:
     - errchkjson
     - nonamedreturns
     - musttag # false-positive https://github.com/junk1tm/musttag/issues/17
+    - gosmopolitan  # not relevant
 
 issues:
   exclude-use-default: false

--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -117,7 +117,7 @@ func (a *Core) signedPost(uri string, content []byte, response interface{}) (*ht
 		return nil, fmt.Errorf("failed to post JWS message: failed to sign content: %w", err)
 	}
 
-	signedBody := bytes.NewBuffer([]byte(signedContent.FullSerialize()))
+	signedBody := bytes.NewBufferString(signedContent.FullSerialize())
 
 	resp, err := a.doer.Post(uri, signedBody, "application/jose+json", response)
 


### PR DESCRIPTION
Update golangci-lint to v1.53.1