### PR TITLE
fix: ARI explanationURL

### DIFF
--- a/acme/commons.go
+++ b/acme/commons.go
@@ -325,7 +325,7 @@ type RenewalInfoResponse struct {
 	//	For example, it may be a page explaining the CA's dynamic load-balancing strategy,
 	//	or a page documenting which certificates are affected by a mass revocation event.
 	//	Callers SHOULD provide this URL to their operator, if present.
-	ExplanationURL string `json:"explanationUrl"`
+	ExplanationURL string `json:"explanationURL"`
 }
 
 // RenewalInfoUpdateRequest is the JWS payload for POST requests made to the renewalInfo endpoint.


### PR DESCRIPTION
 I detected a variation from the RFC: the RFC says `explanationURL` instead of `explanationUrl`.

`explanationURL` follows the same naming rule (commons Go initialism) as `certID`.

https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#section-4.1
https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#section-4.2

Related to #1912