### PR TITLE
 chore: update to go1.20

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.20'
+      GO_VERSION: stable
       HUGO_VERSION: '0.117.0'
       CGO_ENABLED: 0
 

--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -20,33 +20,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      # https://github.com/marketplace/actions/setup-go-environment
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go-version }}
-
       # https://github.com/marketplace/actions/checkout
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Go modules
-        uses: actions/cache@v3
+      # https://github.com/marketplace/actions/setup-go-environment
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
         with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.go-version }}-go-
+          go-version: ${{ matrix.go-version }}
 
       - name: Test
         run: go test -v -cover ./...

--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ '1.19', '1.20', 1.x ]
+        go-version: [ stable, oldstable ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,8 @@ jobs:
     name: Main Process
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.20'
-      GOLANGCI_LINT_VERSION: v1.53.1
+      GO_VERSION: stable
+      GOLANGCI_LINT_VERSION: v1.54.1
       HUGO_VERSION: '0.117.0'
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,26 +21,17 @@ jobs:
 
     steps:
 
-      # https://github.com/marketplace/actions/setup-go-environment
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       # https://github.com/marketplace/actions/checkout
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Go modules
-        uses: actions/cache@v3
+      # https://github.com/marketplace/actions/setup-go-environment
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Check and get dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release version
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.20'
+      GO_VERSION: stable
       CGO_ENABLED: 0
 
     steps:

--- a/certificate/errors_test.go
+++ b/certificate/errors_test.go
@@ -1,0 +1,70 @@
+package certificate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TomatoError struct{}
+
+func (t TomatoError) Error() string {
+	return "tomato"
+}
+
+type CarrotError struct{}
+
+func (t CarrotError) Error() string {
+	return "carrot"
+}
+
+func Test_obtainError_Join(t *testing.T) {
+	failures := newObtainError()
+
+	failures.Add("example.com", &TomatoError{})
+
+	err := failures.Join()
+
+	to := &TomatoError{}
+	assert.ErrorAs(t, err, &to)
+}
+
+func Test_obtainError_Join_multiple_domains(t *testing.T) {
+	failures := newObtainError()
+
+	failures.Add("example.com", &TomatoError{})
+	failures.Add("example.org", &CarrotError{})
+
+	err := failures.Join()
+
+	to := &TomatoError{}
+	assert.ErrorAs(t, err, &to)
+
+	ca := &CarrotError{}
+	assert.ErrorAs(t, err, &ca)
+}
+
+func Test_obtainError_Join_no_error(t *testing.T) {
+	failures := newObtainError()
+
+	assert.NoError(t, failures.Join())
+}
+
+func Test_obtainError_Join_same_domain(t *testing.T) {
+	failures := newObtainError()
+
+	failures.Add("example.com", &TomatoError{})
+	failures.Add("example.com", &CarrotError{})
+
+	err := failures.Join()
+
+	to := &TomatoError{}
+	if errors.As(err, &to) {
+		require.Fail(t, "TomatoError should be overridden by CarrotError")
+	}
+
+	ca := &CarrotError{}
+	assert.ErrorAs(t, err, &ca)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-acme/lego/v4
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/providers/dns/allinkl/internal/types_api.go
+++ b/providers/dns/allinkl/internal/types_api.go
@@ -54,7 +54,7 @@ type DNSRequest struct {
 // ---
 
 type GetDNSSettingsAPIResponse struct {
-	Response GetDNSSettingsResponse `json:"Response"  mapstructure:"Response"`
+	Response GetDNSSettingsResponse `json:"Response" mapstructure:"Response"`
 }
 
 type GetDNSSettingsResponse struct {

--- a/providers/dns/ipv64/internal/client_test.go
+++ b/providers/dns/ipv64/internal/client_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testAPIKey = "secret"
+
 func setupTest(t *testing.T, handler http.HandlerFunc) *Client {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
 
-	client := NewClient("secret")
+	client := NewClient(OAuthStaticAccessToken(server.Client(), testAPIKey))
 	client.HTTPClient = server.Client()
 	client.baseURL, _ = url.Parse(server.URL)
 
@@ -34,8 +36,8 @@ func testHandler(method, filename string, statusCode int) http.HandlerFunc {
 			return
 		}
 
-		auth := req.Header.Get(authorizationHeader)
-		if auth != "Bearer secret" {
+		auth := req.Header.Get("Authorization")
+		if auth != "Bearer "+testAPIKey {
 			http.Error(rw, fmt.Sprintf("invalid API key: %s", auth), http.StatusUnauthorized)
 			return
 		}

--- a/providers/dns/ipv64/ipv64.go
+++ b/providers/dns/ipv64/ipv64.go
@@ -78,7 +78,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("ipv64: credentials missing")
 	}
 
-	client := internal.NewClient(config.APIKey)
+	client := internal.NewClient(internal.OAuthStaticAccessToken(config.HTTPClient, config.APIKey))
 
 	if config.HTTPClient != nil {
 		client.HTTPClient = config.HTTPClient


### PR DESCRIPTION
- updates CI to use go1.20 and go1.21: uses the aliases `stable` and `oldstable` to avoid updating the branch protection each time there is a Go update.
- uses `errors.Join` to improve `obtainError`


https://tip.golang.org/doc/go1.20

Fixes #793
