### PR TITLE
add option to register only for an eab setup

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import "github.com/urfave/cli/v2"
 // CreateCommands Creates all CLI commands.
 func CreateCommands() []*cli.Command {
 	return []*cli.Command{
+		createRegister(),
 		createRun(),
 		createRevoke(),
 		createRenew(),

--- a/cmd/cmd_register.go
+++ b/cmd/cmd_register.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/go-acme/lego/v4/log"
+	"github.com/urfave/cli/v2"
+)
+
+func createRegister() *cli.Command {
+	return &cli.Command{
+		Name:  "register",
+		Usage: "Register an account",
+		Before: func(ctx *cli.Context) error {
+			// we require either domains or csr, but not both
+			hasDomains := len(ctx.StringSlice("domains")) > 0
+			hasCsr := len(ctx.String("csr")) > 0
+			if hasDomains && hasCsr {
+				log.Fatal("Please specify either --domains/-d or --csr/-c, but not both")
+			}
+			if !hasDomains && !hasCsr {
+				log.Fatal("Please specify --domains/-d (or --csr/-c if you already have a CSR)")
+			}
+			return nil
+		},
+		Action: registerAction,
+		Flags:  []cli.Flag{},
+	}
+}
+
+func registerAction(ctx *cli.Context) error {
+	accountsStorage := NewAccountsStorage(ctx)
+
+	account, client := setup(ctx, accountsStorage)
+	setupChallenges(ctx, client)
+
+	if account.Registration == nil {
+		reg, err := register(ctx, client)
+		if err != nil {
+			log.Fatalf("Could not complete registration\n\t%v", err)
+		}
+
+		account.Registration = reg
+		if err = accountsStorage.Save(account); err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf(rootPathWarningMessage, accountsStorage.GetRootPath())
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -17,7 +17,7 @@ import (
 func createRun() *cli.Command {
 	return &cli.Command{
 		Name:  "run",
-		Usage: "Register an account, then create and install a certificate",
+		Usage: "Register an account (if not registered), then create and install a certificate",
 		Before: func(ctx *cli.Context) error {
 			// we require either domains or csr, but not both
 			hasDomains := len(ctx.StringSlice("domains")) > 0


### PR DESCRIPTION
When using lego in an EAB infrastructure, having the ability to test the registration first will help ensure that the eab is correct before going on with creating an ACME request for a certificate.