### PR TITLE
gcloud: support GCE_ZONE_ID to bypass zone list

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1108,6 +1108,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "GCE_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "GCE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
 		ew.writeln(`	- "GCE_TTL":	The TTL of the TXT record used for the DNS challenge`)
+		ew.writeln(`	- "GCE_ZONE_ID":	Allows to skip the automatic detection of the zone`)
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/gcloud`)

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -58,6 +58,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GCE_POLLING_INTERVAL` | Time between DNS propagation check |
 | `GCE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 | `GCE_TTL` | The TTL of the TXT record used for the DNS challenge |
+| `GCE_ZONE_ID` | Allows to skip the automatic detection of the zone |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/providers/dns/gcloud/gcloud.toml
+++ b/providers/dns/gcloud/gcloud.toml
@@ -21,6 +21,7 @@ GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.
     GCE_SERVICE_ACCOUNT = "Account"
   [Configuration.Additional]
     GCE_ALLOW_PRIVATE_ZONE = "Allows requested domain to be in private DNS zone, works only with a private ACME server (by default: false)"
+    GCE_ZONE_ID = "Allows to skip the automatic detection of the zone"
     GCE_POLLING_INTERVAL = "Time between DNS propagation check"
     GCE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     GCE_TTL = "The TTL of the TXT record used for the DNS challenge"


### PR DESCRIPTION
The GCloud IAM permission system permits a zone to grant access to an actor, without the project granting any access. This can be used with Service Accounts to let an SA edit DNS in one particular zone, and nothing more.

Remove the need for the caller to have project-level role access granting the dns.managedZones.list permission, in exchange for the caller telling us the explicit zone ID to use, via the GCE_ZONE_ID environment variable.

-----

PR comment: sorry, I'm going to need help figuring out the test rig and how to set it up to fail the managedzones list call but succeed on zone edits, to add a test for this logic.

PR comment 2: this is #2073 redone from a personal repo at the request of a member of go-acme/lego