### PR TITLE
fix: read status code from response

### DIFF
--- a/acme/api/internal/sender/sender.go
+++ b/acme/api/internal/sender/sender.go
@@ -133,6 +133,10 @@ func checkError(req *http.Request, resp *http.Response) error {
 		errorDetails.Method = req.Method
 		errorDetails.URL = req.URL.String()
 
+		if errorDetails.HTTPStatus == 0 {
+			errorDetails.HTTPStatus = resp.StatusCode
+		}
+
 		// Check for errors we handle specifically
 		if errorDetails.HTTPStatus == http.StatusBadRequest && errorDetails.Type == acme.BadNonceErr {
 			return &acme.NonceError{ProblemDetails: errorDetails}


### PR DESCRIPTION
Currently, the badNonce error handling relies on the status field in the problem object .  
From my understanding of the Problem Object spec ([rfc7807](https://datatracker.ietf.org/doc/html/rfc7807#section-3.1)), the status field is not necessarily required.  

This change uses the response status code if the problem object does not contain the status field.  

