### PR TITLE
regru: HTTP method changed to POST

### DIFF
--- a/providers/dns/regru/internal/client.go
+++ b/providers/dns/regru/internal/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -97,7 +98,7 @@ func (c Client) doRequest(ctx context.Context, request any, fragments ...string)
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Content-Length", fmt.Sprintf("%d", len(postDataEncoded)))
+	req.Header.Add("Content-Length", strconv.Itoa(len(postDataEncoded)))
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/providers/dns/regru/internal/types.go
+++ b/providers/dns/regru/internal/types.go
@@ -56,9 +56,6 @@ func (d DomainResponse) Error() string {
 
 // AddTxtRequest is the representation of the payload of a request to add a TXT record.
 type AddTxtRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-
 	Domains           []Domain `json:"domains,omitempty"`
 	SubDomain         string   `json:"subdomain,omitempty"`
 	Text              string   `json:"text,omitempty"`
@@ -67,9 +64,6 @@ type AddTxtRequest struct {
 
 // RemoveRecordRequest is the representation of the payload of a request to remove a record.
 type RemoveRecordRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-
 	Domains           []Domain `json:"domains,omitempty"`
 	SubDomain         string   `json:"subdomain,omitempty"`
 	Content           string   `json:"content,omitempty"`


### PR DESCRIPTION
http method GET is deprecated
https://www.reg.ru/reseller/api2doc#common_connection

so, we need to change it to POST