### PR TITLE
Prepare release v4.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,22 @@ jobs:
       CGO_ENABLED: 0
 
     steps:
+
+      # https://github.com/marketplace/actions/free-disk-space-ubuntu
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed
+          tool-cache: false
+
+          # all of these default to true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Check out code
         uses: actions/checkout@v3
         with:

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -10,5 +10,5 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -5,10 +5,10 @@ package sender
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme/4.13.0"
+	ourUserAgent = "xenolf-acme/4.13.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )


### PR DESCRIPTION
During the release of v4.12.2 a problem about "no space left on device" appears for the first time https://github.com/go-acme/lego/actions/runs/5313815049
The problem happens during the build of the binaries: Go creates a lot a small artifacts during a build.

I was thinking that it's not really related to disk space but to inode, so I decreased the number of concurrent builds to 1.
And this fixed the problem for v4.12.3.
https://github.com/go-acme/lego/actions/runs/5316467651

Now the problem happens again with v4.13.0, I still think it's related to inode and the build artifacts.
https://github.com/go-acme/lego/actions/runs/5609596730/jobs/10263519288

I added a new step to the release process: [free-disk-space-ubuntu](https://github.com/marketplace/actions/free-disk-space-ubuntu).

Before the step:
```console
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   61G   23G  73% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt
tmpfs           694M   12K  694M   1% /run/user/1001
```

After the step:
```console
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   38G   46G  46% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt
tmpfs           694M   12K  694M   1% /run/user/1001
```

I tried the release flow (with `--snapshot --skip-publish`) on my fork and this seems to work.
https://github.com/ldez/lego/actions/runs/5610504773/jobs/10265562181

Note: every try take about 50 min and there is no real debug access for GitHub action, it's a painful process to debug this.
