### PR TITLE
chore: add snap to release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Snapcraft login
         env:
-          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: snapcraft login
 
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
+      - name: Snapcraft login
+        env:
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: snapcraft login
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+
       - name: Snapcraft login
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -141,3 +141,31 @@ dockers:
       - '--label=org.opencontainers.image.revision={{.FullCommit}}'
       - '--label=org.opencontainers.image.version={{.Version}}'
       - '--platform=linux/arm/v7'
+
+snapcrafts:
+  - name: lego
+    grade: stable
+    confinement: strict
+    license: MIT
+    base: core22
+    publish: true
+    summary: LEGO is a Let's Encrypt client.
+    description: |
+      LEGO is a Let's Encrypt client written in Go.
+
+      The LEGO snap makes it easy to install and use LEGO on any Linux distribution that supports snaps.
+    
+      Usage:
+      * `sudo snap install lego`
+      * `sudo lego --email="you@example.com" --domains="example.com" --server=https://acme-staging-v02.api.letsencrypt.org/directory --http --http.port :8080 run
+    
+    channel_templates:
+      - edge
+
+    apps:
+      lego:
+        command: bin/lego
+        environment:
+          LEGO_PATH: /var/snap/lego/common/.lego
+        plugs:
+          - network-bind

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -149,11 +149,11 @@ snapcrafts:
     license: MIT
     base: core22
     publish: true
-    summary: LEGO is a Let's Encrypt client.
+    summary: Lego is a Let's Encrypt/ACME client.
     description: |
-      LEGO is a Let's Encrypt client written in Go.
+      Lego is a Let's Encrypt/ACME client written in Go.
 
-      The LEGO snap makes it easy to install and use LEGO on any Linux distribution that supports snaps.
+      The lego snap makes it easy to install and use Lego on any Linux distribution that supports snaps.
     
       Usage:
       * `sudo snap install lego`

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -30,6 +30,12 @@ docker run goacme/lego -h
   yay -S lego-bin
   ```
 
+- [Snap](https://snapcraft.io/lego) (official):
+
+  ```bash
+  sudo snap install lego
+  ```
+
 - [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):
 
   ```bash


### PR DESCRIPTION
# Description

The LEGO snap makes it easy to install and use LEGO on any Linux distribution that supports snaps. This PR adds the snap to go releaser to automatically build and publish the snap. 

## Usage

```bash
sudo snap install lego
sudo lego \
  --email="you@example.com" \
  --domains="example.com" \
  --server=https://acme-staging-v02.api.letsencrypt.org/directory \
  --http \
  --http.port :8080 \
  run
```

**Note**: The LEGO snap can only write to the `/var/snap/lego/common/.lego` directory.

## Confinement

The snap is strictly confined, meaning it only has access to what it requires to work and for LEGO that means [network binding](https://snapcraft.io/docs/network-bind-interface). 

## Snap publishing

For the snap publishing to succeed, it will be necessary to do the following before merging this PR:
1. Create a snapcraft account
2. Make a request in the [snapcraft forum](https://forum.snapcraft.io/c/store-requests/) to have the ownership of the `lego` snap name switched from myself to this new account. I can make the request myself once we have step 1 completed. 
3. Generate a snapcraft login token attached to this specific snap with a reasonable ttl
4. Place this token in a GitHub secret named `SNAPCRAFT_STORE_CREDENTIALS`

Once all of those are completed, I will move the PR from draft to live.

## Channel

With the current state of the change proposed here, the snap will be automatically published to the `edge` channel. This means that promotion from edge -> beta -> candidate -> stable would have to be done manually through the Snapcraft UI.


Related to https://github.com/go-acme/lego/discussions/2133