### PR TITLE
ipv64: remove unused option

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1071,7 +1071,8 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "GANDIV5_API_KEY":	API key`)
+		ew.writeln(`	- "GANDIV5_API_KEY":	API key (Deprecated)`)
+		ew.writeln(`	- "GANDIV5_PERSONAL_ACCESS_TOKEN":	Personal Access Token`)
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
@@ -1512,7 +1513,6 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "IPV64_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "IPV64_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "IPV64_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
-		ew.writeln(`	- "IPV64_SEQUENCE_INTERVAL":	Time between sequential requests`)
 		ew.writeln(`	- "IPV64_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_gandiv5.md
+++ b/docs/content/dns/zz_gen_gandiv5.md
@@ -26,7 +26,7 @@ Configuration for [Gandi Live DNS (v5)](https://www.gandi.net).
 Here is an example bash command using the Gandi Live DNS (v5) provider:
 
 ```bash
-GANDIV5_API_KEY=abcdefghijklmnopqrstuvwx \
+GANDIV5_PERSONAL_ACCESS_TOKEN=abcdefghijklmnopqrstuvwx \
 lego --email you@example.com --dns gandiv5 --domains my.example.org run
 ```
 
@@ -37,7 +37,8 @@ lego --email you@example.com --dns gandiv5 --domains my.example.org run
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `GANDIV5_API_KEY` | API key |
+| `GANDIV5_API_KEY` | API key (Deprecated) |
+| `GANDIV5_PERSONAL_ACCESS_TOKEN` | Personal Access Token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/docs/content/dns/zz_gen_ipv64.md
+++ b/docs/content/dns/zz_gen_ipv64.md
@@ -50,7 +50,6 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IPV64_HTTP_TIMEOUT` | API request timeout |
 | `IPV64_POLLING_INTERVAL` | Time between DNS propagation check |
 | `IPV64_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
-| `IPV64_SEQUENCE_INTERVAL` | Time between sequential requests |
 | `IPV64_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/ipv64/ipv64.go
+++ b/providers/dns/ipv64/ipv64.go
@@ -24,6 +24,7 @@ const (
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+	EnvSequenceInterval   = envNamespace + "SEQUENCE_INTERVAL" // Deprecated: unused, will be removed in v5.
 )
 
 // Config is used to configure the creation of the DNSProvider.
@@ -32,6 +33,7 @@ type Config struct {
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
 	HTTPClient         *http.Client
+	SequenceInterval   time.Duration // Deprecated: unused, will be removed in v5.
 }
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.

--- a/providers/dns/ipv64/ipv64.go
+++ b/providers/dns/ipv64/ipv64.go
@@ -24,7 +24,6 @@ const (
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
-	EnvSequenceInterval   = envNamespace + "SEQUENCE_INTERVAL"
 )
 
 // Config is used to configure the creation of the DNSProvider.
@@ -32,7 +31,6 @@ type Config struct {
 	APIKey             string
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
-	SequenceInterval   time.Duration
 	HTTPClient         *http.Client
 }
 
@@ -41,7 +39,6 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
-		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
 			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
 		},

--- a/providers/dns/ipv64/ipv64.toml
+++ b/providers/dns/ipv64/ipv64.toml
@@ -17,7 +17,6 @@ lego --email you@example.com --dns ipv64 --domains my.example.org run
     IPV64_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     IPV64_TTL = "The TTL of the TXT record used for the DNS challenge"
     IPV64_HTTP_TIMEOUT = "API request timeout"
-    IPV64_SEQUENCE_INTERVAL = "Time between sequential requests"
 
 [Links]
   API = "https://ipv64.net/dyndns_updater_api"


### PR DESCRIPTION
`IPV64_SEQUENCE_INTERVAL` is unused.