### PR TITLE
servercow: fix regression

### DIFF
--- a/providers/dns/servercow/internal/client.go
+++ b/providers/dns/servercow/internal/client.go
@@ -149,9 +149,8 @@ func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, paylo
 
 	req.Header.Set("Accept", "application/json")
 
-	if payload != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
+	// Content-Type should be added even if there is no request body.
+	req.Header.Set("Content-Type", "application/json")
 
 	return req, nil
 }


### PR DESCRIPTION
Fixes #1963

servercow doesn't seem to follow the standard about `Content-Type` header.

> Likewise, the "Content-Type" is explicitly specified here as "application/json"!
> --- https://cp.servercow.de/client/plugin/support_manager/knowledgebase/view/34/dns-api-v1/7/
