### PR TITLE
docs: add note about snap

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -35,6 +35,7 @@ docker run goacme/lego -h
   ```bash
   sudo snap install lego
   ```
+  !! Note: The snap can only write to the /var/snap/lego/common/.lego directory !!
 
 - [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):
 

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -35,7 +35,7 @@ docker run goacme/lego -h
   ```bash
   sudo snap install lego
   ```
-  !! Note: The snap can only write to the /var/snap/lego/common/.lego directory !!
+  Note: The snap can only write to the `/var/snap/lego/common/.lego` directory.
 
 - [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):
 


### PR DESCRIPTION
Adding note to cut down on hair pulling, by providing clarity into where exactly certificates are dropped.