### PR TITLE
feat: add LEGO_ISSUER_CERT_PATH to run hook

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -111,14 +111,9 @@ func run(ctx *cli.Context) error {
 
 	certsStorage.SaveResource(cert)
 
-	meta := map[string]string{
-		renewEnvAccountEmail: account.Email,
-		renewEnvCertDomain:   cert.Domain,
-		renewEnvCertPath:     certsStorage.GetFileName(cert.Domain, ".crt"),
-		renewEnvCertKeyPath:  certsStorage.GetFileName(cert.Domain, ".key"),
-		renewEnvCertPEMPath:  certsStorage.GetFileName(cert.Domain, ".pem"),
-		renewEnvCertPFXPath:  certsStorage.GetFileName(cert.Domain, ".pfx"),
-	}
+	meta := map[string]string{}
+
+	addPathToMetadata(meta, cert.Domain, cert, certsStorage)
 
 	return launchHook(ctx.String("run-hook"), meta)
 }

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -111,7 +111,9 @@ func run(ctx *cli.Context) error {
 
 	certsStorage.SaveResource(cert)
 
-	meta := map[string]string{}
+	meta := map[string]string{
+		renewEnvAccountEmail: account.Email,
+	}
 
 	addPathToMetadata(meta, cert.Domain, cert, certsStorage)
 


### PR DESCRIPTION
#2164 made the environment variable LEGO_ISSUER_CERT_PATH available to hook scripts but was isolated to the `renew` command. This PR extends that logic to the `run` command.

Related to #2164, #2160