### PR TITLE
pdns: optional custom API version

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2078,7 +2078,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
-		ew.writeln(`	- "PDNS_CUSTOM_API_VERSION":	Skip API version autodetection and use custom version number.`)
+		ew.writeln(`	- "PDNS_API_VERSION":	Skip API version autodetection and use the provided version number.`)
 		ew.writeln(`	- "PDNS_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "PDNS_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "PDNS_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2078,6 +2078,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "PDNS_CUSTOM_API_VERSION":	Skip API version autodetection and use custom version number.`)
 		ew.writeln(`	- "PDNS_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "PDNS_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "PDNS_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)

--- a/docs/content/dns/zz_gen_pdns.md
+++ b/docs/content/dns/zz_gen_pdns.md
@@ -49,7 +49,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `PDNS_CUSTOM_API_VERSION` | Skip API version autodetection and use custom version number. |
+| `PDNS_API_VERSION` | Skip API version autodetection and use the provided version number. |
 | `PDNS_HTTP_TIMEOUT` | API request timeout |
 | `PDNS_POLLING_INTERVAL` | Time between DNS propagation check |
 | `PDNS_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
@@ -66,7 +66,7 @@ Tested and confirmed to work with PowerDNS authoritative server 3.4.8 and 4.0.1.
 PowerDNS Notes:
 - PowerDNS API does not currently support SSL, therefore you should take care to ensure that traffic between lego and the PowerDNS API is over a trusted network, VPN etc.
 - In order to have the SOA serial automatically increment each time the `_acme-challenge` record is added/modified via the API, set `SOA-EDIT-API` to `INCEPTION-INCREMENT` for the zone in the `domainmetadata` table
-- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_CUSTOM_API_VERSION`.
+- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_API_VERSION`.
 
 
 

--- a/docs/content/dns/zz_gen_pdns.md
+++ b/docs/content/dns/zz_gen_pdns.md
@@ -49,6 +49,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `PDNS_CUSTOM_API_VERSION` | Skip API version autodetection and use custom version number. |
 | `PDNS_HTTP_TIMEOUT` | API request timeout |
 | `PDNS_POLLING_INTERVAL` | Time between DNS propagation check |
 | `PDNS_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
@@ -65,6 +66,7 @@ Tested and confirmed to work with PowerDNS authoritative server 3.4.8 and 4.0.1.
 PowerDNS Notes:
 - PowerDNS API does not currently support SSL, therefore you should take care to ensure that traffic between lego and the PowerDNS API is over a trusted network, VPN etc.
 - In order to have the SOA serial automatically increment each time the `_acme-challenge` record is added/modified via the API, set `SOA-EDIT-API` to `INCEPTION-INCREMENT` for the zone in the `domainmetadata` table
+- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_CUSTOM_API_VERSION`.
 
 
 

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -82,7 +82,7 @@ USAGE:
 
 OPTIONS:
    --days value                              The number of days left on a certificate to renew it. (default: 0)
-   --ari-enable                              Use the renewalInfo endpoint (draft-ietf-acme-ari-02) to check if a certificate should be renewed. (default: false)
+   --ari-enable                              Use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed. (default: false)
    --ari-wait-to-renew-duration value        The maximum duration you're willing to sleep for a renewal time returned by the renewalInfo endpoint. (default: 0s)
    --reuse-key                               Used to indicate you want to reuse your current private key for the new certificate. (default: false)
    --no-bundle                               Do not create a certificate bundle by adding the issuers certificate to the new certificate. (default: false)

--- a/providers/dns/pdns/internal/client.go
+++ b/providers/dns/pdns/internal/client.go
@@ -30,10 +30,11 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(host *url.URL, serverName string, apiKey string) *Client {
+func NewClient(host *url.URL, serverName string, apiVersion int, apiKey string) *Client {
 	return &Client{
 		serverName: serverName,
 		apiKey:     apiKey,
+		apiVersion: apiVersion,
 		Host:       host,
 		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}
@@ -41,10 +42,6 @@ func NewClient(host *url.URL, serverName string, apiKey string) *Client {
 
 func (c *Client) APIVersion() int {
 	return c.apiVersion
-}
-
-func (c *Client) SetCustomAPIVersion(version int) {
-	c.apiVersion = version
 }
 
 func (c *Client) SetAPIVersion(ctx context.Context) error {

--- a/providers/dns/pdns/internal/client.go
+++ b/providers/dns/pdns/internal/client.go
@@ -43,6 +43,10 @@ func (c *Client) APIVersion() int {
 	return c.apiVersion
 }
 
+func (c *Client) SetCustomAPIVersion(version int) {
+	c.apiVersion = version
+}
+
 func (c *Client) SetAPIVersion(ctx context.Context) error {
 	var err error
 

--- a/providers/dns/pdns/internal/client_test.go
+++ b/providers/dns/pdns/internal/client_test.go
@@ -57,7 +57,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 
 	serverURL, _ := url.Parse(server.URL)
 
-	client := NewClient(serverURL, "server", "secret")
+	client := NewClient(serverURL, "server", 0, "secret")
 	client.HTTPClient = server.Client()
 
 	return client
@@ -151,8 +151,7 @@ func TestClient_joinPath(t *testing.T) {
 			host, err := url.Parse(test.baseURL)
 			require.NoError(t, err)
 
-			client := NewClient(host, "test", "secret")
-			client.apiVersion = test.apiVersion
+			client := NewClient(host, "test", test.apiVersion, "secret")
 
 			endpoint := client.joinPath(test.uri)
 

--- a/providers/dns/pdns/pdns.go
+++ b/providers/dns/pdns/pdns.go
@@ -38,7 +38,7 @@ type Config struct {
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
 	TTL                int
-	CustomApiVersion   int
+	CustomAPIVersion   int
 	HTTPClient         *http.Client
 }
 
@@ -46,7 +46,7 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		CustomApiVersion:   env.GetOrDefaultInt(EnvCustomAPIVersion, 0),
+		CustomAPIVersion:   env.GetOrDefaultInt(EnvCustomAPIVersion, 0),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 2*time.Second),
 		ServerName:         env.GetOrDefaultString(EnvServerName, "localhost"),
@@ -99,9 +99,9 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client := internal.NewClient(config.Host, config.ServerName, config.APIKey)
 
-	if config.CustomApiVersion > 0 {
-		client.SetCustomAPIVersion(config.CustomApiVersion)
-		log.Infof("pdns: using custom API version %d", config.CustomApiVersion)
+	if config.CustomAPIVersion > 0 {
+		client.SetCustomAPIVersion(config.CustomAPIVersion)
+		log.Infof("pdns: using custom API version %d", config.CustomAPIVersion)
 	} else {
 		err := client.SetAPIVersion(context.Background())
 		if err != nil {

--- a/providers/dns/pdns/pdns.toml
+++ b/providers/dns/pdns/pdns.toml
@@ -18,6 +18,7 @@ Tested and confirmed to work with PowerDNS authoritative server 3.4.8 and 4.0.1.
 PowerDNS Notes:
 - PowerDNS API does not currently support SSL, therefore you should take care to ensure that traffic between lego and the PowerDNS API is over a trusted network, VPN etc.
 - In order to have the SOA serial automatically increment each time the `_acme-challenge` record is added/modified via the API, set `SOA-EDIT-API` to `INCEPTION-INCREMENT` for the zone in the `domainmetadata` table
+- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_CUSTOM_API_VERSION`.
 '''
 
 [Configuration]
@@ -30,6 +31,7 @@ PowerDNS Notes:
     PDNS_TTL = "The TTL of the TXT record used for the DNS challenge"
     PDNS_HTTP_TIMEOUT = "API request timeout"
     PDNS_SERVER_NAME = "Name of the server in the URL, 'localhost' by default"
+    PDNS_CUSTOM_API_VERSION = "Skip API version autodetection and use custom version number."
 
 [Links]
   API = "https://doc.powerdns.com/md/httpapi/README/"

--- a/providers/dns/pdns/pdns.toml
+++ b/providers/dns/pdns/pdns.toml
@@ -18,7 +18,7 @@ Tested and confirmed to work with PowerDNS authoritative server 3.4.8 and 4.0.1.
 PowerDNS Notes:
 - PowerDNS API does not currently support SSL, therefore you should take care to ensure that traffic between lego and the PowerDNS API is over a trusted network, VPN etc.
 - In order to have the SOA serial automatically increment each time the `_acme-challenge` record is added/modified via the API, set `SOA-EDIT-API` to `INCEPTION-INCREMENT` for the zone in the `domainmetadata` table
-- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_CUSTOM_API_VERSION`.
+- Some PowerDNS servers doesn't have root API endpoints enabled and API version autodetection will not work. In that case version number can be defined using `PDNS_API_VERSION`.
 '''
 
 [Configuration]
@@ -26,12 +26,12 @@ PowerDNS Notes:
     PDNS_API_KEY = "API key"
     PDNS_API_URL = "API URL"
   [Configuration.Additional]
+    PDNS_SERVER_NAME = "Name of the server in the URL, 'localhost' by default"
+    PDNS_API_VERSION = "Skip API version autodetection and use the provided version number."
     PDNS_POLLING_INTERVAL = "Time between DNS propagation check"
     PDNS_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     PDNS_TTL = "The TTL of the TXT record used for the DNS challenge"
     PDNS_HTTP_TIMEOUT = "API request timeout"
-    PDNS_SERVER_NAME = "Name of the server in the URL, 'localhost' by default"
-    PDNS_CUSTOM_API_VERSION = "Skip API version autodetection and use custom version number."
 
 [Links]
   API = "https://doc.powerdns.com/md/httpapi/README/"

--- a/providers/dns/pdns/pdns_test.go
+++ b/providers/dns/pdns/pdns_test.go
@@ -85,31 +85,22 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		{
 			desc:   "success",
 			apiKey: "123",
-			host: func() *url.URL {
-				u, _ := url.Parse("http://example.com")
-				return u
-			}(),
+			host:   mustParse("http://example.com"),
 		},
 		{
 			desc:             "success custom API version",
 			apiKey:           "123",
 			customAPIVersion: 1,
-			host: func() *url.URL {
-				u, _ := url.Parse("http://example.com")
-				return u
-			}(),
+			host:             mustParse("http://example.com"),
 		},
 		{
 			desc:     "missing credentials",
 			expected: "pdns: API key missing",
 		},
 		{
-			desc:   "missing API key",
-			apiKey: "",
-			host: func() *url.URL {
-				u, _ := url.Parse("http://example.com")
-				return u
-			}(),
+			desc:     "missing API key",
+			apiKey:   "",
+			host:     mustParse("http://example.com"),
 			expected: "pdns: API key missing",
 		},
 		{
@@ -124,7 +115,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			config := NewDefaultConfig()
 			config.APIKey = test.apiKey
 			config.Host = test.host
-			config.CustomAPIVersion = test.customAPIVersion
+			config.APIVersion = test.customAPIVersion
 
 			p, err := NewDNSProviderConfig(config)
 
@@ -153,4 +144,12 @@ func TestLivePresentAndCleanup(t *testing.T) {
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")
 	require.NoError(t, err)
+}
+
+func mustParse(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }

--- a/providers/dns/pdns/pdns_test.go
+++ b/providers/dns/pdns/pdns_test.go
@@ -76,14 +76,24 @@ func TestNewDNSProvider(t *testing.T) {
 
 func TestNewDNSProviderConfig(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		apiKey   string
-		host     *url.URL
-		expected string
+		desc             string
+		apiKey           string
+		customApiVersion int
+		host             *url.URL
+		expected         string
 	}{
 		{
 			desc:   "success",
 			apiKey: "123",
+			host: func() *url.URL {
+				u, _ := url.Parse("http://example.com")
+				return u
+			}(),
+		},
+		{
+			desc:             "success custom API version",
+			apiKey:           "123",
+			customApiVersion: 1,
 			host: func() *url.URL {
 				u, _ := url.Parse("http://example.com")
 				return u
@@ -114,6 +124,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			config := NewDefaultConfig()
 			config.APIKey = test.apiKey
 			config.Host = test.host
+			config.CustomApiVersion = test.customApiVersion
 
 			p, err := NewDNSProviderConfig(config)
 

--- a/providers/dns/pdns/pdns_test.go
+++ b/providers/dns/pdns/pdns_test.go
@@ -78,7 +78,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 	testCases := []struct {
 		desc             string
 		apiKey           string
-		customApiVersion int
+		customAPIVersion int
 		host             *url.URL
 		expected         string
 	}{
@@ -93,7 +93,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		{
 			desc:             "success custom API version",
 			apiKey:           "123",
-			customApiVersion: 1,
+			customAPIVersion: 1,
 			host: func() *url.URL {
 				u, _ := url.Parse("http://example.com")
 				return u
@@ -124,7 +124,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			config := NewDefaultConfig()
 			config.APIKey = test.apiKey
 			config.Host = test.host
-			config.CustomApiVersion = test.customApiVersion
+			config.CustomAPIVersion = test.customAPIVersion
 
 			p, err := NewDNSProviderConfig(config)
 


### PR DESCRIPTION
Some PowerDNS servers don't have exposed the [root API endpoints](https://doc.powerdns.com/recursor/common/api/endpoint-api.html) and PowerDNS API version auto-detection fails. Use the optional parameter `PDNS_CUSTOM_API_VERSION` to set the version number in such situations.

related to  #2016