### PR TITLE
when eab is used, use the userID of "eab"

### DIFF
--- a/cmd/accounts_storage.go
+++ b/cmd/accounts_storage.go
@@ -69,7 +69,15 @@ type AccountsStorage struct {
 // NewAccountsStorage Creates a new AccountsStorage.
 func NewAccountsStorage(ctx *cli.Context) *AccountsStorage {
 	// TODO: move to account struct? Currently MUST pass email.
-	email := getEmail(ctx)
+	userID := ctx.String("email")
+	if userID == "" {
+		if ctx.IsSet("eab") {
+			// Placeholder for an email address when an external account binding is used
+			userID = "eab"
+		} else {
+			log.Fatal("You have to pass an account (email address) to the program using --email or -m")
+		}
+	}
 
 	serverURL, err := url.Parse(ctx.String("server"))
 	if err != nil {
@@ -79,10 +87,10 @@ func NewAccountsStorage(ctx *cli.Context) *AccountsStorage {
 	rootPath := filepath.Join(ctx.String("path"), baseAccountsRootFolderName)
 	serverPath := strings.NewReplacer(":", "_", "/", string(os.PathSeparator)).Replace(serverURL.Host)
 	accountsPath := filepath.Join(rootPath, serverPath)
-	rootUserPath := filepath.Join(accountsPath, email)
+	rootUserPath := filepath.Join(accountsPath, userID)
 
 	return &AccountsStorage{
-		userID:          email,
+		userID:          userID,
 		rootPath:        rootPath,
 		rootUserPath:    rootUserPath,
 		keysPath:        filepath.Join(rootUserPath, baseKeysFolderName),

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -81,14 +81,6 @@ func getKeyType(ctx *cli.Context) certcrypto.KeyType {
 	return ""
 }
 
-func getEmail(ctx *cli.Context) string {
-	email := ctx.String("email")
-	if email == "" {
-		log.Fatal("You have to pass an account (email address) to the program using --email or -m")
-	}
-	return email
-}
-
 func getUserAgent(ctx *cli.Context) string {
 	return strings.TrimSpace(fmt.Sprintf("%s lego-cli/%s", ctx.String("user-agent"), ctx.App.Version))
 }


### PR DESCRIPTION
When using an External Account Binding for requesting certs, the email field does not apply.  In this case let's use a generic string of "eab" for the userID and allow -eab to be specified on the command line.