### PR TITLE
constellix: handle rate limiting

### DIFF
--- a/providers/dns/constellix/internal/client.go
+++ b/providers/dns/constellix/internal/client.go
@@ -62,6 +62,11 @@ func (c *Client) do(req *http.Request, result any) error {
 
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == 429 {
+		time.Sleep(5 * time.Second)
+		return c.do(req, result)
+	}
+
 	err = checkResponse(resp)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi,

Constellix has quite strict limits on REST API requests. When retrieving certificates for multiple domains (14 in my case) the following error happens:
```
[  3m5.995s] 2023/11/30 09:20:56 [INFO] [domain.io] acme: Cleaning DNS-01 challenge
[   3m6.43s] 2023/11/30 09:20:56 [WARN] [domain.io] acme: cleaning up failed: constellix: failed to get domain (domain.io.): 429: Rate limit exceeded 
```

Proposed fix retries the rate limited request in 5 seconds (constellix uses sliding window to track the number of requests).

Constellix provides [special headers](https://api.dns.constellix.com/v4/docs#section/Using-the-API/Rate-Limiting) to keep track of remaining requests, however the proposed fix is simpler and works well :) 
