### PR TITLE
cloudflare: update documentation to specify the unit of time-based options

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -500,10 +500,10 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
-		ew.writeln(`	- "CLOUDFLARE_HTTP_TIMEOUT":	API request timeout`)
-		ew.writeln(`	- "CLOUDFLARE_POLLING_INTERVAL":	Time between DNS propagation check`)
-		ew.writeln(`	- "CLOUDFLARE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation`)
-		ew.writeln(`	- "CLOUDFLARE_TTL":	The TTL of the TXT record used for the DNS challenge`)
+		ew.writeln(`	- "CLOUDFLARE_HTTP_TIMEOUT":	API request timeout (in seconds)`)
+		ew.writeln(`	- "CLOUDFLARE_POLLING_INTERVAL":	Time between DNS propagation check (in seconds)`)
+		ew.writeln(`	- "CLOUDFLARE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation (in seconds)`)
+		ew.writeln(`	- "CLOUDFLARE_TTL":	The TTL of the TXT record used for the DNS challenge (in seconds)`)
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/cloudflare`)

--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -60,10 +60,10 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout |
-| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check |
-| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
-| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge |
+| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout (in seconds) |
+| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check (in seconds) |
+| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation (in seconds) |
+| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge (in seconds) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -60,10 +60,10 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout, in seconds |
-| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check, in seconds |
-| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation, in seconds |
-| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge, in seconds |
+| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout |
+| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check |
+| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
+| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -60,10 +60,10 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
-| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout |
-| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check |
-| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
-| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge |
+| `CLOUDFLARE_HTTP_TIMEOUT` | API request timeout, in seconds |
+| `CLOUDFLARE_POLLING_INTERVAL` | Time between DNS propagation check, in seconds |
+| `CLOUDFLARE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation, in seconds |
+| `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge, in seconds |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{< ref "dns#configuration-and-credentials" >}}).

--- a/providers/dns/cloudflare/cloudflare.toml
+++ b/providers/dns/cloudflare/cloudflare.toml
@@ -68,10 +68,10 @@ It follows the principle of least privilege and limits the possible damage, shou
     CLOUDFLARE_DNS_API_TOKEN = "Alias to CF_DNS_API_TOKEN"
     CLOUDFLARE_ZONE_API_TOKEN = "Alias to CF_ZONE_API_TOKEN"
   [Configuration.Additional]
-    CLOUDFLARE_POLLING_INTERVAL = "Time between DNS propagation check, in seconds"
-    CLOUDFLARE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation, in seconds"
-    CLOUDFLARE_TTL = "The TTL of the TXT record used for the DNS challenge, in seconds"
-    CLOUDFLARE_HTTP_TIMEOUT = "API request timeout, in seconds"
+    CLOUDFLARE_POLLING_INTERVAL = "Time between DNS propagation check (in seconds)"
+    CLOUDFLARE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation (in seconds)"
+    CLOUDFLARE_TTL = "The TTL of the TXT record used for the DNS challenge (in seconds)"
+    CLOUDFLARE_HTTP_TIMEOUT = "API request timeout (in seconds)"
 
 [Links]
   API = "https://api.cloudflare.com/"

--- a/providers/dns/cloudflare/cloudflare.toml
+++ b/providers/dns/cloudflare/cloudflare.toml
@@ -68,10 +68,10 @@ It follows the principle of least privilege and limits the possible damage, shou
     CLOUDFLARE_DNS_API_TOKEN = "Alias to CF_DNS_API_TOKEN"
     CLOUDFLARE_ZONE_API_TOKEN = "Alias to CF_ZONE_API_TOKEN"
   [Configuration.Additional]
-    CLOUDFLARE_POLLING_INTERVAL = "Time between DNS propagation check"
-    CLOUDFLARE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation"
-    CLOUDFLARE_TTL = "The TTL of the TXT record used for the DNS challenge"
-    CLOUDFLARE_HTTP_TIMEOUT = "API request timeout"
+    CLOUDFLARE_POLLING_INTERVAL = "Time between DNS propagation check, in seconds"
+    CLOUDFLARE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation, in seconds"
+    CLOUDFLARE_TTL = "The TTL of the TXT record used for the DNS challenge, in seconds"
+    CLOUDFLARE_HTTP_TIMEOUT = "API request timeout, in seconds"
 
 [Links]
   API = "https://api.cloudflare.com/"


### PR DESCRIPTION
Specify CLOUDFLARE additional configuration timeouts and intervals are in seconds