### PR TITLE
fix: ensure case-insensitive comparison of CNAME records

### DIFF
--- a/challenge/dns01/cname.go
+++ b/challenge/dns01/cname.go
@@ -1,12 +1,16 @@
 package dns01
 
-import "github.com/miekg/dns"
+import (
+	"strings"
+
+	"github.com/miekg/dns"
+)
 
 // Update FQDN with CNAME if any.
 func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 	for _, rr := range r.Answer {
 		if cn, ok := rr.(*dns.CNAME); ok {
-			if cn.Hdr.Name == fqdn {
+			if strings.EqualFold(cn.Hdr.Name, fqdn) {
 				return cn.Target
 			}
 		}

--- a/challenge/dns01/cname_test.go
+++ b/challenge/dns01/cname_test.go
@@ -8,22 +8,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCnameCaseInsensitive(t *testing.T) {
-	const qname = "_acme-challenge.uppercase-test.example.com."
-	const cnameTarget = "_acme-challenge.uppercase-test.cname-target.example.com."
-	msg := new(dns.Msg)
-	msg.Authoritative = true
-	msg.Answer = []dns.RR{
-		&dns.CNAME{
-			Hdr: dns.RR_Header{
-				Name:   strings.ToUpper(qname), // CNAME names are case-insensitive
-				Rrtype: dns.TypeCNAME,
-				Class:  dns.ClassINET,
-				Ttl:    3600,
+func Test_updateDomainWithCName_caseInsensitive(t *testing.T) {
+	qname := "_acme-challenge.uppercase-test.example.com."
+	cnameTarget := "_acme-challenge.uppercase-test.cname-target.example.com."
+
+	msg := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Authoritative: true,
+		},
+		Answer: []dns.RR{
+			&dns.CNAME{
+				Hdr: dns.RR_Header{
+					Name:   strings.ToUpper(qname), // CNAME names are case-insensitive
+					Rrtype: dns.TypeCNAME,
+					Class:  dns.ClassINET,
+					Ttl:    3600,
+				},
+				Target: cnameTarget,
 			},
-			Target: cnameTarget,
 		},
 	}
+
 	fqdn := updateDomainWithCName(msg, qname)
+
 	assert.Equal(t, cnameTarget, fqdn)
 }

--- a/challenge/dns01/cname_test.go
+++ b/challenge/dns01/cname_test.go
@@ -1,0 +1,29 @@
+package dns01
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCnameCaseInsensitive(t *testing.T) {
+	const qname = "_acme-challenge.uppercase-test.example.com."
+	const cnameTarget = "_acme-challenge.uppercase-test.cname-target.example.com."
+	msg := new(dns.Msg)
+	msg.Authoritative = true
+	msg.Answer = []dns.RR{
+		&dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name:   strings.ToUpper(qname), // CNAME names are case-insensitive
+				Rrtype: dns.TypeCNAME,
+				Class:  dns.ClassINET,
+				Ttl:    3600,
+			},
+			Target: cnameTarget,
+		},
+	}
+	fqdn := updateDomainWithCName(msg, qname)
+	assert.Equal(t, cnameTarget, fqdn)
+}


### PR DESCRIPTION
Fixes #1955 

Changes:

- Modified the `updateDomainWithCName` function in `cname.go` to use a case-insensitive comparison (`strings.EqualFold`). This allows the function to correctly identify the CNAME records irrespective of case.

- Added a new unit test `TestCnameCaseInsensitive` in `cname_test.go` to validate that the `updateDomainWithCName` function works correctly when the DNS record is in uppercase.