### PR TITLE
azuredns: provide the ability to select authentication methods

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -307,6 +307,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
+		ew.writeln(`	- "AZURE_CLIENT_CERTIFICATE_PATH":	Client certificate path`)
 		ew.writeln(`	- "AZURE_CLIENT_ID":	Client ID`)
 		ew.writeln(`	- "AZURE_CLIENT_SECRET":	Client secret`)
 		ew.writeln(`	- "AZURE_RESOURCE_GROUP":	DNS zone resource group`)
@@ -315,6 +316,8 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "AZURE_AUTH_METHOD":	Specify which authentication method to use`)
+		ew.writeln(`	- "AZURE_AUTH_MSI_TIMEOUT":	Managed Identity timeout duration`)
 		ew.writeln(`	- "AZURE_ENVIRONMENT":	Azure environment, one of: public, usgovernment, and china`)
 		ew.writeln(`	- "AZURE_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "AZURE_PRIVATE_ZONE":	Set to true to use Azure Private DNS Zones and not public`)

--- a/docs/content/dns/zz_gen_azuredns.md
+++ b/docs/content/dns/zz_gen_azuredns.md
@@ -70,6 +70,7 @@ lego --domains example.com --email your_example@email.com --dns azuredns run
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
+| `AZURE_CLIENT_CERTIFICATE_PATH` | Client certificate path |
 | `AZURE_CLIENT_ID` | Client ID |
 | `AZURE_CLIENT_SECRET` | Client secret |
 | `AZURE_RESOURCE_GROUP` | DNS zone resource group |
@@ -84,6 +85,8 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `AZURE_AUTH_METHOD` | Specify which authentication method to use |
+| `AZURE_AUTH_MSI_TIMEOUT` | Managed Identity timeout duration |
 | `AZURE_ENVIRONMENT` | Azure environment, one of: public, usgovernment, and china |
 | `AZURE_POLLING_INTERVAL` | Time between DNS propagation check |
 | `AZURE_PRIVATE_ZONE` | Set to true to use Azure Private DNS Zones and not public |
@@ -96,19 +99,59 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 ## Description
 
-Azure Credentials are automatically detected in the following locations and prioritized in the following order:
+Several authentication methods can be used to authenticate against Azure DNS API.
+
+### Default Azure Credentials (default option)
+
+Default Azure Credentials automatically detects in the following locations and prioritized in the following order:
 
 1. Environment variables for client secret: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`
 2. Environment variables for client certificate: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_CERTIFICATE_PATH`
 3. Workload identity for resources hosted in Azure environment (see below)
-4. Shared credentials file (defaults to `~/.azure`), used by Azure CLI
+4. Shared credentials (defaults to `~/.azure` folder), used by Azure CLI
 
 Link:
 - [Azure Authentication](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication)
 
+### Environment variables
+
+#### Client secret
+
+The Azure Credentials can be configured using the following environment variables:
+* AZURE_CLIENT_ID = "Client ID"
+* AZURE_CLIENT_SECRET = "Client secret"
+* AZURE_TENANT_ID = "Tenant ID"
+
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `env`.
+
+#### Client certificate
+
+The Azure Credentials can be configured using the following environment variables:
+* AZURE_CLIENT_ID = "Client ID"
+* AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
+* AZURE_TENANT_ID = "Tenant ID"
+
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `env`.
+
 ### Workload identity
 
