### PR TITLE
scaleway: add alternative env var names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **[dnsprovider]** Add DNS provider for Shellrent
 - **[dnsprovider]** Add DNS provider for Mail-in-a-Box
 - **[dnsprovider]** Add DNS provider for CPanel and WHM
-- 
+
 ### Changed
 
 - **[lib,ari]** Implement 'replaces' field in newOrder and draft-ietf-acme-ari-03 CertID changes

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2363,14 +2363,15 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "SCALEWAY_API_TOKEN":	API token`)
-		ew.writeln(`	- "SCALEWAY_PROJECT_ID":	Project to use (optional)`)
+		ew.writeln(`	- "SCW_PROJECT_ID":	Project to use (optional)`)
+		ew.writeln(`	- "SCW_SECRET_KEY":	Secret key`)
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
-		ew.writeln(`	- "SCALEWAY_POLLING_INTERVAL":	Time between DNS propagation check`)
-		ew.writeln(`	- "SCALEWAY_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
-		ew.writeln(`	- "SCALEWAY_TTL":	The TTL of the TXT record used for the DNS challenge`)
+		ew.writeln(`	- "SCW_ACCESS_KEY":	Access key`)
+		ew.writeln(`	- "SCW_POLLING_INTERVAL":	Time between DNS propagation check`)
+		ew.writeln(`	- "SCW_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
+		ew.writeln(`	- "SCW_TTL":	The TTL of the TXT record used for the DNS challenge`)
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/scaleway`)

--- a/docs/content/dns/zz_gen_scaleway.md
+++ b/docs/content/dns/zz_gen_scaleway.md
@@ -26,7 +26,7 @@ Configuration for [Scaleway](https://developers.scaleway.com/).
 Here is an example bash command using the Scaleway provider:
 
 ```bash
-SCALEWAY_API_TOKEN=xxxxxxx-xxxxx-xxxx-xxx-xxxxxx \
+SCW_SECRET_KEY=xxxxxxx-xxxxx-xxxx-xxx-xxxxxx \
 lego --email you@example.com --dns scaleway --domains my.example.org run
 ```
 
@@ -37,8 +37,8 @@ lego --email you@example.com --dns scaleway --domains my.example.org run
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `SCALEWAY_API_TOKEN` | API token |
-| `SCALEWAY_PROJECT_ID` | Project to use (optional) |
+| `SCW_PROJECT_ID` | Project to use (optional) |
+| `SCW_SECRET_KEY` | Secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).
@@ -48,9 +48,10 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `SCALEWAY_POLLING_INTERVAL` | Time between DNS propagation check |
-| `SCALEWAY_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
-| `SCALEWAY_TTL` | The TTL of the TXT record used for the DNS challenge |
+| `SCW_ACCESS_KEY` | Access key |
+| `SCW_POLLING_INTERVAL` | Time between DNS propagation check |
+| `SCW_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `SCW_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/providers/dns/scaleway/scaleway.toml
+++ b/providers/dns/scaleway/scaleway.toml
@@ -5,18 +5,19 @@ Code = "scaleway"
 Since = "v3.4.0"
 
 Example = '''
-SCALEWAY_API_TOKEN=xxxxxxx-xxxxx-xxxx-xxx-xxxxxx \
+SCW_SECRET_KEY=xxxxxxx-xxxxx-xxxx-xxx-xxxxxx \
 lego --email you@example.com --dns scaleway --domains my.example.org run
 '''
 
 [Configuration]
   [Configuration.Credentials]
-    SCALEWAY_API_TOKEN = "API token"
-    SCALEWAY_PROJECT_ID = "Project to use (optional)"
+    SCW_SECRET_KEY = "Secret key"
+    SCW_PROJECT_ID = "Project to use (optional)"
   [Configuration.Additional]
-    SCALEWAY_POLLING_INTERVAL = "Time between DNS propagation check"
-    SCALEWAY_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
-    SCALEWAY_TTL = "The TTL of the TXT record used for the DNS challenge"
+    SCW_ACCESS_KEY = "Access key"
+    SCW_POLLING_INTERVAL = "Time between DNS propagation check"
+    SCW_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
+    SCW_TTL = "The TTL of the TXT record used for the DNS challenge"
 
 [Links]
   API = "https://developers.scaleway.com/en/products/domain/dns/api/"

--- a/providers/dns/scaleway/scaleway_test.go
+++ b/providers/dns/scaleway/scaleway_test.go
@@ -12,7 +12,7 @@ import (
 
 const envDomain = envNamespace + "DOMAIN"
 
-var envTest = tester.NewEnvTest(EnvAPIToken, EnvProjectID).
+var envTest = tester.NewEnvTest(EnvAPIToken, EnvSecretKey, EnvAccessKey, EnvProjectID).
 	WithDomain(envDomain)
 
 func TestNewDNSProvider(t *testing.T) {
@@ -34,7 +34,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvAPIToken:  "",
 				EnvProjectID: "",
 			},
-			expected: fmt.Sprintf("scaleway: some credentials information are missing: %s", EnvAPIToken),
+			expected: fmt.Sprintf("scaleway: some credentials information are missing: %s", EnvSecretKey),
 		},
 	}
 


### PR DESCRIPTION
The official Scaleway doc uses some env var naming: https://www.scaleway.com/en/developers/api/domains-and-dns/

To be less confusing for users, I added alternative env var names.

Related to #2135