### PR TITLE
doc: retrieve hugo-theme-learn as hugo module

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,15 +6,9 @@ clean:
 	rm -rf public/
 
 
-hugo-build: clean hugo-themes
+hugo-build: clean
 	hugo --enableGitInfo --source .
 
 hugo:
 	hugo server --disableFastRender --enableGitInfo --watch --source .
 	# hugo server -D
-
-hugo-themes:
-	rm -rf themes
-	mkdir themes
-	git clone --depth=1 https://github.com/matcornic/hugo-theme-learn.git themes/hugo-theme-learn
-	rm -rf themes/hugo-theme-learn/.git

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-acme/lego/docs
+
+go 1.20
+
+require github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,0 +1,2 @@
+github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d h1:p7ktiW/GnHccjB9oO5YGY7us5v/oHmkyF0C7EDZFM3s=
+github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d/go.mod h1:YoToDcvQxmAFhpEuapKUysBDEBckqDEssqTrmeZ2+uY=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -2,8 +2,6 @@ baseURL = "https://go-acme.github.io/lego/"
 languageCode = "en-us"
 title = "Lego"
 
-theme = "hugo-theme-learn"
-
 # Code highlighting settings
 pygmentsCodefences = true
 pygmentsCodeFencesGuesSsyntax = false
@@ -72,3 +70,7 @@ pygmentsUseClasses = true
 
 [outputs]
   home = [ "HTML", "RSS", "JSON"]
+
+[module]
+[[module.imports]]
+  path = "github.com/matcornic/hugo-theme-learn"


### PR DESCRIPTION
This PR changes: the way the documentation is created: `hugo-theme-learn` ist now pulled in as hugo module. This is the newer and more elegant way to use hugo theme components.