### PR TITLE
inwx: improve sleep calculation

### DIFF
--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -211,19 +211,21 @@ func (d *DNSProvider) twoFactorAuth(info *goinwx.LoginResponse) error {
 		time.Sleep(sleep)
 	}
 
-	tan, err := totp.GenerateCode(d.config.SharedSecret, time.Now())
+	now := time.Now()
+
+	tan, err := totp.GenerateCode(d.config.SharedSecret, now)
 	if err != nil {
 		return err
 	}
 
-	d.previousUnlock = time.Now()
+	d.previousUnlock = now.Truncate(30 * time.Second)
 
 	return d.client.Account.Unlock(tan)
 }
 
 func (d *DNSProvider) computeSleep(now time.Time) time.Duration {
 	if d.previousUnlock.IsZero() {
-		return 0 * time.Second
+		return 0
 	}
 
 	endPeriod := d.previousUnlock.Add(30 * time.Second)
@@ -231,5 +233,5 @@ func (d *DNSProvider) computeSleep(now time.Time) time.Duration {
 		return endPeriod.Sub(now)
 	}
 
-	return 0 * time.Second
+	return 0
 }

--- a/providers/dns/inwx/inwx_test.go
+++ b/providers/dns/inwx/inwx_test.go
@@ -147,27 +147,27 @@ func TestLivePresentAndCleanup(t *testing.T) {
 func Test_computeSleep(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		previous string
+		now      string
 		expected time.Duration
 	}{
 		{
 			desc:     "after 30s",
-			previous: "2024-01-01T06:29:20Z",
+			now:      "2024-01-01T06:30:30Z",
 			expected: 0 * time.Second,
 		},
 		{
 			desc:     "0s",
-			previous: "2024-01-01T06:29:30Z",
+			now:      "2024-01-01T06:30:00Z",
 			expected: 0 * time.Second,
 		},
 		{
 			desc:     "before 30s",
-			previous: "2024-01-01T06:29:50Z", // 10 s
+			now:      "2024-01-01T06:29:40Z", // 10 s
 			expected: 20 * time.Second,
 		},
 	}
 
-	now, err := time.Parse(time.RFC3339, "2024-01-01T06:30:00Z")
+	previous, err := time.Parse(time.RFC3339, "2024-01-01T06:29:30Z")
 	require.NoError(t, err)
 
 	for _, test := range testCases {
@@ -175,7 +175,7 @@ func Test_computeSleep(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			previous, err := time.Parse(time.RFC3339, test.previous)
+			now, err := time.Parse(time.RFC3339, test.now)
 			require.NoError(t, err)
 
 			d := &DNSProvider{previousUnlock: previous}


### PR DESCRIPTION
https://github.com/go-acme/lego/pull/2084#discussion_r1458040487

<details>

```go
package foo

import (
	"encoding/base32"
	"testing"
	"time"

	"github.com/pquerna/otp/totp"
	"github.com/stretchr/testify/assert"
	"github.com/stretchr/testify/require"
)

func TestTOTP(t *testing.T) {
	testCases := []struct {
		desc     string
		now      string
		expected string
		counter  string
	}{
		{
			desc:     "TAN A",
			now:      "2024-01-01T06:29:59Z",
			expected: "801386",
			counter:  "2024-01-01T06:29:30Z",
		},
		{
			desc:     "TAN B [1]",
			now:      "2024-01-01T06:30:00Z",
			expected: "078251",
			counter:  "2024-01-01T06:30:00Z",
		},
		{
			desc:     "TAN B [2]",
			now:      "2024-01-01T06:30:29Z",
			expected: "078251",
			counter:  "2024-01-01T06:30:00Z",
		},
		{
			desc:     "TAN C [1]",
			now:      "2024-01-01T06:30:30Z",
			expected: "521951",
			counter:  "2024-01-01T06:30:30Z",
		},
		{
			desc:     "TAN C [2]",
			now:      "2024-01-01T06:30:31Z",
			expected: "521951",
			counter:  "2024-01-01T06:30:30Z",
		},
		{
			desc:     "TAN D [1]",
			now:      "2024-01-01T06:31:10Z",
			expected: "650525",
			counter:  "2024-01-01T06:31:00Z",
		},
	}

	for _, test := range testCases {
		test := test
		t.Run(test.desc, func(t *testing.T) {
			t.Parallel()

			now, err := time.Parse(time.RFC3339, test.now)
			require.NoError(t, err)

			tan, err := totp.GenerateCode(base32.StdEncoding.EncodeToString([]byte("secret")), now)
			require.NoError(t, err)

			assert.Equal(t, test.expected, tan)

			counter, err := time.Parse(time.RFC3339, test.counter)
			require.NoError(t, err)

			assert.Equal(t, counter, now.Truncate(30*time.Second))
		})
	}
}
```

</details>

