### PR TITLE
route53: fix example

### DIFF
--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -30,7 +30,7 @@ AWS_ACCESS_KEY_ID=your_key_id \
 AWS_SECRET_ACCESS_KEY=your_secret_access_key \
 AWS_REGION=aws-region \
 AWS_HOSTED_ZONE_ID=your_hosted_zone_id \
- --domains example.com --email your_example@email.com --dns route53 --accept-tos=true run
+lego --domains example.com --email your_example@email.com --dns route53 --accept-tos=true run
 ```
 
 

--- a/providers/dns/route53/route53.toml
+++ b/providers/dns/route53/route53.toml
@@ -9,7 +9,7 @@ AWS_ACCESS_KEY_ID=your_key_id \
 AWS_SECRET_ACCESS_KEY=your_secret_access_key \
 AWS_REGION=aws-region \
 AWS_HOSTED_ZONE_ID=your_hosted_zone_id \
- --domains example.com --email your_example@email.com --dns route53 --accept-tos=true run
+lego --domains example.com --email your_example@email.com --dns route53 --accept-tos=true run
 '''
 
 Additional = '''


### PR DESCRIPTION
The example was missing the `lego` command.