### PR TITLE
route53: Update IAM policy example to remove route53:ListHostedZonesByName

### DIFF
--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -138,11 +138,6 @@ Replace `Z11111112222222333333` with your hosted zone ID and `example.com` with 
     },
     {
       "Effect": "Allow",
-      "Action": "route53:ListHostedZonesByName",
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
       "Action": [
         "route53:ListResourceRecordSets"
       ],


### PR DESCRIPTION
Seems `route53:ListHostedZonesByName` is not needed if we specify zoneID for `ListResourceRecordSets`. I got this idea from here:

https://cert-manager.io/docs/configuration/acme/dns01/route53/#set-up-an-iam-role

And I tested today, and it does provides certificate without `route53:ListHostedZonesByName`.