### PR TITLE
pdns: reconstruct zone URLs to enable non-root folder API endpoints

### DIFF
--- a/providers/dns/pdns/internal/client.go
+++ b/providers/dns/pdns/internal/client.go
@@ -117,7 +117,7 @@ func (c *Client) GetHostedZone(ctx context.Context, authZone string) (*HostedZon
 }
 
 func (c *Client) UpdateRecords(ctx context.Context, zone *HostedZone, sets RRSets) error {
-	endpoint := c.joinPath("/", zone.URL)
+	endpoint := c.joinPath("/", "servers", c.serverName, "zones", zone.ID)
 
 	req, err := newJSONRequest(ctx, http.MethodPatch, endpoint, sets)
 	if err != nil {
@@ -137,7 +137,7 @@ func (c *Client) Notify(ctx context.Context, zone *HostedZone) error {
 		return nil
 	}
 
-	endpoint := c.joinPath("/", zone.URL, "/notify")
+	endpoint := c.joinPath("/", "servers", c.serverName, "zones", zone.ID, "notify")
 
 	req, err := newJSONRequest(ctx, http.MethodPut, endpoint, nil)
 	if err != nil {

--- a/providers/dns/pdns/internal/client_test.go
+++ b/providers/dns/pdns/internal/client_test.go
@@ -254,13 +254,14 @@ func TestClient_GetHostedZone_v0(t *testing.T) {
 }
 
 func TestClient_UpdateRecords(t *testing.T) {
-	client := setupTest(t, http.MethodPatch, "/api/v1/servers/server/zones/example.org.", http.StatusOK, "zone.json")
+	client := setupTest(t, http.MethodPatch, "/api/v1/servers/localhost/zones/example.org.", http.StatusOK, "zone.json")
 	client.apiVersion = 1
+	client.serverName = "localhost"
 
 	zone := &HostedZone{
 		ID:   "example.org.",
 		Name: "example.org.",
-		URL:  "api/v1/servers/server/zones/example.org.",
+		URL:  "api/v1/servers/localhost/zones/example.org.",
 		Kind: "Master",
 	}
 
@@ -283,9 +284,10 @@ func TestClient_UpdateRecords(t *testing.T) {
 }
 
 func TestClient_UpdateRecords_NonRootApi(t *testing.T) {
-	client := setupTest(t, http.MethodPatch, "/some/path/api/v1/servers/server/zones/example.org.", http.StatusOK, "zone.json")
+	client := setupTest(t, http.MethodPatch, "/some/path/api/v1/servers/localhost/zones/example.org.", http.StatusOK, "zone.json")
 	client.Host = client.Host.JoinPath("some", "path")
 	client.apiVersion = 1
+	client.serverName = "localhost"
 
 	zone := &HostedZone{
 		ID:   "example.org.",
@@ -313,13 +315,14 @@ func TestClient_UpdateRecords_NonRootApi(t *testing.T) {
 }
 
 func TestClient_UpdateRecords_v0(t *testing.T) {
-	client := setupTest(t, http.MethodPatch, "/servers/server/zones/example.org.", http.StatusOK, "zone.json")
+	client := setupTest(t, http.MethodPatch, "/servers/localhost/zones/example.org.", http.StatusOK, "zone.json")
 	client.apiVersion = 0
+	client.serverName = "localhost"
 
 	zone := &HostedZone{
 		ID:   "example.org.",
 		Name: "example.org.",
-		URL:  "servers/server/zones/example.org.",
+		URL:  "servers/localhost/zones/example.org.",
 		Kind: "Master",
 	}
 
@@ -342,13 +345,14 @@ func TestClient_UpdateRecords_v0(t *testing.T) {
 }
 
 func TestClient_Notify(t *testing.T) {
-	client := setupTest(t, http.MethodPut, "/api/v1/servers/server/zones/example.org./notify", http.StatusOK, "")
+	client := setupTest(t, http.MethodPut, "/api/v1/servers/localhost/zones/example.org./notify", http.StatusOK, "")
 	client.apiVersion = 1
+	client.serverName = "localhost"
 
 	zone := &HostedZone{
 		ID:   "example.org.",
 		Name: "example.org.",
-		URL:  "api/v1/servers/server/zones/example.org.",
+		URL:  "api/v1/servers/localhost/zones/example.org.",
 		Kind: "Master",
 	}
 
@@ -357,9 +361,10 @@ func TestClient_Notify(t *testing.T) {
 }
 
 func TestClient_Notify_NonRootApi(t *testing.T) {
-	client := setupTest(t, http.MethodPut, "/some/path/api/v1/servers/server/zones/example.org./notify", http.StatusOK, "")
+	client := setupTest(t, http.MethodPut, "/some/path/api/v1/servers/localhost/zones/example.org./notify", http.StatusOK, "")
 	client.Host = client.Host.JoinPath("some", "path")
 	client.apiVersion = 1
+	client.serverName = "localhost"
 
 	zone := &HostedZone{
 		ID:   "example.org.",
@@ -373,13 +378,13 @@ func TestClient_Notify_NonRootApi(t *testing.T) {
 }
 
 func TestClient_Notify_v0(t *testing.T) {
-	client := setupTest(t, http.MethodPut, "/not/queried/for/api/version/0", http.StatusOK, "")
+	client := setupTest(t, http.MethodPut, "/api/v1/servers/localhost/zones/example.org./notify", http.StatusOK, "")
 	client.apiVersion = 0
 
 	zone := &HostedZone{
 		ID:   "example.org.",
 		Name: "example.org.",
-		URL:  "servers/server/zones/example.org.",
+		URL:  "servers/localhost/zones/example.org.",
 		Kind: "Master",
 	}
 


### PR DESCRIPTION
As I was trying to both better understand the behavior and create a patch for myself that makes lego work for my DNS provider's API, I have implemented a fix for #2128 even as the discussion in the issue has not yet progressed any further. If you require further discussion before this PR should be considered, please let me know.

This corresponds to the first of the two solutions, that I've proposed in #2128. It replaces the usage of the (at least for my provider) absolute URL `zone.URL`, which resulted in incorrect URLs being used when the API endpoint is not located at the server's root, by relative URLs. AFAICS, these should now work in all cases (both if the API endpoint is located at the server's root and if it isn't).

The two added test cases for non-root API endpoints also demonstrate the issue (if you add them without the changes to the code, the tests fail).

The constructed URLs reflect the URLs as they are documented in the PDNS API documentation for [the update for a specific zone](https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id) and for [notifying for a specific zone](https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id-notify). The description in the API is not 100% unambiguous as `{zone_id}` is not explicitly defined as to be the same as the Zone's ID returned by the API for that zone (as `"id"`). But both conceptually (as the zone's ID's main feature is URL-embedability) and from looking at the PDNS code (at least to the level that I could dig through it without spending a lot of time on it), this should be the case. If this is true, I don't see a downside of constructing the URLs in this way for existing use cases and it enables mine.

Sadly, I don't have a PDNS installation to play with and test this further (and also no time to set one up for this). Therefore, I cannot verify myself that it properly works in all cases except for the automated tests and my considerations listed above.

Fixes #2128