### PR TITLE
ovh: add OAuth2 authentication

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2099,11 +2099,11 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "OVH_APPLICATION_KEY":	Application key`)
-		ew.writeln(`	- "OVH_APPLICATION_SECRET":	Application secret`)
+		ew.writeln(`	- "OVH_APPLICATION_KEY":	Application key (Application Key authentication)`)
+		ew.writeln(`	- "OVH_APPLICATION_SECRET":	Application secret (Application Key authentication)`)
 		ew.writeln(`	- "OVH_CLIENT_ID":	Client ID (OAuth2)`)
 		ew.writeln(`	- "OVH_CLIENT_SECRET":	Client secret (OAuth2)`)
-		ew.writeln(`	- "OVH_CONSUMER_KEY":	Consumer key`)
+		ew.writeln(`	- "OVH_CONSUMER_KEY":	Consumer key (Application Key authentication)`)
 		ew.writeln(`	- "OVH_ENDPOINT":	Endpoint URL (ovh-eu or ovh-ca)`)
 		ew.writeln()
 

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2101,6 +2101,8 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "OVH_APPLICATION_KEY":	Application key`)
 		ew.writeln(`	- "OVH_APPLICATION_SECRET":	Application secret`)
+		ew.writeln(`	- "OVH_CLIENT_ID":	Client ID (OAuth2)`)
+		ew.writeln(`	- "OVH_CLIENT_SECRET":	Client secret (OAuth2)`)
 		ew.writeln(`	- "OVH_CONSUMER_KEY":	Consumer key`)
 		ew.writeln(`	- "OVH_ENDPOINT":	Endpoint URL (ovh-eu or ovh-ca)`)
 		ew.writeln()

