### PR TITLE
gandiv5: Add "Bearer" prefix to the auth header

### DIFF
--- a/providers/dns/gandiv5/gandiv5_test.go
+++ b/providers/dns/gandiv5/gandiv5_test.go
@@ -121,8 +121,8 @@ func TestDNSProvider(t *testing.T) {
 	mux.HandleFunc("/domains/example.com/records/_acme-challenge.abc.def/TXT", func(rw http.ResponseWriter, req *http.Request) {
 		log.Infof("request: %s %s", req.Method, req.URL)
 
-		if req.Header.Get("Authorization") == "" {
-			http.Error(rw, `{"message": "missing Authorization"}`, http.StatusUnauthorized)
+		if req.Header.Get("Authorization") != "Bearer 123412341234123412341234" {
+			http.Error(rw, `{"message": "missing or malformed Authorization"}`, http.StatusUnauthorized)
 			return
 		}
 

--- a/providers/dns/gandiv5/internal/client.go
+++ b/providers/dns/gandiv5/internal/client.go
@@ -134,7 +134,7 @@ func (c *Client) do(req *http.Request, result any) error {
 	}
 
 	if c.pat != "" {
-		req.Header.Set(authorizationHeader, c.pat)
+		req.Header.Set(authorizationHeader, "Bearer "+c.pat)
 	}
 
 	resp, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
The "Bearer" prefix is required per
https://api.gandi.net/docs/authentication/ to declare the content of the Authorization header as a personal access token.

Without this change, the user has to specify `GANDIV5_PERSONAL_ACCESS_TOKEN='Bearer 12341234'` instead of `GANDIV5_PERSONAL_ACCESS_TOKEN=12341234` which disagrees with the documentation and the existing test data.

This change is not backwards-compatible. This should be OK because the commit 113648a36817a5d9667b8dd1f1c6c67eeb914916 (#2007) which added support for personal access tokens was not in any release yet.