### PR TITLE
otc: sequential challenge 

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2030,6 +2030,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "OTC_HTTP_TIMEOUT":	API request timeout`)
 		ew.writeln(`	- "OTC_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "OTC_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
+		ew.writeln(`	- "OTC_SEQUENCE_INTERVAL":	Time between sequential requests`)
 		ew.writeln(`	- "OTC_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_otc.md
+++ b/docs/content/dns/zz_gen_otc.md
@@ -51,6 +51,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `OTC_HTTP_TIMEOUT` | API request timeout |
 | `OTC_POLLING_INTERVAL` | Time between DNS propagation check |
 | `OTC_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `OTC_SEQUENCE_INTERVAL` | Time between sequential requests |
 | `OTC_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/otc/otc.go
+++ b/providers/dns/otc/otc.go
@@ -206,8 +206,7 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
-// Sequential makes all DNS challenges for this provider to happen sequntially
-// Adjusting here to cope with spikes in propagation times.
+// The sequential function makes all DNS challenges for this provider happen sequentially.
 func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
 }

--- a/providers/dns/otc/otc.go
+++ b/providers/dns/otc/otc.go
@@ -33,6 +33,7 @@ const (
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
 	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+	EnvSequenceInterval   = envNamespace + "SEQUENCE_INTERVAL"
 )
 
 // Config is used to configure the creation of the DNSProvider.
@@ -44,6 +45,7 @@ type Config struct {
 	Password           string
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
+	SequenceInterval   time.Duration
 	TTL                int
 	HTTPClient         *http.Client
 }
@@ -55,6 +57,7 @@ func NewDefaultConfig() *Config {
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		IdentityEndpoint:   env.GetOrDefaultString(EnvIdentityEndpoint, defaultIdentityEndpoint),
+		SequenceInterval:   env.GetOrDefaultSecond(EnvSequenceInterval, dns01.DefaultPropagationTimeout),
 		HTTPClient: &http.Client{
 			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
 			Transport: &http.Transport{
@@ -201,4 +204,10 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 // Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+// Sequential makes all DNS challenges for this provider to happen sequntially
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Sequential() time.Duration {
+	return d.config.SequenceInterval
 }

--- a/providers/dns/otc/otc.go
+++ b/providers/dns/otc/otc.go
@@ -206,7 +206,8 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
-// The sequential function makes all DNS challenges for this provider happen sequentially.
+// Sequential All DNS challenges for this provider will be resolved sequentially.
+// Returns the interval between each iteration.
 func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
 }

--- a/providers/dns/otc/otc.toml
+++ b/providers/dns/otc/otc.toml
@@ -16,6 +16,7 @@ Example = ''''''
   [Configuration.Additional]
     OTC_POLLING_INTERVAL = "Time between DNS propagation check"
     OTC_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
+    OTC_SEQUENCE_INTERVAL = "Time between sequential requests"
     OTC_TTL = "The TTL of the TXT record used for the DNS challenge"
     OTC_HTTP_TIMEOUT = "API request timeout"
 


### PR DESCRIPTION
OTC doesn't support creating multiple recordsets with the same name.
Therefore, we configure the OTC provider for the sequential challenge.

feat: added OTC_SEQUENCE_INTERVAL environment variable. The default
value is dns01.DefaultPropagationTimeout

closes #2021