--- a/docs/content/dns/zz_gen_ovh.md
+++ b/docs/content/dns/zz_gen_ovh.md
@@ -26,9 +26,18 @@ Configuration for [OVH](https://www.ovh.com/).
 Here is an example bash command using the OVH provider:
 
 ```bash
+# Application Key authentication:
+
 OVH_APPLICATION_KEY=1234567898765432 \
 OVH_APPLICATION_SECRET=b9841238feb177a84330febba8a832089 \
 OVH_CONSUMER_KEY=256vfsd347245sdfg \
+OVH_ENDPOINT=ovh-eu \
+lego --email you@example.com --dns ovh --domains my.example.org run
+
+# Or OAuth2:
+
+OVH_CLIENT_ID=yyy \
+OVH_CLIENT_SECRET=xxx \
 OVH_ENDPOINT=ovh-eu \
 lego --email you@example.com --dns ovh --domains my.example.org run
 ```
@@ -40,11 +49,11 @@ lego --email you@example.com --dns ovh --domains my.example.org run
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `OVH_APPLICATION_KEY` | Application key |
-| `OVH_APPLICATION_SECRET` | Application secret |
+| `OVH_APPLICATION_KEY` | Application key (Application Key authentication) |
+| `OVH_APPLICATION_SECRET` | Application secret (Application Key authentication) |
 | `OVH_CLIENT_ID` | Client ID (OAuth2) |
 | `OVH_CLIENT_SECRET` | Client secret (OAuth2) |
-| `OVH_CONSUMER_KEY` | Consumer key |
+| `OVH_CONSUMER_KEY` | Consumer key (Application Key authentication) |
 | `OVH_ENDPOINT` | Endpoint URL (ovh-eu or ovh-ca) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
@@ -90,13 +99,13 @@ Another method for authentication is by using OAuth2 client credentials.
 
 An IAM policy and service account can be created by following the [OVH guide](https://help.ovhcloud.com/csm/en-manage-service-account?id=kb_article_view&sysparm_article=KB0059343).
 
-Following IAM policies need to be authorized for the affected domain :
+Following IAM policies need to be authorized for the affected domain:
 
 * dnsZone:apiovh:record/create
 * dnsZone:apiovh:record/delete
 * dnsZone:apiovh:refresh
 
-## Important note
+## Important Note
 
 Both authentication methods cannot be used at the same time.
 

--- a/docs/content/dns/zz_gen_ovh.md
+++ b/docs/content/dns/zz_gen_ovh.md
@@ -42,6 +42,8 @@ lego --email you@example.com --dns ovh --domains my.example.org run
 |-----------------------|-------------|
 | `OVH_APPLICATION_KEY` | Application key |
 | `OVH_APPLICATION_SECRET` | Application secret |
+| `OVH_CLIENT_ID` | Client ID (OAuth2) |
+| `OVH_CLIENT_SECRET` | Client secret (OAuth2) |
 | `OVH_CONSUMER_KEY` | Consumer key |
 | `OVH_ENDPOINT` | Endpoint URL (ovh-eu or ovh-ca) |
 
@@ -81,6 +83,22 @@ When requesting the consumer key, the following configuration can be used to def
   ]
 }
 ```
+
+## OAuth2 Client Credentials
+
+Another method for authentication is by using OAuth2 client credentials.
+
+An IAM policy and service account can be created by following the [OVH guide](https://help.ovhcloud.com/csm/en-manage-service-account?id=kb_article_view&sysparm_article=KB0059343).
+
+Following IAM policies need to be authorized for the affected domain :
+
+* dnsZone:apiovh:record/create
+* dnsZone:apiovh:record/delete
+* dnsZone:apiovh:refresh
+
+## Important note
+
+Both authentication methods cannot be used at the same time.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/nrdcg/porkbun v0.3.0
 	github.com/nzdjb/go-metaname v1.0.0
 	github.com/oracle/oci-go-sdk/v65 v65.63.1
-	github.com/ovh/go-ovh v1.4.3
+	github.com/ovh/go-ovh v1.5.1
 	github.com/pquerna/otp v1.4.0
 	github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2
 	github.com/sacloud/api-client-go v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:Ff
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/oracle/oci-go-sdk/v65 v65.63.1 h1:dYL7sk9L1+C9LCmoq+zjPMNteuJJfk54YExq/4pV9xQ=
 github.com/oracle/oci-go-sdk/v65 v65.63.1/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
-github.com/ovh/go-ovh v1.4.3 h1:Gs3V823zwTFpzgGLZNI6ILS4rmxZgJwJCz54Er9LwD0=
-github.com/ovh/go-ovh v1.4.3/go.mod h1:AkPXVtgwB6xlKblMjRKJJmjRp+ogrE7fz2lVgcQY8SY=
+github.com/ovh/go-ovh v1.5.1 h1:P8O+7H+NQuFK9P/j4sFW5C0fvSS2DnHYGPwdVCp45wI=
+github.com/ovh/go-ovh v1.5.1/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -74,6 +74,10 @@ type Config struct {
 	HTTPClient         *http.Client
 }
 
+func (c *Config) hasAppKeyAuth() bool {
+	return c.ApplicationKey != "" || c.ApplicationSecret != "" || c.ConsumerKey != ""
+}
+
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
 	return &Config{
@@ -110,6 +114,10 @@ func NewDNSProvider() (*DNSProvider, error) {
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config == nil {
 		return nil, errors.New("ovh: the configuration of the DNS provider is nil")
+	}
+
+	if config.OAuth2Config != nil && config.hasAppKeyAuth() {
+		return nil, errors.New("ovh: can't use both authentication systems (ApplicationKey and OAuth2)")
 	}
 
 	client, err := newClient(config)

--- a/providers/dns/ovh/ovh.toml
+++ b/providers/dns/ovh/ovh.toml
@@ -33,6 +33,22 @@ When requesting the consumer key, the following configuration can be used to def
   ]
 }
 ```
