### PR TITLE
bunny: Support delegated sub-domains

### DIFF
--- a/providers/dns/bunny/bunny.go
+++ b/providers/dns/bunny/bunny.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
-	"github.com/miekg/dns"
 	"github.com/nrdcg/bunny-go"
 )
 
@@ -191,28 +190,9 @@ func getZone(fqdn string) (string, error) {
 		return "", err
 	}
 
-	zone, _, err := splitDomain(dns01.UnFqdn(authZone))
-	if err != nil {
-		return "", err
-	}
+	zone := dns01.UnFqdn(authZone)
 
 	return zone, nil
-}
-
-func splitDomain(full string) (string, string, error) {
-	split := dns.Split(full)
-	if len(split) < 2 {
-		return "", "", fmt.Errorf("unsupported domain: %s", full)
-	}
-
-	if len(split) == 2 {
-		return full, "", nil
-	}
-
-	domain := full[split[len(split)-2]:]
-	subDomain := full[:split[len(split)-2]-1]
-
-	return domain, subDomain, nil
 }
 
 func pointer[T string | int | int32 | int64](v T) *T { return &v }

--- a/providers/dns/bunny/bunny_test.go
+++ b/providers/dns/bunny/bunny_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/go-acme/lego/v4/platform/tester"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,84 +122,4 @@ func TestLiveCleanUp(t *testing.T) {
 
 	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")
 	require.NoError(t, err)
-}
-
-func Test_splitDomain(t *testing.T) {
-	type expected struct {
-		root       string
-		sub        string
-		requireErr require.ErrorAssertionFunc
-	}
-
-	testCases := []struct {
-		desc     string
-		domain   string
-		expected expected
-	}{
-		{
-			desc:   "empty",
-			domain: "",
-			expected: expected{
-				requireErr: require.Error,
-			},
-		},
-		{
-			desc:   "2 levels",
-			domain: "example.com",
-			expected: expected{
-				root:       "example.com",
-				sub:        "",
-				requireErr: require.NoError,
-			},
-		},
-		{
-			desc:   "3 levels",
-			domain: "_acme-challenge.example.com",
-			expected: expected{
-				root:       "example.com",
-				sub:        "_acme-challenge",
-				requireErr: require.NoError,
-			},
-		},
-		{
-			desc:   "4 levels",
-			domain: "_acme-challenge.sub.example.com",
-			expected: expected{
-				root:       "example.com",
-				sub:        "_acme-challenge.sub",
-				requireErr: require.NoError,
-			},
-		},
-		{
-			desc:   "5 levels",
-			domain: "_acme-challenge.my.sub.example.com",
-			expected: expected{
-				root:       "example.com",
-				sub:        "_acme-challenge.my.sub",
-				requireErr: require.NoError,
-			},
-		},
-		{
-			desc:   "6 levels",
-			domain: "_acme-challenge.my.sub.sub.example.com",
-			expected: expected{
-				root:       "example.com",
-				sub:        "_acme-challenge.my.sub.sub",
-				requireErr: require.NoError,
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			root, sub, err := splitDomain(test.domain)
-			test.expected.requireErr(t, err)
-
-			assert.Equal(t, test.expected.root, root)
-			assert.Equal(t, test.expected.sub, sub)
-		})
-	}
 }


### PR DESCRIPTION
The splitDomain algorithm assumes the apex domain is of "length" 2 and disregards where the SOA is found. This might have been the only way this provider could work in the past, but at this time it seems bunny responds with a correct SOA-RR.

Virtual ( pseudo) sub-domain with A-RR continue to function.