### PR TITLE
designate: allow manually overwriting DNS zone

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -704,6 +704,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "DESIGNATE_POLLING_INTERVAL":	Time between DNS propagation check`)
 		ew.writeln(`	- "DESIGNATE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
 		ew.writeln(`	- "DESIGNATE_TTL":	The TTL of the TXT record used for the DNS challenge`)
+		ew.writeln(`	- "DESIGNATE_ZONE_NAME":	The zone name to use in the OpenStack Project to manage TXT records.`)
 		ew.writeln(`	- "OS_PROJECT_ID":	Project ID`)
 		ew.writeln(`	- "OS_TENANT_NAME":	Tenant name (deprecated see OS_PROJECT_NAME and OS_PROJECT_ID)`)
 

--- a/docs/content/dns/zz_gen_designate.md
+++ b/docs/content/dns/zz_gen_designate.md
@@ -77,6 +77,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DESIGNATE_POLLING_INTERVAL` | Time between DNS propagation check |
 | `DESIGNATE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 | `DESIGNATE_TTL` | The TTL of the TXT record used for the DNS challenge |
+| `DESIGNATE_ZONE_NAME` | The zone name to use in the OpenStack Project to manage TXT records. |
 | `OS_PROJECT_ID` | Project ID |
 | `OS_TENANT_NAME` | Tenant name (deprecated see OS_PROJECT_NAME and OS_PROJECT_ID) |
 

--- a/providers/dns/designate/designate.toml
+++ b/providers/dns/designate/designate.toml
@@ -66,6 +66,7 @@ Public cloud providers with support for Designate:
     DESIGNATE_POLLING_INTERVAL = "Time between DNS propagation check"
     DESIGNATE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     DESIGNATE_TTL = "The TTL of the TXT record used for the DNS challenge"
+    DESIGNATE_ZONE_NAME = "The zone name to use in the OpenStack Project to manage TXT records."
 
 [Links]
   API = "https://docs.openstack.org/designate/latest/"

--- a/providers/dns/designate/designate.toml
+++ b/providers/dns/designate/designate.toml
@@ -63,10 +63,10 @@ Public cloud providers with support for Designate:
   [Configuration.Additional]
     OS_PROJECT_ID = "Project ID"
     OS_TENANT_NAME = "Tenant name (deprecated see OS_PROJECT_NAME and OS_PROJECT_ID)"
+    DESIGNATE_ZONE_NAME = "The zone name to use in the OpenStack Project to manage TXT records."
     DESIGNATE_POLLING_INTERVAL = "Time between DNS propagation check"
     DESIGNATE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
     DESIGNATE_TTL = "The TTL of the TXT record used for the DNS challenge"
-    DESIGNATE_ZONE_NAME = "The zone name to use in the OpenStack Project to manage TXT records."
 
 [Links]
   API = "https://docs.openstack.org/designate/latest/"


### PR DESCRIPTION
This is basically the same feature as in #1433 for the OpenStack Designate provider.

This solves problems that occur in situations like SplitDNS/Private DNS Zones where the automatic SOA detection might not work to the full extend. When setting the Zone Name via environment, it specifically uses this Zone Name when communicating with the Designate API. Otherwise, nothing changes.