### PR TITLE
cloudflare: update api client to v0.70.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.39.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/civo/civogo v0.3.11
-	github.com/cloudflare/cloudflare-go v0.49.0
+	github.com/cloudflare/cloudflare-go v0.69.0
 	github.com/cpu/goacmedns v0.1.1
 	github.com/dnsimple/dnsimple-go v1.2.0
 	github.com/exoscale/egoscale v0.100.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.39.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/civo/civogo v0.3.11
-	github.com/cloudflare/cloudflare-go v0.69.0
+	github.com/cloudflare/cloudflare-go v0.70.0
 	github.com/cpu/goacmedns v0.1.1
 	github.com/dnsimple/dnsimple-go v1.2.0
 	github.com/exoscale/egoscale v0.100.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/civo/civogo v0.3.11 h1:mON/fyrV946Sbk6paRtOSGsN+asCgCmHCgArf5xmGxM=
 github.com/civo/civogo v0.3.11/go.mod h1:7+GeeFwc4AYTULaEshpT2vIcl3Qq8HPoxA17viX3l6g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.69.0 h1:DHRjCQyM0p4qd3e0t3wnUNtRso1BQPUe4BtMAxZjKqY=
-github.com/cloudflare/cloudflare-go v0.69.0/go.mod h1:A6gZktcMokwEgzoAP4BbVDoUU7VorNFAU7FzfIejVF8=
+github.com/cloudflare/cloudflare-go v0.70.0 h1:4opGbUygM8DjirUuaz23jn3akuAcnOCEx+0nQtQEcFo=
+github.com/cloudflare/cloudflare-go v0.70.0/go.mod h1:VW6GuazkaZ4xEDkFt24lkXQUsE8q7BiGqDniC2s8WEM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/civo/civogo v0.3.11 h1:mON/fyrV946Sbk6paRtOSGsN+asCgCmHCgArf5xmGxM=
 github.com/civo/civogo v0.3.11/go.mod h1:7+GeeFwc4AYTULaEshpT2vIcl3Qq8HPoxA17viX3l6g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.49.0 h1:KqJYk/YQ5ZhmyYz1oa4kGDskfF1gVuZfqesaJ/XDLto=
-github.com/cloudflare/cloudflare-go v0.49.0/go.mod h1:h0QgcIZ3qEXwFiwfBO8sQxjVdYsLX+PfD7NFEnANaKg=
+github.com/cloudflare/cloudflare-go v0.69.0 h1:DHRjCQyM0p4qd3e0t3wnUNtRso1BQPUe4BtMAxZjKqY=
+github.com/cloudflare/cloudflare-go v0.69.0/go.mod h1:A6gZktcMokwEgzoAP4BbVDoUU7VorNFAU7FzfIejVF8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -134,7 +134,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("cloudflare: failed to find zone %s: %w", authZone, err)
 	}
 
-	dnsRecord := cloudflare.DNSRecord{
+	dnsRecord := cloudflare.CreateDNSRecordParams{
 		Type:    "TXT",
 		Name:    dns01.UnFqdn(info.EffectiveFQDN),
 		Content: info.Value,
@@ -146,15 +146,11 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("cloudflare: failed to create TXT record: %w", err)
 	}
 
-	if !response.Success {
-		return fmt.Errorf("cloudflare: failed to create TXT record: %+v %+v", response.Errors, response.Messages)
-	}
-
 	d.recordIDsMu.Lock()
-	d.recordIDs[token] = response.Result.ID
+	d.recordIDs[token] = response.ID
 	d.recordIDsMu.Unlock()
 
-	log.Infof("cloudflare: new record for %s, ID %s", domain, response.Result.ID)
+	log.Infof("cloudflare: new record for %s, ID %s", domain, response.ID)
 
 	return nil
 }

--- a/providers/dns/cloudflare/wrapper.go
+++ b/providers/dns/cloudflare/wrapper.go
@@ -59,8 +59,8 @@ func newClient(config *Config) (*metaClient, error) {
 	}, nil
 }
 
-func (m *metaClient) CreateDNSRecord(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
-	return m.clientEdit.CreateDNSRecord(ctx, zoneID, rr)
+func (m *metaClient) CreateDNSRecord(ctx context.Context, zoneID string, rr cloudflare.CreateDNSRecordParams) (cloudflare.DNSRecord, error) {
+	return m.clientEdit.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), rr)
 }
 
 func (m *metaClient) DNSRecords(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
@@ -68,7 +68,7 @@ func (m *metaClient) DNSRecords(ctx context.Context, zoneID string, rr cloudflar
 }
 
 func (m *metaClient) DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error {
-	return m.clientEdit.DeleteDNSRecord(ctx, zoneID, recordID)
+	return m.clientEdit.DeleteDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), recordID)
 }
 
 func (m *metaClient) ZoneIDByName(fdqn string) (string, error) {

--- a/providers/dns/cloudflare/wrapper.go
+++ b/providers/dns/cloudflare/wrapper.go
@@ -63,8 +63,8 @@ func (m *metaClient) CreateDNSRecord(ctx context.Context, zoneID string, rr clou
 	return m.clientEdit.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), rr)
 }
 
