### PR TITLE
Add flag to only include manual DNS provider

### DIFF
--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -1,3 +1,5 @@
+//go:build !manualdnsonly
+
 package dns
 
 import (

--- a/providers/dns/dns_providers_manual.go
+++ b/providers/dns/dns_providers_manual.go
@@ -1,0 +1,20 @@
+//go:build manualdnsonly
+
+package dns
+
+import (
+	"fmt"
+	"github.com/go-acme/lego/v4/challenge/dns01"
+
+	"github.com/go-acme/lego/v4/challenge"
+)
+
+// NewDNSChallengeProviderByName Factory for DNS providers.
+func NewDNSChallengeProviderByName(name string) (challenge.Provider, error) {
+	switch name {
+	case "manual":
+		return dns01.NewDNSProviderManual()
+	default:
+		return nil, fmt.Errorf("unrecognized DNS provider: %s", name)
+	}
+}


### PR DESCRIPTION
# General idea

When using lego as a library, having support of all the DNS providers is not always useful. 
It adds a huge amount of dependencies,  considerably increasing library size (50MB+ difference).
The idea is to be able to disable these third parties by setting a compile time flag to use when you do not need these implementations. 



