### PR TITLE
cloudru: change default URLs

### DIFF
--- a/providers/dns/cloudru/internal/client.go
+++ b/providers/dns/cloudru/internal/client.go
@@ -16,8 +16,8 @@ import (
 
 // Default API endpoints.
 const (
-	APIBaseURL  = "https://console.sbercloud.ru/api/clouddns/v1"
-	AuthBaseURL = "https://auth.iam.sbercloud.ru/auth/system/openid/token"
+	APIBaseURL  = "https://console.cloud.ru/api/clouddns/v1"
+	AuthBaseURL = "https://auth.iam.cloud.ru/auth/system/openid/token"
 )
 
 // Client the Cloud.ru API client.


### PR DESCRIPTION
Changes:
- APIBaseURL changed: The variable has been changed because I was getting the RBAC access denied error. Technical support cloud.ru gave me an answer: "Danil, good afternoon! There is an error in our documentation, use the host console.cloud.ru instead of console.sbercloud.ru to send a request to the API." With the host console.cloud.ru the error is gone.

- AuthBaseURL changed: The old variable works too. But I think that soon they will completely migrate the host API from sbercloud.ru on cloud.ru .