-func (m *metaClient) DNSRecords(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
-	return m.clientEdit.DNSRecords(ctx, zoneID, rr)
+func (m *metaClient) DNSRecords(ctx context.Context, zoneID string, rr cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error) {
+	return m.clientEdit.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(zoneID), rr)
 }
 
 func (m *metaClient) DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error {


### PR DESCRIPTION
I was having problems with lego yesterday - thought it might be because of the older `cloudflare-go` package.

Turns out - that wasn't it - it was API key shenanigans - but I thought maybe y'all would be interested in a library upgrade PR.

The tests pass:

```
=== RUN   TestNewDNSProvider
=== RUN   TestNewDNSProvider/success_email,_API_key
=== RUN   TestNewDNSProvider/success_API_token
=== RUN   TestNewDNSProvider/success_separate_API_tokens
=== RUN   TestNewDNSProvider/missing_credentials
=== RUN   TestNewDNSProvider/missing_email
=== RUN   TestNewDNSProvider/missing_api_key
--- PASS: TestNewDNSProvider (0.00s)
    --- PASS: TestNewDNSProvider/success_email,_API_key (0.00s)
    --- PASS: TestNewDNSProvider/success_API_token (0.00s)
    --- PASS: TestNewDNSProvider/success_separate_API_tokens (0.00s)
    --- PASS: TestNewDNSProvider/missing_credentials (0.00s)
    --- PASS: TestNewDNSProvider/missing_email (0.00s)
    --- PASS: TestNewDNSProvider/missing_api_key (0.00s)
=== RUN   TestNewDNSProviderWithToken
=== RUN   TestNewDNSProviderWithToken/same_client_when_zone_token_is_missing
=== RUN   TestNewDNSProviderWithToken/same_client_when_zone_token_equals_dns_token
=== RUN   TestNewDNSProviderWithToken/failure_when_only_zone_api_given
=== RUN   TestNewDNSProviderWithToken/different_clients_when_zone_and_dns_token_differ
=== RUN   TestNewDNSProviderWithToken/aliases_work_as_expected
--- PASS: TestNewDNSProviderWithToken (0.00s)
    --- PASS: TestNewDNSProviderWithToken/same_client_when_zone_token_is_missing (0.00s)
    --- PASS: TestNewDNSProviderWithToken/same_client_when_zone_token_equals_dns_token (0.00s)
    --- PASS: TestNewDNSProviderWithToken/failure_when_only_zone_api_given (0.00s)
    --- PASS: TestNewDNSProviderWithToken/different_clients_when_zone_and_dns_token_differ (0.00s)
    --- PASS: TestNewDNSProviderWithToken/aliases_work_as_expected (0.00s)
=== RUN   TestNewDNSProviderConfig
=== RUN   TestNewDNSProviderConfig/success_with_email_and_api_key
=== RUN   TestNewDNSProviderConfig/success_with_api_token
=== RUN   TestNewDNSProviderConfig/prefer_api_token
=== RUN   TestNewDNSProviderConfig/missing_credentials
=== RUN   TestNewDNSProviderConfig/missing_email
=== RUN   TestNewDNSProviderConfig/missing_api_key
=== RUN   TestNewDNSProviderConfig/missing_api_token,_fallback_to_api_key/email
--- PASS: TestNewDNSProviderConfig (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_with_email_and_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/success_with_api_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/prefer_api_token (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_credentials (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_email (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_key (0.00s)
    --- PASS: TestNewDNSProviderConfig/missing_api_token,_fallback_to_api_key/email (0.00s)
=== RUN   TestLivePresent
    cloudflare_test.go:270: skipping live test
--- SKIP: TestLivePresent (0.00s)
=== RUN   TestLiveCleanUp
    cloudflare_test.go:283: skipping live test
--- SKIP: TestLiveCleanUp (0.00s)
PASS
	github.com/go-acme/lego/v4/providers/dns/cloudflare	coverage: 36.0% of statements
ok  	github.com/go-acme/lego/v4/providers/dns/cloudflare	0.631s	coverage: 36.0% of statements
```

I ran and got a certificate:

```console
$ make build
BIN_OUTPUT: dist/lego
rm -rf dist/ builds/ cover.out
Version: d1c260a3f4bcaa94a726b5e977f58e7efa034118
go build -trimpath -ldflags '-X "main.version=d1c260a3f4bcaa94a726b5e977f58e7efa034118"' -o  dist/lego ./cmd/lego/
$ ~/bin/lego --version
lego version d1c260a3f4bcaa94a726b5e977f58e7efa034118 darwin/arm64
$ ~/bin/lego --email darron.froese@dapperlabs.com \
  --dns cloudflare \
  --domains "testing.dapper.services" \
  --domains "a.testing.dapper.services" \
  --domains "b.testing.dapper.services" \
  --domains "c.testing.dapper.services" run
2023/06/07 15:48:23 [INFO] [testing.dapper.services, a.testing.dapper.services, b.testing.dapper.services, c.testing.dapper.services] acme: Obtaining bundled SAN certificate
2023/06/07 15:48:24 [INFO] [a.testing.dapper.services] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/234835955367
2023/06/07 15:48:24 [INFO] [b.testing.dapper.services] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/234835955377
2023/06/07 15:48:24 [INFO] [c.testing.dapper.services] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/234835955387
2023/06/07 15:48:24 [INFO] [testing.dapper.services] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/234835955397
2023/06/07 15:48:24 [INFO] [a.testing.dapper.services] acme: Could not find solver for: tls-alpn-01
2023/06/07 15:48:24 [INFO] [a.testing.dapper.services] acme: Could not find solver for: http-01
2023/06/07 15:48:24 [INFO] [a.testing.dapper.services] acme: use dns-01 solver
2023/06/07 15:48:24 [INFO] [b.testing.dapper.services] acme: Could not find solver for: tls-alpn-01
2023/06/07 15:48:24 [INFO] [b.testing.dapper.services] acme: Could not find solver for: http-01
2023/06/07 15:48:24 [INFO] [b.testing.dapper.services] acme: use dns-01 solver
2023/06/07 15:48:24 [INFO] [testing.dapper.services] acme: Could not find solver for: tls-alpn-01
2023/06/07 15:48:24 [INFO] [testing.dapper.services] acme: Could not find solver for: http-01
2023/06/07 15:48:24 [INFO] [testing.dapper.services] acme: use dns-01 solver
2023/06/07 15:48:24 [INFO] [c.testing.dapper.services] acme: Could not find solver for: tls-alpn-01
2023/06/07 15:48:24 [INFO] [c.testing.dapper.services] acme: Could not find solver for: http-01
2023/06/07 15:48:24 [INFO] [c.testing.dapper.services] acme: use dns-01 solver
2023/06/07 15:48:24 [INFO] [a.testing.dapper.services] acme: Preparing to solve DNS-01
2023/06/07 15:48:24 [INFO] cloudflare: new record for a.testing.dapper.services, ID 54004c24a57d045e921119286f57b106
2023/06/07 15:48:24 [INFO] [b.testing.dapper.services] acme: Preparing to solve DNS-01
2023/06/07 15:48:24 [INFO] cloudflare: new record for b.testing.dapper.services, ID 648699ac06cc42c66bb329fbe84951b3
2023/06/07 15:48:24 [INFO] [testing.dapper.services] acme: Preparing to solve DNS-01
2023/06/07 15:48:25 [INFO] cloudflare: new record for testing.dapper.services, ID 372931330dfe9da28dbcebaae057a8dc
2023/06/07 15:48:25 [INFO] [c.testing.dapper.services] acme: Preparing to solve DNS-01
2023/06/07 15:48:25 [INFO] cloudflare: new record for c.testing.dapper.services, ID 12d0a24e985d55e5884c2c8207788b85
2023/06/07 15:48:25 [INFO] [a.testing.dapper.services] acme: Trying to solve DNS-01
2023/06/07 15:48:25 [INFO] [a.testing.dapper.services] acme: Checking DNS record propagation using [10.255.0.1:53]
2023/06/07 15:48:27 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2023/06/07 15:48:52 [INFO] [a.testing.dapper.services] The server validated our request
2023/06/07 15:48:52 [INFO] [b.testing.dapper.services] acme: Trying to solve DNS-01
2023/06/07 15:48:52 [INFO] [b.testing.dapper.services] acme: Checking DNS record propagation using [10.255.0.1:53]
2023/06/07 15:48:54 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2023/06/07 15:48:58 [INFO] [b.testing.dapper.services] The server validated our request
2023/06/07 15:48:58 [INFO] [testing.dapper.services] acme: Trying to solve DNS-01
2023/06/07 15:48:58 [INFO] [testing.dapper.services] acme: Checking DNS record propagation using [10.255.0.1:53]
2023/06/07 15:49:00 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2023/06/07 15:49:08 [INFO] [testing.dapper.services] The server validated our request
2023/06/07 15:49:08 [INFO] [c.testing.dapper.services] acme: Trying to solve DNS-01
2023/06/07 15:49:08 [INFO] [c.testing.dapper.services] acme: Checking DNS record propagation using [10.255.0.1:53]
2023/06/07 15:49:10 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2023/06/07 15:49:16 [INFO] [c.testing.dapper.services] The server validated our request
2023/06/07 15:49:16 [INFO] [a.testing.dapper.services] acme: Cleaning DNS-01 challenge
2023/06/07 15:49:16 [INFO] [b.testing.dapper.services] acme: Cleaning DNS-01 challenge
2023/06/07 15:49:16 [INFO] [testing.dapper.services] acme: Cleaning DNS-01 challenge
2023/06/07 15:49:17 [INFO] [c.testing.dapper.services] acme: Cleaning DNS-01 challenge
2023/06/07 15:49:17 [INFO] [testing.dapper.services, a.testing.dapper.services, b.testing.dapper.services, c.testing.dapper.services] acme: Validations succeeded; requesting certificates
2023/06/07 15:49:17 [INFO] [testing.dapper.services] Server responded with a certificate.
```