### PR TITLE
feat: support simplified issuance for very long domain names at Let's Encrypt

### DIFF
--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -216,6 +216,26 @@ func ParsePEMCertificate(cert []byte) (*x509.Certificate, error) {
 	return x509.ParseCertificate(pemBlock.Bytes)
 }
 
+func GetCertificateMainDomain(cert *x509.Certificate) (string, error) {
+	return getMainDomain(cert.Subject, cert.DNSNames)
+}
+
+func GetCSRMainDomain(cert *x509.CertificateRequest) (string, error) {
+	return getMainDomain(cert.Subject, cert.DNSNames)
+}
+
+func getMainDomain(subject pkix.Name, dnsNames []string) (string, error) {
+	if subject.CommonName == "" && len(dnsNames) == 0 {
+		return "", errors.New("missing domain")
+	}
+
+	if subject.CommonName != "" {
+		return subject.CommonName, nil
+	}
+
+	return dnsNames[0], nil
+}
+
 func ExtractDomains(cert *x509.Certificate) []string {
 	var domains []string
 	if cert.Subject.CommonName != "" {

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -243,7 +243,6 @@ func (c *Certifier) getForOrder(domains []string, order acme.ExtendedOrder, bund
 		}
 	}
 
-	// Determine certificate name(s) based on the authorization resources
 	commonName := ""
 	if len(domains[0]) <= 64 {
 		commonName = domains[0]
@@ -255,10 +254,12 @@ func (c *Certifier) getForOrder(domains []string, order acme.ExtendedOrder, bund
 	//   Clients SHOULD NOT make any assumptions about the sort order of
 	//   "identifiers" or "authorizations" elements in the returned order
 	//   object.
-	san := []string{}
+
+	var san []string
 	if commonName != "" {
-		san = []string{commonName}
+		san = append(san, commonName)
 	}
+
 	for _, auth := range order.Identifiers {
 		if auth.Value != commonName {
 			san = append(san, auth.Value)
@@ -603,8 +604,13 @@ func (c *Certifier) Get(url string, bundle bool) (*Resource, error) {
 		return nil, err
 	}
 
+	domain, err := certcrypto.GetCertificateMainDomain(x509Certs[0])
+	if err != nil {
+		return nil, err
+	}
+
 	return &Resource{
-		Domain:            x509Certs[0].Subject.CommonName,
+		Domain:            domain,
 		Certificate:       cert,
 		IssuerCertificate: issuer,
 		CertURL:           url,

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -244,7 +244,10 @@ func (c *Certifier) getForOrder(domains []string, order acme.ExtendedOrder, bund
 	}
 
 	// Determine certificate name(s) based on the authorization resources
-	commonName := domains[0]
+	commonName := ""
+	if len(domains[0]) <= 64 {
+		commonName = domains[0]
+	}
 
 	// RFC8555 Section 7.4 "Applying for Certificate Issuance"
 	// https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4
@@ -252,7 +255,10 @@ func (c *Certifier) getForOrder(domains []string, order acme.ExtendedOrder, bund
 	//   Clients SHOULD NOT make any assumptions about the sort order of
 	//   "identifiers" or "authorizations" elements in the returned order
 	//   object.
-	san := []string{commonName}
+	san := []string{}
+	if commonName != "" {
+		san = []string{commonName}
+	}
 	for _, auth := range order.Identifiers {
 		if auth.Value != commonName {
 			san = append(san, auth.Value)
@@ -274,9 +280,8 @@ func (c *Certifier) getForCSR(domains []string, order acme.ExtendedOrder, bundle
 		return nil, err
 	}
 
-	commonName := domains[0]
 	certRes := &Resource{
-		Domain:     commonName,
+		Domain:     domains[0],
 		CertURL:    respOrder.Certificate,
 		PrivateKey: privateKeyPem,
 	}

--- a/cmd/cmd_list.go
+++ b/cmd/cmd_list.go
@@ -84,10 +84,15 @@ func listCertificates(ctx *cli.Context) error {
 			return err
 		}
 
+		name, err := certcrypto.GetCertificateMainDomain(pCert)
+		if err != nil {
+			return err
+		}
+
 		if names {
-			fmt.Println(pCert.Subject.CommonName)
+			fmt.Println(name)
 		} else {
-			fmt.Println("  Certificate Name:", pCert.Subject.CommonName)
+			fmt.Println("  Certificate Name:", name)
 			fmt.Println("    Domains:", strings.Join(pCert.DNSNames, ", "))
 			fmt.Println("    Expiry Date:", pCert.NotAfter)
 			fmt.Println("    Certificate Path:", filename)

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -228,7 +228,10 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 		log.Fatal(err)
 	}
 
-	domain := csr.Subject.CommonName
+	domain, err := certcrypto.GetCSRMainDomain(csr)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
 
 	// load the cert resource from files.
 	// We store the certificate, private key and metadata in different files


### PR DESCRIPTION
Let's encrypt will support certificates without common name starting at 2023-11-29. Details see in this [announcement](https://community.letsencrypt.org/t/simplifying-issuance-for-very-long-domain-names/207924). It allows to create certificates for domains longer than 64 characters without needing to set the common name to a shorter domain name. 

This PR makes small adjustments to the certificate ordering to reflect the new possibility. The common name is only set if the first domain name is shorter or equal than 64 characters. Therefore the change should be compatible with the current usage.

*Note: The new behaviour can already be tested on the staging server (https://acme-staging-v02.api.letsencrypt.org/directory)*

Fixes #2049