+
+## OAuth2 client credentials
+
+Another method for authentication is by using OAuth2 client credentials.
+
+An IAM policy and service account can be created by following the [OVH guide](https://help.ovhcloud.com/csm/en-manage-service-account?id=kb_article_view&sysparm_article=KB0059343).
+
+Following IAM policies need to be authorized for the affected domain :
+
+* dnsZone:apiovh:record/create
+* dnsZone:apiovh:record/delete
+* dnsZone:apiovh:refresh
+
+## Important note
+
+Either authentication methods can be used **but** not both at the same time and doing so will result in an error.
 '''
 
 [Configuration]
@@ -41,6 +57,10 @@ When requesting the consumer key, the following configuration can be used to def
     OVH_APPLICATION_KEY = "Application key"
     OVH_APPLICATION_SECRET = "Application secret"
     OVH_CONSUMER_KEY = "Consumer key"
+  [Configuration.OAuth2Client]
+    OVH_ENDPOINT = "Endpoint URL (ovh-eu or ovh-ca)"
+    OVH_CLIENT_ID = "Client ID"
+    OVH_CLIENT_SECRET = "Client secret"
   [Configuration.Additional]
     OVH_POLLING_INTERVAL = "Time between DNS propagation check"
     OVH_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"

--- a/providers/dns/ovh/ovh.toml
+++ b/providers/dns/ovh/ovh.toml
@@ -5,9 +5,18 @@ Code = "ovh"
 Since = "v0.4.0"
 
 Example = '''
+# Application Key authentication:
+
 OVH_APPLICATION_KEY=1234567898765432 \
 OVH_APPLICATION_SECRET=b9841238feb177a84330febba8a832089 \
 OVH_CONSUMER_KEY=256vfsd347245sdfg \
+OVH_ENDPOINT=ovh-eu \
+lego --email you@example.com --dns ovh --domains my.example.org run
+
+# Or OAuth2:
+
+OVH_CLIENT_ID=yyy \
+OVH_CLIENT_SECRET=xxx \
 OVH_ENDPOINT=ovh-eu \
 lego --email you@example.com --dns ovh --domains my.example.org run
 '''
@@ -40,13 +49,13 @@ Another method for authentication is by using OAuth2 client credentials.
 
 An IAM policy and service account can be created by following the [OVH guide](https://help.ovhcloud.com/csm/en-manage-service-account?id=kb_article_view&sysparm_article=KB0059343).
 
-Following IAM policies need to be authorized for the affected domain :
+Following IAM policies need to be authorized for the affected domain:
 
 * dnsZone:apiovh:record/create
 * dnsZone:apiovh:record/delete
 * dnsZone:apiovh:refresh
 
-## Important note
+## Important Note
 
 Both authentication methods cannot be used at the same time.
 '''
@@ -54,9 +63,9 @@ Both authentication methods cannot be used at the same time.
 [Configuration]
   [Configuration.Credentials]
     OVH_ENDPOINT = "Endpoint URL (ovh-eu or ovh-ca)"
-    OVH_APPLICATION_KEY = "Application key"
-    OVH_APPLICATION_SECRET = "Application secret"
-    OVH_CONSUMER_KEY = "Consumer key"
+    OVH_APPLICATION_KEY = "Application key (Application Key authentication)"
+    OVH_APPLICATION_SECRET = "Application secret (Application Key authentication)"
+    OVH_CONSUMER_KEY = "Consumer key (Application Key authentication)"
     OVH_CLIENT_ID = "Client ID (OAuth2)"
     OVH_CLIENT_SECRET = "Client secret (OAuth2)"
   [Configuration.Additional]

--- a/providers/dns/ovh/ovh.toml
+++ b/providers/dns/ovh/ovh.toml
@@ -34,7 +34,7 @@ When requesting the consumer key, the following configuration can be used to def
 }
 ```
 
-## OAuth2 client credentials
+## OAuth2 Client Credentials
 
 Another method for authentication is by using OAuth2 client credentials.
 
@@ -48,7 +48,7 @@ Following IAM policies need to be authorized for the affected domain :
 
 ## Important note
 
-Either authentication methods can be used **but** not both at the same time and doing so will result in an error.
+Both authentication methods cannot be used at the same time.
 '''
 
 [Configuration]
@@ -57,10 +57,8 @@ Either authentication methods can be used **but** not both at the same time and 
     OVH_APPLICATION_KEY = "Application key"
     OVH_APPLICATION_SECRET = "Application secret"
     OVH_CONSUMER_KEY = "Consumer key"
-  [Configuration.OAuth2Client]
-    OVH_ENDPOINT = "Endpoint URL (ovh-eu or ovh-ca)"
-    OVH_CLIENT_ID = "Client ID"
-    OVH_CLIENT_SECRET = "Client secret"
+    OVH_CLIENT_ID = "Client ID (OAuth2)"
+    OVH_CLIENT_SECRET = "Client secret (OAuth2)"
   [Configuration.Additional]
     OVH_POLLING_INTERVAL = "Time between DNS propagation check"
     OVH_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -15,7 +15,7 @@ var envTest = tester.NewEnvTest(
 	EnvApplicationKey,
 	EnvApplicationSecret,
 	EnvConsumerKey,
-	EnvClientId,
+	EnvClientID,
 	EnvClientSecret).
 	WithDomain(envDomain)
 
@@ -38,7 +38,7 @@ func TestNewDNSProvider(t *testing.T) {
 			desc: "success client id",
 			envVars: map[string]string{
 				EnvEndpoint:     "ovh-eu",
-				EnvClientId:     "E",
+				EnvClientID:     "E",
 				EnvClientSecret: "F",
 			},
 		},
@@ -70,7 +70,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvApplicationSecret: "C",
 				EnvConsumerKey:       "D",
 			},
-			expected: "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
+			expected: "ovh: new client: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
 			desc: "missing application key",
@@ -106,7 +106,7 @@ func TestNewDNSProvider(t *testing.T) {
 			desc: "missing client secret",
 			envVars: map[string]string{
 				EnvEndpoint:     "ovh-eu",
-				EnvClientId:     "A",
+				EnvClientID:     "A",
 				EnvClientSecret: "",
 			},
 			expected: "ovh: some credentials information are missing: OVH_CLIENT_SECRET",
@@ -118,7 +118,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvApplicationKey:    "B",
 				EnvApplicationSecret: "C",
 				EnvConsumerKey:       "D",
-				EnvClientId:          "E",
+				EnvClientID:          "E",
 				EnvClientSecret:      "F",
 			},
 			expected: "ovh: set OVH_APPLICATION_KEY or OVH_CLIENT_ID but not both",
@@ -154,6 +154,8 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		applicationKey    string
 		applicationSecret string
 		consumerKey       string
+		clientID          string
+		clientSecret      string
 		expected          string
 	}{
 		{
@@ -168,7 +170,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			expected: "ovh: credentials missing",
 		},
 		{
-			desc:              "missing api endpoint",
+			desc:              "application key: missing api endpoint",
 			apiEndpoint:       "",
 			applicationKey:    "B",
 			applicationSecret: "C",
@@ -176,15 +178,15 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			expected:          "ovh: credentials missing",
 		},
 		{
-			desc:              "invalid api endpoint",
+			desc:              "application key: invalid api endpoint",
 			apiEndpoint:       "foobar",
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "D",
-			expected:          "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
+			expected:          "ovh: new client: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
-			desc:              "missing application key",
+			desc:              "application key: missing application key",
 			apiEndpoint:       "ovh-eu",
 			applicationKey:    "",
 			applicationSecret: "C",
@@ -192,7 +194,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			expected:          "ovh: credentials missing",
 		},
 		{
-			desc:              "missing application secret",
+			desc:              "application key: missing application secret",
 			apiEndpoint:       "ovh-eu",
 			applicationKey:    "B",
 			applicationSecret: "",
@@ -200,82 +202,42 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			expected:          "ovh: credentials missing",
 		},
 		{
-			desc:              "missing consumer key",
+			desc:              "application key: missing consumer key",
 			apiEndpoint:       "ovh-eu",
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "",
 			expected:          "ovh: credentials missing",
 		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.desc, func(t *testing.T) {
-			defer envTest.RestoreEnv()
-			envTest.ClearEnv()
-
-			config := NewDefaultConfig()
-			config.APIEndpoint = test.apiEndpoint
-			config.ApplicationKey = test.applicationKey
-			config.ApplicationSecret = test.applicationSecret
-			config.ConsumerKey = test.consumerKey
-
-			p, err := NewDNSProviderConfig(config)
-
-			if test.expected == "" {
-				require.NoError(t, err)
-				require.NotNil(t, p)
-				require.NotNil(t, p.config)
-				require.NotNil(t, p.client)
-				require.NotNil(t, p.recordIDs)
-			} else {
-				require.EqualError(t, err, test.expected)
-			}
-		})
-	}
-}
-
-func TestNewDNSProviderOAuth2Config(t *testing.T) {
-	testCases := []struct {
-		desc         string
-		apiEndpoint  string
-		clientID     string
-		clientSecret string
-		expected     string
-	}{
 		{
-			desc:         "success",
+			desc:         "oauth2: success",
 			apiEndpoint:  "ovh-eu",
 			clientID:     "B",
 			clientSecret: "C",
 		},
 		{
-			desc:     "missing credentials",
-			expected: "ovh: credentials missing",
-		},
-		{
-			desc:         "missing api endpoint",
+			desc:         "oauth2: missing api endpoint",
 			apiEndpoint:  "",
 			clientID:     "B",
 			clientSecret: "C",
 			expected:     "ovh: credentials missing",
 		},
 		{
-			desc:         "invalid api endpoint",
+			desc:         "oauth2: invalid api endpoint",
 			apiEndpoint:  "foobar",
 			clientID:     "B",
 			clientSecret: "C",
-			expected:     "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
+			expected:     "ovh: new OAuth2 client: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
-			desc:         "missing client id",
+			desc:         "oauth2: missing client id",
 			apiEndpoint:  "ovh-eu",
 			clientID:     "",
 			clientSecret: "C",
 			expected:     "ovh: credentials missing",
 		},
 		{
-			desc:         "missing client secret",
+			desc:         "oauth2: missing client secret",
 			apiEndpoint:  "ovh-eu",
 			clientID:     "B",
 			clientSecret: "",
@@ -290,12 +252,18 @@ func TestNewDNSProviderOAuth2Config(t *testing.T) {
 
 			config := NewDefaultConfig()
 			config.APIEndpoint = test.apiEndpoint
-			config.OAuth2Config = &OAuth2Config{
-				ClientID:     test.clientID,
-				ClientSecret: test.clientSecret,
+			config.ApplicationKey = test.applicationKey
+			config.ApplicationSecret = test.applicationSecret
+			config.ConsumerKey = test.consumerKey
+
+			if test.clientID != "" || test.clientSecret != "" {
+				config.OAuth2Config = &OAuth2Config{
+					ClientID:     test.clientID,
+					ClientSecret: test.clientSecret,
+				}
 			}
 
-			p, err := NewDNSProviderOAuth2Config(config)
+			p, err := NewDNSProviderConfig(config)
 
 			if test.expected == "" {
 				require.NoError(t, err)

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -247,9 +247,6 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			defer envTest.RestoreEnv()
-			envTest.ClearEnv()
-
 			config := NewDefaultConfig()
 			config.APIEndpoint = test.apiEndpoint
 			config.ApplicationKey = test.applicationKey

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -60,7 +60,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvApplicationSecret: "C",
 				EnvConsumerKey:       "D",
 			},
-			expected: "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list of using an URL",
+			expected: "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
 			desc: "missing application key",
@@ -145,12 +145,12 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			expected:          "ovh: credentials missing",
 		},
 		{
-			desc:              "missing invalid api endpoint",
+			desc:              "invalid api endpoint",
 			apiEndpoint:       "foobar",
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "D",
-			expected:          "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list of using an URL",
+			expected:          "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
 			desc:              "missing application key",

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -216,11 +216,9 @@ func TestNewDNSProviderConfig(t *testing.T) {
 
 			config := NewDefaultConfig()
 			config.APIEndpoint = test.apiEndpoint
-			config.ApplicationConfig = &ApplicationConfig{
-				ApplicationKey:    test.applicationKey,
-				ApplicationSecret: test.applicationSecret,
-				ConsumerKey:       test.consumerKey,
-			}
+			config.ApplicationKey = test.applicationKey
+			config.ApplicationSecret = test.applicationSecret
+			config.ConsumerKey = test.consumerKey
 
 			p, err := NewDNSProviderConfig(config)
 
@@ -241,14 +239,14 @@ func TestNewDNSProviderOAuth2Config(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		apiEndpoint  string
-		clientId     string
+		clientID     string
 		clientSecret string
 		expected     string
 	}{
 		{
 			desc:         "success",
 			apiEndpoint:  "ovh-eu",
-			clientId:     "B",
+			clientID:     "B",
 			clientSecret: "C",
 		},
 		{
@@ -258,28 +256,28 @@ func TestNewDNSProviderOAuth2Config(t *testing.T) {
 		{
 			desc:         "missing api endpoint",
 			apiEndpoint:  "",
-			clientId:     "B",
+			clientID:     "B",
 			clientSecret: "C",
 			expected:     "ovh: credentials missing",
 		},
 		{
 			desc:         "invalid api endpoint",
 			apiEndpoint:  "foobar",
-			clientId:     "B",
+			clientID:     "B",
 			clientSecret: "C",
 			expected:     "ovh: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
 			desc:         "missing client id",
 			apiEndpoint:  "ovh-eu",
-			clientId:     "",
+			clientID:     "",
 			clientSecret: "C",
 			expected:     "ovh: credentials missing",
 		},
 		{
 			desc:         "missing client secret",
 			apiEndpoint:  "ovh-eu",
-			clientId:     "B",
+			clientID:     "B",
 			clientSecret: "",
 			expected:     "ovh: credentials missing",
 		},
@@ -293,7 +291,7 @@ func TestNewDNSProviderOAuth2Config(t *testing.T) {
 			config := NewDefaultConfig()
 			config.APIEndpoint = test.apiEndpoint
 			config.OAuth2Config = &OAuth2Config{
-				ClientId:     test.clientId,
+				ClientID:     test.clientID,
 				ClientSecret: test.clientSecret,
 			}
 

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -243,6 +243,16 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			clientSecret: "",
 			expected:     "ovh: credentials are missing",
 		},
+		{
+			desc:              "mixed auth",
+			apiEndpoint:       "ovh-eu",
+			applicationKey:    "B",
+			applicationSecret: "C",
+			consumerKey:       "D",
+			clientID:          "B",
+			clientSecret:      "C",
+			expected:          "ovh: can't use both authentication systems (ApplicationKey and OAuth2)",
+		},
 	}
 
 	// The OVH client use the same env vars than lego, so it requires to clean them.

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -26,7 +26,7 @@ func TestNewDNSProvider(t *testing.T) {
 		expected string
 	}{
 		{
-			desc: "success application key",
+			desc: "application key: success",
 			envVars: map[string]string{
 				EnvEndpoint:          "ovh-eu",
 				EnvApplicationKey:    "B",
@@ -35,25 +35,7 @@ func TestNewDNSProvider(t *testing.T) {
 			},
 		},
 		{
-			desc: "success client id",
-			envVars: map[string]string{
-				EnvEndpoint:     "ovh-eu",
-				EnvClientID:     "E",
-				EnvClientSecret: "F",
-			},
-		},
-		{
-			desc: "missing credentials",
-			envVars: map[string]string{
-				EnvEndpoint:          "",
-				EnvApplicationKey:    "",
-				EnvApplicationSecret: "",
-				EnvConsumerKey:       "",
-			},
-			expected: "ovh: some credentials information are missing: OVH_ENDPOINT,OVH_APPLICATION_KEY,OVH_APPLICATION_SECRET,OVH_CONSUMER_KEY",
-		},
-		{
-			desc: "missing endpoint",
+			desc: "application key: missing endpoint",
 			envVars: map[string]string{
 				EnvEndpoint:          "",
 				EnvApplicationKey:    "B",
@@ -63,7 +45,7 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "ovh: some credentials information are missing: OVH_ENDPOINT",
 		},
 		{
-			desc: "missing invalid endpoint",
+			desc: "application key: missing invalid endpoint",
 			envVars: map[string]string{
 				EnvEndpoint:          "foobar",
 				EnvApplicationKey:    "B",
@@ -73,7 +55,7 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "ovh: new client: unknown endpoint 'foobar', consider checking 'Endpoints' list or using an URL",
 		},
 		{
-			desc: "missing application key",
+			desc: "application key: missing application key",
 			envVars: map[string]string{
 				EnvEndpoint:          "ovh-eu",
 				EnvApplicationKey:    "",
@@ -83,7 +65,7 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "ovh: some credentials information are missing: OVH_APPLICATION_KEY",
 		},
 		{
-			desc: "missing application secret",
+			desc: "application key: missing application secret",
 			envVars: map[string]string{
 				EnvEndpoint:          "ovh-eu",
 				EnvApplicationKey:    "B",
@@ -93,7 +75,7 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "ovh: some credentials information are missing: OVH_APPLICATION_SECRET",
 		},
 		{
-			desc: "missing consumer key",
+			desc: "application key: missing consumer key",
 			envVars: map[string]string{
 				EnvEndpoint:          "ovh-eu",
 				EnvApplicationKey:    "B",
@@ -103,16 +85,45 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "ovh: some credentials information are missing: OVH_CONSUMER_KEY",
 		},
 		{
-			desc: "missing client secret",
+			desc: "oauth2: success",
 			envVars: map[string]string{
 				EnvEndpoint:     "ovh-eu",
-				EnvClientID:     "A",
+				EnvClientID:     "E",
+				EnvClientSecret: "F",
+			},
+		},
+		{
+			desc: "oauth2: missing client secret",
+			envVars: map[string]string{
+				EnvEndpoint:     "ovh-eu",
+				EnvClientID:     "E",
 				EnvClientSecret: "",
 			},
 			expected: "ovh: some credentials information are missing: OVH_CLIENT_SECRET",
 		},
 		{
-			desc: "fail both auth methods set",
+			desc: "oauth2: missing client ID",
+			envVars: map[string]string{
+				EnvEndpoint:     "ovh-eu",
+				EnvClientID:     "",
+				EnvClientSecret: "F",
+			},
+			expected: "ovh: some credentials information are missing: OVH_CLIENT_ID",
+		},
+		{
+			desc: "missing credentials",
+			envVars: map[string]string{
+				EnvEndpoint:          "",
+				EnvApplicationKey:    "",
+				EnvApplicationSecret: "",
+				EnvConsumerKey:       "",
+				EnvClientID:          "",
+				EnvClientSecret:      "",
+			},
+			expected: "ovh: some credentials information are missing: OVH_ENDPOINT,OVH_APPLICATION_KEY,OVH_APPLICATION_SECRET,OVH_CONSUMER_KEY",
+		},
+		{
+			desc: "mixed auth",
 			envVars: map[string]string{
 				EnvEndpoint:          "ovh-eu",
 				EnvApplicationKey:    "B",
@@ -159,15 +170,11 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		expected          string
 	}{
 		{
-			desc:              "success",
+			desc:              "application key: success",
 			apiEndpoint:       "ovh-eu",
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "D",
-		},
-		{
-			desc:     "missing credentials",
-			expected: "ovh: credentials are missing",
 		},
 		{
 			desc:              "application key: missing api endpoint",
@@ -242,6 +249,10 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			clientID:     "B",
 			clientSecret: "",
 			expected:     "ovh: credentials are missing",
+		},
+		{
+			desc:     "missing credentials",
+			expected: "ovh: credentials are missing",
 		},
 		{
 			desc:              "mixed auth",

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -121,7 +121,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvClientID:          "E",
 				EnvClientSecret:      "F",
 			},
-			expected: "ovh: set OVH_APPLICATION_KEY or OVH_CLIENT_ID but not both",
+			expected: "ovh: can't use both OVH_APPLICATION_KEY and OVH_CLIENT_ID at the same time",
 		},
 	}
 
@@ -167,7 +167,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		},
 		{
 			desc:     "missing credentials",
-			expected: "ovh: credentials missing",
+			expected: "ovh: credentials are missing",
 		},
 		{
 			desc:              "application key: missing api endpoint",
@@ -175,7 +175,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "D",
-			expected:          "ovh: credentials missing",
+			expected:          "ovh: credentials are missing",
 		},
 		{
 			desc:              "application key: invalid api endpoint",
@@ -191,7 +191,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			applicationKey:    "",
 			applicationSecret: "C",
 			consumerKey:       "D",
-			expected:          "ovh: credentials missing",
+			expected:          "ovh: credentials are missing",
 		},
 		{
 			desc:              "application key: missing application secret",
@@ -199,7 +199,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			applicationKey:    "B",
 			applicationSecret: "",
 			consumerKey:       "D",
-			expected:          "ovh: credentials missing",
+			expected:          "ovh: credentials are missing",
 		},
 		{
 			desc:              "application key: missing consumer key",
@@ -207,7 +207,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			applicationKey:    "B",
 			applicationSecret: "C",
 			consumerKey:       "",
-			expected:          "ovh: credentials missing",
+			expected:          "ovh: credentials are missing",
 		},
 		{
 			desc:         "oauth2: success",
@@ -220,7 +220,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			apiEndpoint:  "",
 			clientID:     "B",
 			clientSecret: "C",
-			expected:     "ovh: credentials missing",
+			expected:     "ovh: credentials are missing",
 		},
 		{
 			desc:         "oauth2: invalid api endpoint",
@@ -234,16 +234,20 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			apiEndpoint:  "ovh-eu",
 			clientID:     "",
 			clientSecret: "C",
-			expected:     "ovh: credentials missing",
+			expected:     "ovh: credentials are missing",
 		},
 		{
 			desc:         "oauth2: missing client secret",
 			apiEndpoint:  "ovh-eu",
 			clientID:     "B",
 			clientSecret: "",
-			expected:     "ovh: credentials missing",
+			expected:     "ovh: credentials are missing",
 		},
 	}
+
+	// The OVH client use the same env vars than lego, so it requires to clean them.
+	defer envTest.RestoreEnv()
+	envTest.ClearEnv()
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
## Description

The latest go-ovh version allows authentication using OAuth2 client_id and client_secret. Which in turn can be provisioned using the OVH terraform provider thus enabling everything to be configured as code.

## Note

I'm not usually writing code in Go so I'm not sure if everything is idiomatic. Please advice if something needs to be changed to be more in line with the rest of the code.