### PR TITLE
inwx: wait before generating new TOTP TANs

### DIFF
--- a/providers/dns/inwx/inwx_test.go
+++ b/providers/dns/inwx/inwx_test.go
@@ -2,8 +2,10 @@ package inwx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-acme/lego/v4/platform/tester"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -140,4 +142,46 @@ func TestLivePresentAndCleanup(t *testing.T) {
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")
 	require.NoError(t, err)
+}
+
+func Test_computeSleep(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		time     string
+		expected time.Duration
+	}{
+		{
+			desc:     "after 30s",
+			time:     "2024-01-01T06:29:20Z",
+			expected: 0 * time.Second,
+		},
+		{
+			desc:     "0s",
+			time:     "2024-01-01T06:29:30Z",
+			expected: 0 * time.Second,
+		},
+		{
+			desc:     "before 30s",
+			time:     "2024-01-01T06:29:50Z", // 10 s
+			expected: 20 * time.Second,
+		},
+	}
+
+	now, err := time.Parse(time.RFC3339, "2024-01-01T06:30:00Z")
+	require.NoError(t, err)
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			previous, err := time.Parse(time.RFC3339, test.time)
+			require.NoError(t, err)
+
+			d := &DNSProvider{previousCall: previous}
+
+			sleep := d.computeSleep(now)
+			assert.Equal(t, test.expected, sleep)
+		})
+	}
 }

--- a/providers/dns/inwx/inwx_test.go
+++ b/providers/dns/inwx/inwx_test.go
@@ -147,22 +147,22 @@ func TestLivePresentAndCleanup(t *testing.T) {
 func Test_computeSleep(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		time     string
+		previous string
 		expected time.Duration
 	}{
 		{
 			desc:     "after 30s",
-			time:     "2024-01-01T06:29:20Z",
+			previous: "2024-01-01T06:29:20Z",
 			expected: 0 * time.Second,
 		},
 		{
 			desc:     "0s",
-			time:     "2024-01-01T06:29:30Z",
+			previous: "2024-01-01T06:29:30Z",
 			expected: 0 * time.Second,
 		},
 		{
 			desc:     "before 30s",
-			time:     "2024-01-01T06:29:50Z", // 10 s
+			previous: "2024-01-01T06:29:50Z", // 10 s
 			expected: 20 * time.Second,
 		},
 	}
@@ -175,10 +175,10 @@ func Test_computeSleep(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			previous, err := time.Parse(time.RFC3339, test.time)
+			previous, err := time.Parse(time.RFC3339, test.previous)
 			require.NoError(t, err)
 
-			d := &DNSProvider{previousCall: previous}
+			d := &DNSProvider{previousUnlock: previous}
 
 			sleep := d.computeSleep(now)
 			assert.Equal(t, test.expected, sleep)


### PR DESCRIPTION
This is a workaround for #1608.  INWX forbids to re-use the same TOTP twice, but the INWX DNS provider tries to reauthenticate from scratch on each step.

I believe that this is not easily implementable with the existing Lego DNS provider interface, so to avoid refactoring that interaction, let's just make the INWX provider wait a bit until a new token is available.  A new token is available every 30 seconds.

The current workaround is to invoke Lego many more times.  Retrying at a higher level is worse than retrying here.

Fixes #1608