-#### Azure Managed Identity
+Workload identity allows workloads running Azure Kubernetes Services (AKS) clusters to authenticate as an Azure AD application identity using federated credentials.
+
+This must be configured in kubernetes workload deployment in one hand and on the Azure AD application registration in the other hand.
+
+Here is a summary of the steps to follow to use it :
+* create a `ServiceAccount` resource, add following annotations to reference the targeted Azure AD application registration : `azure.workload.identity/client-id` and `azure.workload.identity/tenant-id`.
+* on the `Deployment` resource you must reference the previous `ServiceAccount` and add the following label : `azure.workload.identity/use: "true"`.
+* create a fedreated credentials of type `Kubernetes accessing Azure resources`, add the cluster issuer URL  and add the namespace and name of your kubernetes service account.
+
+Link :
+- [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
+
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `wli`.
+
+### Azure Managed Identity
+
+#### Azure Managed Identity (with Azure workload)
 
 The Azure Managed Identity service allows linking Azure AD identities to Azure resources, without needing to manually manage client IDs and secrets.
 
@@ -138,6 +181,11 @@ az role assignment create \
 --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/dnszones/${AZURE_DNS_ZONE}/TXT/${AZ_RECORD_SET}"
 ```
 
+A timeout wrapper is configured for this authentication method.
+The duraction can be configured by setting the `AZURE_AUTH_MSI_TIMEOUT`.
+The default timeout is 2 seconds.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
+
 #### Azure Managed Identity (with Azure Arc)
 
 The Azure Arc agent provides the ability to use a Managed Identity on resources hosted outside of Azure
@@ -146,22 +194,21 @@ The Azure Arc agent provides the ability to use a Managed Identity on resources 
 While the upstream `azidentity` SDK will try to automatically identify and use the Azure Arc metadata service,
 if you get `azuredns: DefaultAzureCredential: failed to acquire a token.` error messages,
 you may need to set the environment variables:
-  * `IMDS_ENDPOINT=http://localhost:40342`
-  * `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
+* `IMDS_ENDPOINT=http://localhost:40342`
+* `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
 
-#### Workload identity for AKS
+A timeout wrapper is configured for this authentication method.
+The duraction can be configured by setting the `AZURE_AUTH_MSI_TIMEOUT`.
+The default timeout is 2 seconds.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
 
-Workload identity allows workloads running Azure Kubernetes Services (AKS) clusters to authenticate as an Azure AD application identity using federated credentials.
+### Azure CLI
 
-This must be configured in kubernetes workload deployment in one hand and on the Azure AD application registration in the other hand.
+The Azure CLI is a command-line tool provided by Microsoft to interact with Azure resources.
+It provides an easy way to authenticate by simply running `az login` command.
+The generated token will be cached by default in the `~/.azure` folder.
 
-Here is a summary of the steps to follow to use it :
-* create a `ServiceAccount` resource, add following annotations to reference the targeted Azure AD application registration : `azure.workload.identity/client-id` and `azure.workload.identity/tenant-id`.
-* on the `Deployment` resource you must reference the previous `ServiceAccount` and add the following label : `azure.workload.identity/use: "true"`.
-* create a fedreated credentials of type `Kubernetes accessing Azure resources`, add the cluster issuer URL  and add the namespace and name of your kubernetes service account.
-
-Link :
-- [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `cli`.
 
 
 

--- a/providers/dns/azuredns/azuredns.go
+++ b/providers/dns/azuredns/azuredns.go
@@ -117,7 +117,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	credentials, err := getCredentials(config)
 	if err != nil {
-		return nil, errors.New("azuredns: Unable to retrieve valid credentials")
+		return nil, fmt.Errorf("azuredns: Unable to retrieve valid credentials: %w", err)
 	}
 
 	if config.SubscriptionID == "" {

--- a/providers/dns/azuredns/azuredns.toml
+++ b/providers/dns/azuredns/azuredns.toml
@@ -64,7 +64,7 @@ The Azure Credentials can be configured using the following environment variable
 * AZURE_CLIENT_SECRET = "Client secret"
 * AZURE_TENANT_ID = "Tenant ID"
 
-This authentication method can be disabled by setting the `AZURE_USE_ENV_VARS` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_ENV_VARS` environment variable to `true`.
 
 #### Client certificate
 
@@ -73,7 +73,7 @@ The Azure Credentials can be configured using the following environment variable
 * AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
 * AZURE_TENANT_ID = "Tenant ID"
 
-This authentication method can be disabled by setting the `AZURE_USE_ENV_VARS` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_ENV_VARS` environment variable to `true`.
 
 ### Workload identity
 
@@ -89,7 +89,7 @@ Here is a summary of the steps to follow to use it :
 Link :
 - [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
 
-This authentication method can be disabled by setting the `AZURE_USE_WLI` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_WLI` environment variable to `true`.
 
 ### Azure Managed Identity
 
@@ -124,7 +124,7 @@ az role assignment create \
 ```
 
 A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
-This authentication method can be disabled by setting the `AZURE_USE_MSI` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_MSI` environment variable to `true`.
 
 #### Azure Managed Identity (with Azure Arc)
 
@@ -138,7 +138,7 @@ you may need to set the environment variables:
 * `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
 
 A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
-This authentication method can be disabled by setting the `AZURE_USE_MSI` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_MSI` environment variable to `true`.
 
 ### Azure CLI
 
@@ -146,7 +146,7 @@ The Azure CLI is a command-line tool provided by Microsoft to interact with Azur
 It provides an easy way to authenticate by simply running `az login` command.
 The generated token will be cached by default in the `~/.azure` folder.
 
-This authentication method can be disabled by setting the `AZURE_USE_CLI` environment variable to `false`.
+This authentication method can be specificaly used by setting the `AZURE_USE_CLI` environment variable to `true`.
 
 '''
 
@@ -156,10 +156,10 @@ This authentication method can be disabled by setting the `AZURE_USE_CLI` enviro
     AZURE_CLIENT_SECRET = "Client secret"
     AZURE_TENANT_ID = "Tenant ID"
     AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
-    AZURE_USE_ENV_VARS = "Enable environment variables credentials, true by default"
-    AZURE_USE_WLI = "Enable workload identity credentials, true by default"
-    AZURE_USE_MSI = "Enable managed service identity credentials, true by default"
-    AZURE_USE_CLI = "Enable Azure CLI credentials, true by default"
+    AZURE_USE_ENV_VARS = "Specificaly use environment variables credentials"
+    AZURE_USE_WLI = "Specificaly use workload identity credentials"
+    AZURE_USE_MSI = "Specificaly use managed service identity credentials"
+    AZURE_USE_CLI = "Specificaly use Azure CLI credentials"
   [Configuration.DnsZone]
     AZURE_SUBSCRIPTION_ID = "DNS zone subscription ID"
     AZURE_RESOURCE_GROUP = "DNS zone resource group"

--- a/providers/dns/azuredns/azuredns.toml
+++ b/providers/dns/azuredns/azuredns.toml
@@ -45,7 +45,11 @@ lego --domains example.com --email your_example@email.com --dns azuredns run
 Additional = '''
 ## Description
 
-Azure Credentials automatically detects in the following locations and prioritized in the following order:
+Several authentication methods can be used to authenticate against Azure DNS API.
+
+### Default Azure Credentials (default option)
+
+Default Azure Credentials automatically detects in the following locations and prioritized in the following order:
 
 1. Environment variables for client secret: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`
 2. Environment variables for client certificate: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_CERTIFICATE_PATH`
@@ -64,7 +68,7 @@ The Azure Credentials can be configured using the following environment variable
 * AZURE_CLIENT_SECRET = "Client secret"
 * AZURE_TENANT_ID = "Tenant ID"
 
-This authentication method can be specificaly used by setting the `AZURE_USE_ENV_VARS` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `env`.
 
 #### Client certificate
 
@@ -73,7 +77,7 @@ The Azure Credentials can be configured using the following environment variable
 * AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
 * AZURE_TENANT_ID = "Tenant ID"
 
-This authentication method can be specificaly used by setting the `AZURE_USE_ENV_VARS` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `env`.
 
 ### Workload identity
 
@@ -89,7 +93,7 @@ Here is a summary of the steps to follow to use it :
 Link :
 - [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
 
-This authentication method can be specificaly used by setting the `AZURE_USE_WLI` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `wli`.
 
 ### Azure Managed Identity
 
@@ -124,7 +128,7 @@ az role assignment create \
 ```
 
 A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
-This authentication method can be specificaly used by setting the `AZURE_USE_MSI` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
 
 #### Azure Managed Identity (with Azure Arc)
 
@@ -138,7 +142,7 @@ you may need to set the environment variables:
 * `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
 
 A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
-This authentication method can be specificaly used by setting the `AZURE_USE_MSI` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
 
 ### Azure CLI
 
@@ -146,7 +150,7 @@ The Azure CLI is a command-line tool provided by Microsoft to interact with Azur
 It provides an easy way to authenticate by simply running `az login` command.
 The generated token will be cached by default in the `~/.azure` folder.
 
-This authentication method can be specificaly used by setting the `AZURE_USE_CLI` environment variable to `true`.
+This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `cli`.
 
 '''
 
@@ -156,10 +160,7 @@ This authentication method can be specificaly used by setting the `AZURE_USE_CLI
     AZURE_CLIENT_SECRET = "Client secret"
     AZURE_TENANT_ID = "Tenant ID"
     AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
-    AZURE_USE_ENV_VARS = "Specificaly use environment variables credentials"
-    AZURE_USE_WLI = "Specificaly use workload identity credentials"
-    AZURE_USE_MSI = "Specificaly use managed service identity credentials"
-    AZURE_USE_CLI = "Specificaly use Azure CLI credentials"
+    AZURE_AUTH_METHOD = "Specify which authentication method to use"
   [Configuration.DnsZone]
     AZURE_SUBSCRIPTION_ID = "DNS zone subscription ID"
     AZURE_RESOURCE_GROUP = "DNS zone resource group"

--- a/providers/dns/azuredns/azuredns.toml
+++ b/providers/dns/azuredns/azuredns.toml
@@ -127,7 +127,9 @@ az role assignment create \
 --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/dnszones/${AZURE_DNS_ZONE}/TXT/${AZ_RECORD_SET}"
 ```
 
-A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
+A timeout wrapper is configured for this authentication method.
+The duraction can be configured by setting the `AZURE_AUTH_MSI_TIMEOUT`.
+The default timeout is 2 seconds.
 This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
 
 #### Azure Managed Identity (with Azure Arc)
@@ -141,7 +143,9 @@ you may need to set the environment variables:
 * `IMDS_ENDPOINT=http://localhost:40342`
 * `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
 
-A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
+A timeout wrapper is configured for this authentication method.
+The duraction can be configured by setting the `AZURE_AUTH_MSI_TIMEOUT`.
+The default timeout is 2 seconds.
 This authentication method can be specificaly used by setting the `AZURE_AUTH_METHOD` environment variable to `msi`.
 
 ### Azure CLI
@@ -160,18 +164,17 @@ This authentication method can be specificaly used by setting the `AZURE_AUTH_ME
     AZURE_CLIENT_SECRET = "Client secret"
     AZURE_TENANT_ID = "Tenant ID"
     AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
-    AZURE_AUTH_METHOD = "Specify which authentication method to use"
-  [Configuration.DnsZone]
     AZURE_SUBSCRIPTION_ID = "DNS zone subscription ID"
     AZURE_RESOURCE_GROUP = "DNS zone resource group"
   [Configuration.Additional]
     AZURE_ENVIRONMENT = "Azure environment, one of: public, usgovernment, and china"
     AZURE_PRIVATE_ZONE = "Set to true to use Azure Private DNS Zones and not public"
     AZURE_ZONE_NAME = "Zone name to use inside Azure DNS service to add the TXT record in"
+    AZURE_AUTH_METHOD = "Specify which authentication method to use"
+    AZURE_AUTH_MSI_TIMEOUT = "Managed Identity timeout duration"
     AZURE_TTL = "The TTL of the TXT record used for the DNS challenge"
     AZURE_POLLING_INTERVAL = "Time between DNS propagation check"
     AZURE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
-    AZURE_MSI_TIMEOUT = "Managed Identity timeout duration"
 
 [Links]
   API = "https://docs.microsoft.com/en-us/go/azure/"

--- a/providers/dns/azuredns/azuredns.toml
+++ b/providers/dns/azuredns/azuredns.toml
@@ -45,19 +45,55 @@ lego --domains example.com --email your_example@email.com --dns azuredns run
 Additional = '''
 ## Description
 
-Azure Credentials are automatically detected in the following locations and prioritized in the following order:
+Azure Credentials automatically detects in the following locations and prioritized in the following order:
 
 1. Environment variables for client secret: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`
 2. Environment variables for client certificate: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_CERTIFICATE_PATH`
 3. Workload identity for resources hosted in Azure environment (see below)
-4. Shared credentials file (defaults to `~/.azure`), used by Azure CLI
+4. Shared credentials (defaults to `~/.azure` folder), used by Azure CLI
 
 Link:
 - [Azure Authentication](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication)
 
+### Environment variables
+
+#### Client secret
+
+The Azure Credentials can be configured using the following environment variables:
+* AZURE_CLIENT_ID = "Client ID"
+* AZURE_CLIENT_SECRET = "Client secret"
+* AZURE_TENANT_ID = "Tenant ID"
+
+This authentication method can be disabled by setting the `AZURE_USE_ENV_VARS` environment variable to `false`.
+
+#### Client certificate
+
+The Azure Credentials can be configured using the following environment variables:
+* AZURE_CLIENT_ID = "Client ID"
+* AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
+* AZURE_TENANT_ID = "Tenant ID"
+
+This authentication method can be disabled by setting the `AZURE_USE_ENV_VARS` environment variable to `false`.
+
 ### Workload identity
 
-#### Azure Managed Identity
+Workload identity allows workloads running Azure Kubernetes Services (AKS) clusters to authenticate as an Azure AD application identity using federated credentials.
+
+This must be configured in kubernetes workload deployment in one hand and on the Azure AD application registration in the other hand.
+
+Here is a summary of the steps to follow to use it :
+* create a `ServiceAccount` resource, add following annotations to reference the targeted Azure AD application registration : `azure.workload.identity/client-id` and `azure.workload.identity/tenant-id`.
+* on the `Deployment` resource you must reference the previous `ServiceAccount` and add the following label : `azure.workload.identity/use: "true"`.
+* create a fedreated credentials of type `Kubernetes accessing Azure resources`, add the cluster issuer URL  and add the namespace and name of your kubernetes service account.
+
+Link :
+- [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
+
+This authentication method can be disabled by setting the `AZURE_USE_WLI` environment variable to `false`.
+
+### Azure Managed Identity
+
+#### Azure Managed Identity (with Azure workload)
 
 The Azure Managed Identity service allows linking Azure AD identities to Azure resources, without needing to manually manage client IDs and secrets.
 
@@ -87,6 +123,9 @@ az role assignment create \
 --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/dnszones/${AZURE_DNS_ZONE}/TXT/${AZ_RECORD_SET}"
 ```
 
+A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
+This authentication method can be disabled by setting the `AZURE_USE_MSI` environment variable to `false`.
+
 #### Azure Managed Identity (with Azure Arc)
 
 The Azure Arc agent provides the ability to use a Managed Identity on resources hosted outside of Azure
@@ -95,22 +134,19 @@ The Azure Arc agent provides the ability to use a Managed Identity on resources 
 While the upstream `azidentity` SDK will try to automatically identify and use the Azure Arc metadata service,
 if you get `azuredns: DefaultAzureCredential: failed to acquire a token.` error messages,
 you may need to set the environment variables:
-  * `IMDS_ENDPOINT=http://localhost:40342`
-  * `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
+* `IMDS_ENDPOINT=http://localhost:40342`
+* `IDENTITY_ENDPOINT=http://localhost:40342/metadata/identity/oauth2/token`
 
-#### Workload identity for AKS
+A timeout wrapper is configured for this authentication method. The duraction can be configured by setting the `AZURE_MSI_TIMEOUT`. The default timeout is 2 seconds.
+This authentication method can be disabled by setting the `AZURE_USE_MSI` environment variable to `false`.
 
-Workload identity allows workloads running Azure Kubernetes Services (AKS) clusters to authenticate as an Azure AD application identity using federated credentials.
+### Azure CLI
 
-This must be configured in kubernetes workload deployment in one hand and on the Azure AD application registration in the other hand.
+The Azure CLI is a command-line tool provided by Microsoft to interact with Azure resources.
+It provides an easy way to authenticate by simply running `az login` command.
+The generated token will be cached by default in the `~/.azure` folder.
 
-Here is a summary of the steps to follow to use it :
-* create a `ServiceAccount` resource, add following annotations to reference the targeted Azure AD application registration : `azure.workload.identity/client-id` and `azure.workload.identity/tenant-id`.
-* on the `Deployment` resource you must reference the previous `ServiceAccount` and add the following label : `azure.workload.identity/use: "true"`.
-* create a fedreated credentials of type `Kubernetes accessing Azure resources`, add the cluster issuer URL  and add the namespace and name of your kubernetes service account.
-
-Link :
-- [Azure AD Workload identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
+This authentication method can be disabled by setting the `AZURE_USE_CLI` environment variable to `false`.
 
 '''
 
@@ -119,6 +155,12 @@ Link :
     AZURE_CLIENT_ID = "Client ID"
     AZURE_CLIENT_SECRET = "Client secret"
     AZURE_TENANT_ID = "Tenant ID"
+    AZURE_CLIENT_CERTIFICATE_PATH = "Client certificate path"
+    AZURE_USE_ENV_VARS = "Enable environment variables credentials, true by default"
+    AZURE_USE_WLI = "Enable workload identity credentials, true by default"
+    AZURE_USE_MSI = "Enable managed service identity credentials, true by default"
+    AZURE_USE_CLI = "Enable Azure CLI credentials, true by default"
+  [Configuration.DnsZone]
     AZURE_SUBSCRIPTION_ID = "DNS zone subscription ID"
     AZURE_RESOURCE_GROUP = "DNS zone resource group"
   [Configuration.Additional]
@@ -128,6 +170,7 @@ Link :
     AZURE_TTL = "The TTL of the TXT record used for the DNS challenge"
     AZURE_POLLING_INTERVAL = "Time between DNS propagation check"
     AZURE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
+    AZURE_MSI_TIMEOUT = "Managed Identity timeout duration"
 
 [Links]
   API = "https://docs.microsoft.com/en-us/go/azure/"

--- a/providers/dns/azuredns/azuredns_test.go
+++ b/providers/dns/azuredns/azuredns_test.go
@@ -13,13 +13,13 @@ import (
 
 const envDomain = envNamespace + "DOMAIN"
 
-func TestNewDNSProvider(t *testing.T) {
-	envTest := tester.NewEnvTest(
-		EnvEnvironment,
-		EnvSubscriptionID,
-		EnvResourceGroup).
-		WithDomain(envDomain)
+var envTest = tester.NewEnvTest(
+	EnvEnvironment,
+	EnvSubscriptionID,
+	EnvResourceGroup).
+	WithDomain(envDomain)
 
+func TestNewDNSProvider(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		envVars  map[string]string
@@ -140,12 +140,6 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestLivePresent(t *testing.T) {
-	envTest := tester.NewEnvTest(
-		EnvEnvironment,
-		EnvSubscriptionID,
-		EnvResourceGroup).
-		WithDomain(envDomain)
-
 	if !envTest.IsLiveTest() {
 		t.Skip("skipping live test")
 	}
@@ -159,12 +153,6 @@ func TestLivePresent(t *testing.T) {
 }
 
 func TestLiveCleanUp(t *testing.T) {
-	envTest := tester.NewEnvTest(
-		EnvEnvironment,
-		EnvSubscriptionID,
-		EnvResourceGroup).
-		WithDomain(envDomain)
-
 	if !envTest.IsLiveTest() {
 		t.Skip("skipping live test")
 	}

--- a/providers/dns/azuredns/azuredns_test.go
+++ b/providers/dns/azuredns/azuredns_test.go
@@ -13,13 +13,13 @@ import (
 
 const envDomain = envNamespace + "DOMAIN"
 
-var envTest = tester.NewEnvTest(
-	EnvEnvironment,
-	EnvSubscriptionID,
-	EnvResourceGroup).
-	WithDomain(envDomain)
-
 func TestNewDNSProvider(t *testing.T) {
+	envTest := tester.NewEnvTest(
+		EnvEnvironment,
+		EnvSubscriptionID,
+		EnvResourceGroup).
+		WithDomain(envDomain)
+
 	testCases := []struct {
 		desc     string
 		envVars  map[string]string
@@ -140,6 +140,12 @@ func TestNewDNSProviderConfig(t *testing.T) {
 }
 
 func TestLivePresent(t *testing.T) {
+	envTest := tester.NewEnvTest(
+		EnvEnvironment,
+		EnvSubscriptionID,
+		EnvResourceGroup).
+		WithDomain(envDomain)
+
 	if !envTest.IsLiveTest() {
 		t.Skip("skipping live test")
 	}
@@ -153,6 +159,12 @@ func TestLivePresent(t *testing.T) {
 }
 
 func TestLiveCleanUp(t *testing.T) {
+	envTest := tester.NewEnvTest(
+		EnvEnvironment,
+		EnvSubscriptionID,
+		EnvResourceGroup).
+		WithDomain(envDomain)
+
 	if !envTest.IsLiveTest() {
 		t.Skip("skipping live test")
 	}


### PR DESCRIPTION
Hello,

After using `azuredns` new DNS provider, I figured out it could be really useful to manage which authentication methods to use, in order to configure more accurately the expected behavior.

Therefore, I have splited the `DefaultAzureCredential` by using the different Azure credential methods and added the possibility to disable some of them.

Note that for `NewManagedIdentityCredential` I added a timeout management as described in the [azidentity package documentation](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#example-NewChainedTokenCredential-ManagedIdentityTimeout)

Let me know if you want me to add anything.
Thanks.