### PR TITLE
ns1: fix record creation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      GOLANGCI_LINT_VERSION: ${{vars.GOLANGCI_LINT_VERSION}}
-      HUGO_VERSION: ${{vars.HUGO_VERSION}}
+      GOLANGCI_LINT_VERSION: v1.56.1
+      HUGO_VERSION: 0.117.0
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI
       MEMCACHED_HOSTS: localhost:11211

--- a/providers/dns/ns1/ns1.go
+++ b/providers/dns/ns1/ns1.go
@@ -97,7 +97,9 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	if errors.Is(err, rest.ErrRecordMissing) || record == nil {
 		log.Infof("Create a new record for [zone: %s, fqdn: %s, domain: %s]", zone.Zone, info.EffectiveFQDN, domain)
 
-		record = dns.NewRecord(zone.Zone, dns01.UnFqdn(info.EffectiveFQDN), "TXT", nil, nil)
+		// Work through a bug in the NS1 API library that causes 400 Input validation failed (Value None for field '<obj>.filters' is not of type ...)
+		// So the `tags` and `blockedTags` parameters should be initialized to empty.
+		record = dns.NewRecord(zone.Zone, dns01.UnFqdn(info.EffectiveFQDN), "TXT", make(map[string]string), make([]string, 0))
 		record.TTL = d.config.TTL
 		record.Answers = []*dns.Answer{{Rdata: []string{info.Value}}}
 


### PR DESCRIPTION
Regression on the API client from a breaking change of the NS1 API client: https://github.com/ns1/ns1-go/pull/220

Same problem as https://github.com/ns1/ns1-go/pull/51

```
unable to generate a certificate for the domains [*.internal.redacted.com internal.redacted.com internal.redacted.com]:
error: one or more domains had a problem:
[*.internal.redacted.com] [*.internal.redacted.com] acme: error presenting token:
ns1: failed to create record [zone: \"internal.redacted.com\", fqdn: \"_acme-challenge.internal.redacted.com.\"]: PUT https://api.nsone.net/v1/zones/internal.redacted.com/_acme-challenge.internal.redacted.com/TXT: 400 Input validation failed (Value None for field '<obj>.tags' is not of type object)
[internal.redacted.com] [internal.redacted.com] acme: error presenting token:
ns1: failed to create record [zone: \"internal.redacted.com\", fqdn: \"_acme-challenge.internal.redacted.com.\"]: PUT https://api.nsone.net/v1/zones/internal.redacted.com/_acme-challenge.internal.redacted.com/TXT: 400 Input validation failed (Value None for field '<obj>.tags' is not of type object)
```

Related to:
- https://github.com/traefik/traefik/issues/10450
- https://github.com/ns1/ns1-go/issues/224