### PR TITLE
docs: update theme

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      HUGO_VERSION: 0.117.0
+      HUGO_VERSION: 0.131.0
       CGO_ENABLED: 0
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       GO_VERSION: stable
       GOLANGCI_LINT_VERSION: v1.59.1
-      HUGO_VERSION: 0.117.0
+      HUGO_VERSION: 0.131.0
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI
       MEMCACHED_HOSTS: localhost:11211

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,11 +1,9 @@
 ---
-title: "Welcome"
+title: "Lego"
 date: 2019-03-03T16:39:46+01:00
 draft: false
-chapter: true
+chapter: false
 ---
-
-# Lego
 
 Let's Encrypt client and ACME library written in Go.
 
@@ -25,7 +23,7 @@ Let's Encrypt client and ACME library written in Go.
   - TLS (tls-alpn-01)
 - SAN certificate support
 - [CNAME support](https://letsencrypt.org/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html) by default
-- Comes with multiple optional [DNS providers]({{< ref "dns" >}})
-- [Custom challenge solvers]({{< ref "usage/library/Writing-a-Challenge-Solver" >}})
+- Comes with multiple optional [DNS providers]({{% ref "dns" %}})
+- [Custom challenge solvers]({{% ref "usage/library/Writing-a-Challenge-Solver" %}})
 - Certificate bundling
 - OCSP helper function

--- a/docs/content/dns/_index.md
+++ b/docs/content/dns/_index.md
@@ -15,7 +15,7 @@ The environment variables can reference a value.
 
 Here is an example bash command using the Cloudflare DNS provider:
 
-```console
+```bash
 $ CLOUDFLARE_EMAIL=you@example.com \
   CLOUDFLARE_API_KEY=b9841238feb177a84330febba8a83208921177bffe733 \
   lego --dns cloudflare --domains www.example.com --email you@example.com run
@@ -33,7 +33,7 @@ The file must contain only the value.
 
 Here is an example bash command using the CloudFlare DNS provider:
 
-```console
+```bash
 $ cat /the/path/to/my/key
 b9841238feb177a84330febba8a83208921177bffe733
 

--- a/docs/content/dns/zz_gen_acme-dns.md
+++ b/docs/content/dns/zz_gen_acme-dns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns acme-dns --domains my.example.org run
 | `ACME_DNS_STORAGE_PATH` | The ACME-DNS JSON account data file. A per-domain account will be registered/persisted to this file and used for TXT updates. |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_alidns.md
+++ b/docs/content/dns/zz_gen_alidns.md
@@ -50,7 +50,7 @@ lego --email you@example.com --dns alidns --domains my.example.org run
 | `ALICLOUD_SECURITY_TOKEN` | STS Security Token (optional) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -63,7 +63,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ALICLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_allinkl.md
+++ b/docs/content/dns/zz_gen_allinkl.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns allinkl --domains my.example.org run
 | `ALL_INKL_PASSWORD` | KAS password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ALL_INKL_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_arvancloud.md
+++ b/docs/content/dns/zz_gen_arvancloud.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns arvancloud --domains my.example.org run
 | `ARVANCLOUD_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ARVANCLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_auroradns.md
+++ b/docs/content/dns/zz_gen_auroradns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns auroradns --domains my.example.org run
 | `AURORA_SECRET` | Secret password to be used |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AURORA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_autodns.md
+++ b/docs/content/dns/zz_gen_autodns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns autodns --domains my.example.org run
 | `AUTODNS_API_USER` | Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AUTODNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_azure.md
+++ b/docs/content/dns/zz_gen_azure.md
@@ -43,7 +43,7 @@ _Please contribute by adding a CLI example._
 | `instance metadata service` | If the credentials are **not** set via the environment, then it will attempt to get a bearer token via the [instance metadata service](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service). |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -58,7 +58,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AZURE_ZONE_NAME` | Zone name to use inside Azure DNS service to add the TXT record in |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_azuredns.md
+++ b/docs/content/dns/zz_gen_azuredns.md
@@ -73,7 +73,7 @@ lego --domains example.com --email your_example@email.com --dns azuredns run
 | `AZURE_TENANT_ID` | Tenant ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -93,7 +93,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AZURE_ZONE_NAME` | Zone name to use inside Azure DNS service to add the TXT record in |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_bindman.md
+++ b/docs/content/dns/zz_gen_bindman.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns bindman --domains my.example.org run
 | `BINDMAN_MANAGER_ADDRESS` | The server URL, should have scheme, hostname, and port (if required) of the Bindman-DNS Manager server |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -52,7 +52,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `BINDMAN_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_bluecat.md
+++ b/docs/content/dns/zz_gen_bluecat.md
@@ -49,7 +49,7 @@ lego --email you@example.com --dns bluecat --domains my.example.org run
 | `BLUECAT_USER_NAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -63,7 +63,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `BLUECAT_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_brandit.md
+++ b/docs/content/dns/zz_gen_brandit.md
@@ -42,7 +42,7 @@ lego --email myemail@example.com --dns brandit --domains my.example.org run
 | `BRANDIT_API_USERNAME` | The API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `BRANDIT_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_bunny.md
+++ b/docs/content/dns/zz_gen_bunny.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns bunny --domains my.example.org run
 | `BUNNY_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -52,7 +52,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `BUNNY_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_checkdomain.md
+++ b/docs/content/dns/zz_gen_checkdomain.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns checkdomain --domains my.example.org run
 | `CHECKDOMAIN_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CHECKDOMAIN_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_civo.md
+++ b/docs/content/dns/zz_gen_civo.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns civo --domains my.example.org run
 | `CIVO_TOKEN` | Authentication token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -52,7 +52,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CIVO_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_clouddns.md
+++ b/docs/content/dns/zz_gen_clouddns.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns clouddns --domains my.example.org run
 | `CLOUDDNS_PASSWORD` | Account password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CLOUDDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -53,7 +53,7 @@ lego --email you@example.com --dns cloudflare --domains my.example.org run
 | `CLOUDFLARE_ZONE_API_TOKEN` | Alias to CF_ZONE_API_TOKEN |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -66,7 +66,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CLOUDFLARE_TTL` | The TTL of the TXT record used for the DNS challenge (in seconds) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_cloudns.md
+++ b/docs/content/dns/zz_gen_cloudns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns cloudns --domains my.example.org run
 | `CLOUDNS_AUTH_PASSWORD` | The password for API user ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CLOUDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_cloudru.md
+++ b/docs/content/dns/zz_gen_cloudru.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns cloudru --domains my.example.org run
 | `CLOUDRU_SERVICE_INSTANCE_ID` | Service Instance ID (parentId) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -58,7 +58,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CLOUDRU_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_cloudxns.md
+++ b/docs/content/dns/zz_gen_cloudxns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns cloudxns --domains my.example.org run
 | `CLOUDXNS_SECRET_KEY` | The API secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CLOUDXNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_conoha.md
+++ b/docs/content/dns/zz_gen_conoha.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns conoha --domains my.example.org run
 | `CONOHA_TENANT_ID` | Tenant ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -58,7 +58,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CONOHA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_constellix.md
+++ b/docs/content/dns/zz_gen_constellix.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns constellix --domains my.example.org run
 | `CONSTELLIX_SECRET_KEY` | User secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CONSTELLIX_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_cpanel.md
+++ b/docs/content/dns/zz_gen_cpanel.md
@@ -54,7 +54,7 @@ lego --email you@example.com --dns cpanel --domains my.example.org run
 | `CPANEL_USERNAME` | username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -69,7 +69,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `CPANEL_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_derak.md
+++ b/docs/content/dns/zz_gen_derak.md
@@ -40,7 +40,7 @@ lego --email myemail@example.com --dns derak --domains my.example.org run
 | `DERAK_API_KEY` | The API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DERAK_WEBSITE_ID` | Force the zone/website ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_desec.md
+++ b/docs/content/dns/zz_gen_desec.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns desec --domains my.example.org run
 | `DESEC_TOKEN` | Domain token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DESEC_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_designate.md
+++ b/docs/content/dns/zz_gen_designate.md
@@ -67,7 +67,7 @@ lego --email you@example.com --dns designate --domains my.example.org run
 | `OS_USER_ID` | User ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -82,7 +82,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `OS_TENANT_NAME` | Tenant name (deprecated see OS_PROJECT_NAME and OS_PROJECT_ID) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_digitalocean.md
+++ b/docs/content/dns/zz_gen_digitalocean.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns digitalocean --domains my.example.org run
 | `DO_AUTH_TOKEN` | Authentication token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DO_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_directadmin.md
+++ b/docs/content/dns/zz_gen_directadmin.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns directadmin --domains my.example.org run
 | `DIRECTADMIN_USERNAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -58,7 +58,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DIRECTADMIN_ZONE_NAME` | Zone name used to add the TXT record |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dnshomede.md
+++ b/docs/content/dns/zz_gen_dnshomede.md
@@ -43,7 +43,7 @@ lego --email you@example.com --dns dnshomede --domains my.example.org --domains 
 | `DNSHOMEDE_CREDENTIALS` | Comma-separated list of domain:password credential pairs |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dnsimple.md
+++ b/docs/content/dns/zz_gen_dnsimple.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns dnsimple --domains my.example.org run
 | `DNSIMPLE_OAUTH_TOKEN` | OAuth token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DNSIMPLE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_dnsmadeeasy.md
+++ b/docs/content/dns/zz_gen_dnsmadeeasy.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns dnsmadeeasy --domains my.example.org run
 | `DNSMADEEASY_API_SECRET` | The API Secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DNSMADEEASY_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dnspod.md
+++ b/docs/content/dns/zz_gen_dnspod.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns dnspod --domains my.example.org run
 | `DNSPOD_API_KEY` | The user token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DNSPOD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dode.md
+++ b/docs/content/dns/zz_gen_dode.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns dode --domains my.example.org run
 | `DODE_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DODE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_domeneshop.md
+++ b/docs/content/dns/zz_gen_domeneshop.md
@@ -42,7 +42,7 @@ lego --email example@example.com --dns domeneshop --domains example.com run
 | `DOMENESHOP_API_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DOMENESHOP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ### API credentials
 

--- a/docs/content/dns/zz_gen_dreamhost.md
+++ b/docs/content/dns/zz_gen_dreamhost.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns dreamhost --domains my.example.org run
 | `DREAMHOST_API_KEY` | The API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DREAMHOST_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_duckdns.md
+++ b/docs/content/dns/zz_gen_duckdns.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns duckdns --domains my.example.org run
 | `DUCKDNS_TOKEN` | Account token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DUCKDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dyn.md
+++ b/docs/content/dns/zz_gen_dyn.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns dyn --domains my.example.org run
 | `DYN_USER_NAME` | User name |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DYN_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_dynu.md
+++ b/docs/content/dns/zz_gen_dynu.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns dynu --domains my.example.org run
 | `DYNU_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `DYNU_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_easydns.md
+++ b/docs/content/dns/zz_gen_easydns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns easydns --domains my.example.org run
 | `EASYDNS_TOKEN` | API Token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `EASYDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 To test with the sandbox environment set ```EASYDNS_ENDPOINT=https://sandbox.rest.easydns.net```
 

--- a/docs/content/dns/zz_gen_edgedns.md
+++ b/docs/content/dns/zz_gen_edgedns.md
@@ -48,7 +48,7 @@ lego --email you@example.com --dns edgedns --domains my.example.org run
 | `AKAMAI_HOST` | API host, managed by the Akamai EdgeGrid client |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -60,7 +60,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AKAMAI_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 Akamai's credentials are automatically detected in the following locations and prioritized in the following order:
 

--- a/docs/content/dns/zz_gen_efficientip.md
+++ b/docs/content/dns/zz_gen_efficientip.md
@@ -46,7 +46,7 @@ lego --email you@example.com --dns efficientip --domains my.example.org run
 | `EFFICIENTIP_USERNAME` | Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -61,7 +61,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `EFFICIENTIP_VIEW_NAME` | View name (ex: external) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_epik.md
+++ b/docs/content/dns/zz_gen_epik.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns epik --domains my.example.org run
 | `EPIK_SIGNATURE` | Epik API signature (https://registrar.epik.com/account/api-settings/) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `EPIK_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_exoscale.md
+++ b/docs/content/dns/zz_gen_exoscale.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns exoscale --domains my.example.org run
 | `EXOSCALE_API_SECRET` | API secret |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `EXOSCALE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_freemyip.md
+++ b/docs/content/dns/zz_gen_freemyip.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns freemyip --domains my.example.org run
 | `FREEMYIP_TOKEN` | Account token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `FREEMYIP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_gandi.md
+++ b/docs/content/dns/zz_gen_gandi.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns gandi --domains my.example.org run
 | `GANDI_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GANDI_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_gandiv5.md
+++ b/docs/content/dns/zz_gen_gandiv5.md
@@ -41,7 +41,7 @@ lego --email you@example.com --dns gandiv5 --domains my.example.org run
 | `GANDIV5_PERSONAL_ACCESS_TOKEN` | Personal Access Token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GANDIV5_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -47,7 +47,7 @@ GCE_PROJECT="gc-project-id" GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.
 | `GCE_SERVICE_ACCOUNT_FILE` | Account file path |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -61,7 +61,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GCE_ZONE_ID` | Allows to skip the automatic detection of the zone |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_gcore.md
+++ b/docs/content/dns/zz_gen_gcore.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns gcore --domains my.example.org run
 | `GCORE_PERMANENT_API_TOKEN` | Permanent API token (https://gcore.com/blog/permanent-api-token-explained/) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GCORE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_glesys.md
+++ b/docs/content/dns/zz_gen_glesys.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns glesys --domains my.example.org run
 | `GLESYS_API_USER` | API user |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GLESYS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_godaddy.md
+++ b/docs/content/dns/zz_gen_godaddy.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns godaddy --domains my.example.org run
 | `GODADDY_API_SECRET` | API secret |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GODADDY_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 GoDaddy has recently (2024-04) updated the account requirements to access parts of their production Domains API:
 

--- a/docs/content/dns/zz_gen_googledomains.md
+++ b/docs/content/dns/zz_gen_googledomains.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns googledomains --domains my.example.org run
 | `GOOGLE_DOMAINS_ACCESS_TOKEN` | Access token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -52,7 +52,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `GOOGLE_DOMAINS_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_hetzner.md
+++ b/docs/content/dns/zz_gen_hetzner.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns hetzner --domains my.example.org run
 | `HETZNER_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `HETZNER_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_hostingde.md
+++ b/docs/content/dns/zz_gen_hostingde.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns hostingde --domains my.example.org run
 | `HOSTINGDE_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `HOSTINGDE_ZONE_NAME` | Zone name in ACE format |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_hosttech.md
+++ b/docs/content/dns/zz_gen_hosttech.md
@@ -41,7 +41,7 @@ lego --email you@example.com --dns hosttech --domains my.example.org run
 | `HOSTTECH_PASSWORD` | API password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `HOSTTECH_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_httpnet.md
+++ b/docs/content/dns/zz_gen_httpnet.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns httpnet --domains my.example.org run
 | `HTTPNET_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `HTTPNET_ZONE_NAME` | Zone name in ACE format |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_httpreq.md
+++ b/docs/content/dns/zz_gen_httpreq.md
@@ -41,7 +41,7 @@ lego --email you@example.com --dns httpreq --domains my.example.org run
 | `HTTPREQ_MODE` | `RAW`, none |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `HTTPREQ_USERNAME` | Basic authentication username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_hurricane.md
+++ b/docs/content/dns/zz_gen_hurricane.md
@@ -43,7 +43,7 @@ lego --email you@example.com --dns hurricane --domains my.example.org --domains 
 | `HURRICANE_TOKENS` | TXT record names and tokens |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_hyperone.md
+++ b/docs/content/dns/zz_gen_hyperone.md
@@ -46,7 +46,7 @@ lego --email you@example.com --dns hyperone --domains my.example.org run
 | `HYPERONE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_ibmcloud.md
+++ b/docs/content/dns/zz_gen_ibmcloud.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns ibmcloud --domains my.example.org run
 | `SOFTLAYER_USERNAME` | Username (IBM Cloud is <accountID>_<emailAddress>) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SOFTLAYER_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_iij.md
+++ b/docs/content/dns/zz_gen_iij.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns iij --domains my.example.org run
 | `IIJ_DO_SERVICE_CODE` | DO service code |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IIJ_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_iijdpf.md
+++ b/docs/content/dns/zz_gen_iijdpf.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns iijdpf --domains my.example.org run
 | `IIJ_DPF_DPM_SERVICE_CODE` | IIJ Managed DNS Service's service code |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IIJ_DPF_TTL` | The TTL of the TXT record used for the DNS challenge, default to 300 |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_infoblox.md
+++ b/docs/content/dns/zz_gen_infoblox.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns infoblox --domains my.example.org run
 | `INFOBLOX_USERNAME` | Account Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -61,7 +61,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `INFOBLOX_WAPI_VERSION` | The version of WAPI being used, default: 2.11 |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 When creating an API's user ensure it has the proper permissions for the view you are working with.
 

--- a/docs/content/dns/zz_gen_infomaniak.md
+++ b/docs/content/dns/zz_gen_infomaniak.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns infomaniak --domains my.example.org run
 | `INFOMANIAK_ACCESS_TOKEN` | Access token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `INFOMANIAK_TTL` | The TTL of the TXT record used for the DNS challenge in seconds |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Access token
 

--- a/docs/content/dns/zz_gen_internetbs.md
+++ b/docs/content/dns/zz_gen_internetbs.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns internetbs --domains my.example.org run
 | `INTERNET_BS_PASSWORD` | API password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `INTERNET_BS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_inwx.md
+++ b/docs/content/dns/zz_gen_inwx.md
@@ -48,7 +48,7 @@ lego --email you@example.com --dns inwx --domains my.example.org run
 | `INWX_USERNAME` | Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -62,7 +62,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `INWX_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_ionos.md
+++ b/docs/content/dns/zz_gen_ionos.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns ionos --domains my.example.org run
 | `IONOS_API_KEY` | API key `<prefix>.<secret>` https://developer.hosting.ionos.com/docs/getstarted |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IONOS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_ipv64.md
+++ b/docs/content/dns/zz_gen_ipv64.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns ipv64 --domains my.example.org run
 | `IPV64_API_KEY` | Account API Key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IPV64_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_iwantmyname.md
+++ b/docs/content/dns/zz_gen_iwantmyname.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns iwantmyname --domains my.example.org run
 | `IWANTMYNAME_USERNAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `IWANTMYNAME_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_joker.md
+++ b/docs/content/dns/zz_gen_joker.md
@@ -56,7 +56,7 @@ lego --email you@example.com --dns joker --domains my.example.org run
 | `JOKER_USERNAME` | Joker.com username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -70,7 +70,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `JOKER_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## SVC mode
 

--- a/docs/content/dns/zz_gen_liara.md
+++ b/docs/content/dns/zz_gen_liara.md
@@ -40,7 +40,7 @@ lego --email myemail@example.com --dns liara --domains my.example.org run
 | `LIARA_API_KEY` | The API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LIARA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_lightsail.md
+++ b/docs/content/dns/zz_gen_lightsail.md
@@ -39,7 +39,7 @@ _Please contribute by adding a CLI example._
 | `DNS_ZONE` | Domain name of the DNS zone |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -51,7 +51,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LIGHTSAIL_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_linode.md
+++ b/docs/content/dns/zz_gen_linode.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns linode --domains my.example.org run
 | `LINODE_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LINODE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_liquidweb.md
+++ b/docs/content/dns/zz_gen_liquidweb.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns liquidweb --domains my.example.org run
 | `LWAPI_USERNAME` | Liquid Web API Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LWAPI_ZONE` | DNS Zone |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_loopia.md
+++ b/docs/content/dns/zz_gen_loopia.md
@@ -42,7 +42,7 @@ lego --email my@email.com --dns loopia --domains my.domain.com run
 | `LOOPIA_API_USER` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LOOPIA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ### API user
 

--- a/docs/content/dns/zz_gen_luadns.md
+++ b/docs/content/dns/zz_gen_luadns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns luadns --domains my.example.org run
 | `LUADNS_API_USERNAME` | Username (your email) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `LUADNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_mailinabox.md
+++ b/docs/content/dns/zz_gen_mailinabox.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns mailinabox --domains my.example.org run
 | `MAILINABOX_PASSWORD` | User password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `MAILINABOX_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_metaname.md
+++ b/docs/content/dns/zz_gen_metaname.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns metaname --domains my.example.org run
 | `METANAME_API_KEY` | API Key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `METANAME_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_mydnsjp.md
+++ b/docs/content/dns/zz_gen_mydnsjp.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns mydnsjp --domains my.example.org run
 | `MYDNSJP_PASSWORD` | Password |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `MYDNSJP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_mythicbeasts.md
+++ b/docs/content/dns/zz_gen_mythicbeasts.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns mythicbeasts --domains my.example.org run
 | `MYTHICBEASTS_USERNAME` | User name |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `MYTHICBEASTS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 If you are using specific API keys, then the username is the API ID for your API key, and the password is the API secret.
 

--- a/docs/content/dns/zz_gen_namecheap.md
+++ b/docs/content/dns/zz_gen_namecheap.md
@@ -47,7 +47,7 @@ lego --email you@example.com --dns namecheap --domains my.example.org run
 | `NAMECHEAP_API_USER` | API user |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -61,7 +61,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NAMECHEAP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_namedotcom.md
+++ b/docs/content/dns/zz_gen_namedotcom.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns namedotcom --domains my.example.org run
 | `NAMECOM_USERNAME` | Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NAMECOM_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_namesilo.md
+++ b/docs/content/dns/zz_gen_namesilo.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns namesilo --domains my.example.org run
 | `NAMESILO_API_KEY` | Client ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -52,7 +52,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NAMESILO_TTL` | The TTL of the TXT record used for the DNS challenge, should be in [3600, 2592000] |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_nearlyfreespeech.md
+++ b/docs/content/dns/zz_gen_nearlyfreespeech.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns nearlyfreespeech --domains my.example.org run
 | `NEARLYFREESPEECH_LOGIN` | Username for API requests |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NEARLYFREESPEECH_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_netcup.md
+++ b/docs/content/dns/zz_gen_netcup.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns netcup --domains my.example.org run
 | `NETCUP_CUSTOMER_NUMBER` | Customer number |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NETCUP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_netlify.md
+++ b/docs/content/dns/zz_gen_netlify.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns netlify --domains my.example.org run
 | `NETLIFY_TOKEN` | Token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NETLIFY_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_nicmanager.md
+++ b/docs/content/dns/zz_gen_nicmanager.md
@@ -61,7 +61,7 @@ lego --email you@example.com --dns nicmanager --domains my.example.org run
 | `NICMANAGER_API_USERNAME` | Username, used for Username-based login |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -76,7 +76,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NICMANAGER_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_nifcloud.md
+++ b/docs/content/dns/zz_gen_nifcloud.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns nifcloud --domains my.example.org run
 | `NIFCLOUD_SECRET_ACCESS_KEY` | Secret access key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NIFCLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_njalla.md
+++ b/docs/content/dns/zz_gen_njalla.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns njalla --domains my.example.org run
 | `NJALLA_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NJALLA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_nodion.md
+++ b/docs/content/dns/zz_gen_nodion.md
@@ -40,7 +40,7 @@ lego --email myemail@example.com --dns nodion --domains my.example.org run
 | `NODION_API_TOKEN` | The API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NODION_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_ns1.md
+++ b/docs/content/dns/zz_gen_ns1.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns ns1 --domains my.example.org run
 | `NS1_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `NS1_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_oraclecloud.md
+++ b/docs/content/dns/zz_gen_oraclecloud.md
@@ -52,7 +52,7 @@ lego --email you@example.com --dns oraclecloud --domains my.example.org run
 | `OCI_USER_OCID` | User OCID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -64,7 +64,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `OCI_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_otc.md
+++ b/docs/content/dns/zz_gen_otc.md
@@ -41,7 +41,7 @@ _Please contribute by adding a CLI example._
 | `OTC_USER_NAME` | User name |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `OTC_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_ovh.md
+++ b/docs/content/dns/zz_gen_ovh.md
@@ -57,7 +57,7 @@ lego --email you@example.com --dns ovh --domains my.example.org run
 | `OVH_ENDPOINT` | Endpoint URL (ovh-eu or ovh-ca) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -70,7 +70,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `OVH_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Application Key and Secret
 

--- a/docs/content/dns/zz_gen_pdns.md
+++ b/docs/content/dns/zz_gen_pdns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns pdns --domains my.example.org run
 | `PDNS_API_URL` | API URL |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `PDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Information
 

--- a/docs/content/dns/zz_gen_plesk.md
+++ b/docs/content/dns/zz_gen_plesk.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns plesk --domains my.example.org run
 | `PLESK_USERNAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `PLESK_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_porkbun.md
+++ b/docs/content/dns/zz_gen_porkbun.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns porkbun --domains my.example.org run
 | `PORKBUN_SECRET_API_KEY` | secret API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `PORKBUN_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_rackspace.md
+++ b/docs/content/dns/zz_gen_rackspace.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns rackspace --domains my.example.org run
 | `RACKSPACE_USER` | API user |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `RACKSPACE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_rcodezero.md
+++ b/docs/content/dns/zz_gen_rcodezero.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns rcodezero --domains my.example.org run
 | `RCODEZERO_API_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `RCODEZERO_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_regru.md
+++ b/docs/content/dns/zz_gen_regru.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns regru --domains my.example.org run
 | `REGRU_USERNAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `REGRU_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_rfc2136.md
+++ b/docs/content/dns/zz_gen_rfc2136.md
@@ -56,7 +56,7 @@ lego --email you@example.com --dns rfc2136 --domains my.example.org run
 | `RFC2136_TSIG_SECRET` | Secret key payload. To disable TSIG authentication, leave the` RFC2136_TSIG*` variables unset. |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -70,7 +70,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `RFC2136_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_rimuhosting.md
+++ b/docs/content/dns/zz_gen_rimuhosting.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns rimuhosting --domains my.example.org run
 | `RIMUHOSTING_API_KEY` | User API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `RIMUHOSTING_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_route53.md
+++ b/docs/content/dns/zz_gen_route53.md
@@ -51,7 +51,7 @@ lego --domains example.com --email your_example@email.com --dns route53 --accept
 | `AWS_WAIT_FOR_RECORD_SETS_CHANGED` | Wait for changes to be INSYNC (it can be unstable) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -65,7 +65,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `AWS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Description
 

--- a/docs/content/dns/zz_gen_safedns.md
+++ b/docs/content/dns/zz_gen_safedns.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns safedns --domains my.example.org run
 | `SAFEDNS_AUTH_TOKEN` | Authentication token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SAFEDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_sakuracloud.md
+++ b/docs/content/dns/zz_gen_sakuracloud.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns sakuracloud --domains my.example.org run
 | `SAKURACLOUD_ACCESS_TOKEN_SECRET` | Access token secret |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SAKURACLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_scaleway.md
+++ b/docs/content/dns/zz_gen_scaleway.md
@@ -41,7 +41,7 @@ lego --email you@example.com --dns scaleway --domains my.example.org run
 | `SCW_SECRET_KEY` | Secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SCW_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_selectel.md
+++ b/docs/content/dns/zz_gen_selectel.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns selectel --domains my.example.org run
 | `SELECTEL_API_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SELECTEL_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_selectelv2.md
+++ b/docs/content/dns/zz_gen_selectelv2.md
@@ -46,7 +46,7 @@ lego --email you@example.com --dns selectelv2 --domains my.example.org run
 | `SELECTELV2_USERNAME` | Openstack username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -60,7 +60,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SELECTELV2_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_servercow.md
+++ b/docs/content/dns/zz_gen_servercow.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns servercow --domains my.example.org run
 | `SERVERCOW_USERNAME` | API username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SERVERCOW_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_shellrent.md
+++ b/docs/content/dns/zz_gen_shellrent.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns shellrent --domains my.example.org run
 | `SHELLRENT_USERNAME` | Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SHELLRENT_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_simply.md
+++ b/docs/content/dns/zz_gen_simply.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns simply --domains my.example.org run
 | `SIMPLY_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SIMPLY_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_sonic.md
+++ b/docs/content/dns/zz_gen_sonic.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns sonic --domains my.example.org run
 | `SONIC_USER_ID` | User ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `SONIC_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## API keys
 

--- a/docs/content/dns/zz_gen_stackpath.md
+++ b/docs/content/dns/zz_gen_stackpath.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns stackpath --domains my.example.org run
 | `STACKPATH_STACK_ID` | Stack ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `STACKPATH_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_tencentcloud.md
+++ b/docs/content/dns/zz_gen_tencentcloud.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns tencentcloud --domains my.example.org run
 | `TENCENTCLOUD_SECRET_KEY` | Access Key secret |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `TENCENTCLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_transip.md
+++ b/docs/content/dns/zz_gen_transip.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns transip --domains my.example.org run
 | `TRANSIP_PRIVATE_KEY_PATH` | Private key path |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `TRANSIP_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_ultradns.md
+++ b/docs/content/dns/zz_gen_ultradns.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns ultradns --domains my.example.org run
 | `ULTRADNS_USERNAME` | API Username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ULTRADNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_variomedia.md
+++ b/docs/content/dns/zz_gen_variomedia.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns variomedia --domains my.example.org run
 | `VARIOMEDIA_API_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VARIOMEDIA_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_vegadns.md
+++ b/docs/content/dns/zz_gen_vegadns.md
@@ -39,7 +39,7 @@ _Please contribute by adding a CLI example._
 | `VEGADNS_URL` | API endpoint URL |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -51,7 +51,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VEGADNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_vercel.md
+++ b/docs/content/dns/zz_gen_vercel.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns vercel --domains my.example.org run
 | `VERCEL_API_TOKEN` | Authentication token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VERCEL_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_versio.md
+++ b/docs/content/dns/zz_gen_versio.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns versio --domains my.example.org run
 | `VERSIO_USERNAME` | Basic authentication username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -57,7 +57,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VERSIO_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 To test with the sandbox environment set ```VERSIO_ENDPOINT=https://www.versio.nl/testapi/v1/```
 

--- a/docs/content/dns/zz_gen_vinyldns.md
+++ b/docs/content/dns/zz_gen_vinyldns.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns vinyldns --domains my.example.org run
 | `VINYLDNS_SECRET_KEY` | The VinylDNS API Secret key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VINYLDNS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 The vinyldns integration makes use of dotted hostnames to ease permission management.
 Users are required to have DELETE ACL level or zone admin permissions on the VinylDNS zone containing the target host.

--- a/docs/content/dns/zz_gen_vkcloud.md
+++ b/docs/content/dns/zz_gen_vkcloud.md
@@ -44,7 +44,7 @@ lego --email you@example.com --dns vkcloud --domains "example.org" --domains "*.
 | `VK_CLOUD_USERNAME` | Email of VK Cloud account |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -59,7 +59,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VK_CLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## Credential information
 

--- a/docs/content/dns/zz_gen_vscale.md
+++ b/docs/content/dns/zz_gen_vscale.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns vscale --domains my.example.org run
 | `VSCALE_API_TOKEN` | API token |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -54,7 +54,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VSCALE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_vultr.md
+++ b/docs/content/dns/zz_gen_vultr.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns vultr --domains my.example.org run
 | `VULTR_API_KEY` | API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `VULTR_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_webnames.md
+++ b/docs/content/dns/zz_gen_webnames.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns webnames --domains my.example.org run
 | `WEBNAMES_API_KEY` | Domain API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `WEBNAMES_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## API Key
 

--- a/docs/content/dns/zz_gen_websupport.md
+++ b/docs/content/dns/zz_gen_websupport.md
@@ -42,7 +42,7 @@ lego --email myemail@example.com --dns websupport --domains my.example.org run
 | `WEBSUPPORT_SECRET` | API secret |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `WEBSUPPORT_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_wedos.md
+++ b/docs/content/dns/zz_gen_wedos.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns wedos --domains my.example.org run
 | `WEDOS_WAPI_PASSWORD` | Password needs to be generated and IP allowed in the admin interface |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `WEDOS_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_yandex.md
+++ b/docs/content/dns/zz_gen_yandex.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns yandex --domains my.example.org run
 | `YANDEX_PDD_TOKEN` | Basic authentication username |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `YANDEX_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_yandex360.md
+++ b/docs/content/dns/zz_gen_yandex360.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns yandex360 --domains my.example.org run
 | `YANDEX360_ORG_ID` | The organization ID |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -55,7 +55,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `YANDEX360_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_yandexcloud.md
+++ b/docs/content/dns/zz_gen_yandexcloud.md
@@ -55,7 +55,7 @@ lego --email you@example.com --dns yandexcloud --domains "example.org" --domains
 | `YANDEX_CLOUD_IAM_TOKEN` | The base64 encoded json which contains information about iam token of service account with `dns.admin` permissions |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -67,7 +67,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `YANDEX_CLOUD_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## IAM Token
 

--- a/docs/content/dns/zz_gen_zoneee.md
+++ b/docs/content/dns/zz_gen_zoneee.md
@@ -42,7 +42,7 @@ lego --email you@example.com --dns zoneee --domains my.example.org run
 | `ZONEEE_API_USER` | API user |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -56,7 +56,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ZONEEE_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_zonomi.md
+++ b/docs/content/dns/zz_gen_zonomi.md
@@ -40,7 +40,7 @@ lego --email you@example.com --dns zonomi --domains my.example.org run
 | `ZONOMI_API_KEY` | User API key |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 ## Additional Configuration
@@ -53,7 +53,7 @@ More information [here]({{< ref "dns#configuration-and-credentials" >}}).
 | `ZONOMI_TTL` | The TTL of the TXT record used for the DNS challenge |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{< ref "dns#configuration-and-credentials" >}}).
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/usage/cli/General-Instructions.md
+++ b/docs/content/usage/cli/General-Instructions.md
@@ -6,11 +6,11 @@ summary: Read this first to clarify some assumptions made by the following guide
 weight: 1
 ---
 
-These examples assume you have [lego installed]({{< ref "installation" >}}).
+These examples assume you have [lego installed]({{% ref "installation" %}}).
 You can get a pre-built binary from the [releases](https://github.com/go-acme/lego/releases) page.
 
 The web server examples require that the `lego` binary has permission to bind to ports 80 and 443.
-If your environment does not allow you to bind to these ports, please read [Running without root privileges]({{< ref "usage/cli/Options#running-without-root-privileges" >}}) and [Port Usage]({{< ref "usage/cli/Options#port-usage" >}}).
+If your environment does not allow you to bind to these ports, please read [Running without root privileges]({{% ref "usage/cli/Options#running-without-root-privileges" %}}) and [Port Usage]({{% ref "usage/cli/Options#port-usage" %}}).
 
 Unless otherwise instructed with the `--path` command line flag, lego will look for a directory named `.lego` in the *current working directory*.
 If you run `cd /dir/a && lego ... run`, lego will create a directory `/dir/a/.lego` where it will save account registration and certificate files into.

--- a/docs/content/usage/cli/Obtain-a-Certificate.md
+++ b/docs/content/usage/cli/Obtain-a-Certificate.md
@@ -45,7 +45,7 @@ If you're looking for a `cert.pem` and `privkey.pem`, you can just use `example.
 ## Using a DNS provider
 
 If you can't or don't want to start a web server, you need to use a DNS provider.
-lego comes with [support for many]({{< ref "dns#dns-providers" >}}) providers,
+lego comes with [support for many]({{% ref "dns#dns-providers" %}}) providers,
 and you need to pick the one where your domain's DNS settings are set up.
 Typically, this is the registrar where you bought the domain, but in some cases this can be another third-party provider.
 

--- a/docs/content/usage/cli/Renew-a-Certificate.md
+++ b/docs/content/usage/cli/Renew-a-Certificate.md
@@ -12,7 +12,7 @@ This guide describes how to renew existing certificates.
 Certificates issues by Let's Encrypt are valid for a period of 90 days.
 To avoid certificate errors, you need to ensure that you renew your certificate *before* it expires.
 
-In order to renew a certificate, follow the general instructions laid out under [Obtain a Certificate]({{< ref "usage/cli/Obtain-a-Certificate" >}}), and replace `lego ... run` with `lego ... renew`.
+In order to renew a certificate, follow the general instructions laid out under [Obtain a Certificate]({{% ref "usage/cli/Obtain-a-Certificate" %}}), and replace `lego ... run` with `lego ... renew`.
 Note that the `renew` sub-command supports a slightly different set of some command line flags.
 
 ## Using the built-in web server
@@ -32,7 +32,7 @@ lego --email="you@example.com" --domains="example.com" --http renew --days 45
 ## Using a DNS provider
 
 If you can't or don't want to start a web server, you need to use a DNS provider.
-lego comes with [support for many]({{< ref "dns#dns-providers" >}}) providers,
+lego comes with [support for many]({{% ref "dns#dns-providers" %}}) providers,
 and you need to pick the one where your domain's DNS settings are set up.
 Typically, this is the registrar where you bought the domain, but in some cases this can be another third-party provider.
 
@@ -64,7 +64,7 @@ Some information is provided through environment variables:
 - `LEGO_CERT_PEM_PATH`: (only with `--pem`) the path to the PEM certificate.
 - `LEGO_CERT_PFX_PATH`: (only with `--pfx`) the path to the PFX certificate.
 
-See [Obtain a Certificate → Use case]({{< ref "usage/cli/Obtain-a-Certificate#use-case" >}}) for an example script.
+See [Obtain a Certificate → Use case]({{% ref "usage/cli/Obtain-a-Certificate#use-case" %}}) for an example script.
 
 ## Automatic renewal
 

--- a/docs/content/usage/cli/examples.md
+++ b/docs/content/usage/cli/examples.md
@@ -11,19 +11,19 @@ hidden: true
 
 You'll find the content now at one of these pages:
 
-- Guide: [**How to obtain a certificate**]({{< ref "usage/cli/Obtain-a-Certificate" >}})
+- Guide: [**How to obtain a certificate**]({{% ref "usage/cli/Obtain-a-Certificate" %}})
   - Using the built-in web server
   - Using a DNS provider
   - Using a custom certificate signing request (CSR)
   - Using an existing, running web server
   - Running a script afterward
   - Use case
-- Guide: [**How to renew a certificate**]({{< ref "usage/cli/Renew-a-Certificate" >}})
+- Guide: [**How to renew a certificate**]({{% ref "usage/cli/Renew-a-Certificate" %}})
   - Using the built-in web server
   - Using a DNS provider
   - Running a script afterward
   - Automatic renewal
-- Reference: [**Command line options**]({{< ref "usage/cli/Options" >}})
+- Reference: [**Command line options**]({{% ref "usage/cli/Options" %}})
   - Usage
   - Let's Encrypt ACME server
   - Running without root privileges

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/go-acme/lego/docs
 
 go 1.20
 
-require github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d // indirect
+require github.com/McShelby/hugo-theme-relearn v0.0.0-20240802145348-259f21f89851

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d h1:p7ktiW/GnHccjB9oO5YGY7us5v/oHmkyF0C7EDZFM3s=
-github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d/go.mod h1:YoToDcvQxmAFhpEuapKUysBDEBckqDEssqTrmeZ2+uY=
+github.com/McShelby/hugo-theme-relearn v0.0.0-20240802145348-259f21f89851 h1:JpmKIb1bRzuAcgnphwSb35Xz9rk/Alq19uRWVGSwScA=
+github.com/McShelby/hugo-theme-relearn v0.0.0-20240802145348-259f21f89851/go.mod h1:mKQQdxZNIlLvAj8X3tMq+RzntIJSr9z7XdzuMomt0IM=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -18,8 +18,6 @@ pygmentsUseClasses = true
   # Useful to give opportunity to people to create merge request for your doc.
   # See the config.toml file from this documentation site to have an example.
 #  editURL = ""
-  # Author of the site, will be used in meta information
-  author = "Lego Team"
   # Description of the site, will be used in meta information
 #  description = ""
   # Shows a checkmark for visited pages on the menu
@@ -46,6 +44,10 @@ pygmentsUseClasses = true
   custom_css = ["css/theme-custom.css"]
   disableLandingPageButton = true
 
+  # Author of the site, will be used in meta information
+  [params.author]
+    name = "Lego Team"
+
 [Languages]
 [Languages.en]
   title = "Let’s Encrypt client and ACME library written in Go."
@@ -69,8 +71,8 @@ pygmentsUseClasses = true
   weight = 12
 
 [outputs]
-  home = [ "HTML", "RSS", "JSON"]
+  home = [ "html", "rss", "search", "searchpage"]
 
 [module]
 [[module.imports]]
-  path = "github.com/matcornic/hugo-theme-learn"
+  path = "github.com/McShelby/hugo-theme-relearn"

--- a/docs/layouts/shortcodes/clihelp.html
+++ b/docs/layouts/shortcodes/clihelp.html
@@ -1,24 +1,12 @@
-<div class="tab-panel">
-    <div class="tab-nav">
-    {{ $commands := index $.Site.Data.zz_cli_help "command" }}
-    {{ range $idx, $tab := $commands }}
-        <button
-            data-tab-item="{{ .title }}"
-            data-tab-group="cli-help"
-            class="tab-nav-button btn {{ cond (eq $idx 0) "active" ""}}"
-            onclick="switchTab('cli-help','{{ .title }}')"
-         >{{ .title }}</button>
-    {{ end }}
-    </div>
-    <div class="tab-content">
-        {{ range $idx, $tab := $commands }}
-        <div
-            data-tab-item="{{ .title }}"
-            data-tab-group="cli-help"
-            class="tab-item {{ cond (eq $idx 0) "active" ""}}"
-        >
-            <pre>{{ .content }}</pre>
-        </div>
-        {{ end }}
-    </div>
-</div>
+{{ $tabs := slice }}
+
+{{ $commands := index $.Site.Data.zz_cli_help "command" }}
+{{ range $idx, $tab := $commands }}
+  {{ $content := (print "```\n" $tab.content "\n```") }}
+  {{ $tabs = $tabs | append (dict "title" $tab.title "content" ($content | page.RenderString) "icon" "terminal") }}
+{{ end }}
+
+{{ partial "shortcodes/tabs.html" (dict
+  "page" page
+  "content" $tabs
+) }}

--- a/internal/dnsdocs/dns.md.tmpl
+++ b/internal/dnsdocs/dns.md.tmpl
@@ -47,7 +47,7 @@ _Please contribute by adding a CLI example._
 {{- end}}
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{ `{{< ref "dns#configuration-and-credentials" >}}` }}).
+More information [here]({{ `{{% ref "dns#configuration-and-credentials" %}}` }}).
 {{- end}}
 
 {{if .Configuration.Additional }}
@@ -60,7 +60,7 @@ More information [here]({{ `{{< ref "dns#configuration-and-credentials" >}}` }})
 {{- end}}
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
-More information [here]({{ `{{< ref "dns#configuration-and-credentials" >}}` }}).
+More information [here]({{ `{{% ref "dns#configuration-and-credentials" %}}` }}).
 {{- end}}
 {{- end}}
 


### PR DESCRIPTION
The current is deprecated: https://github.com/matcornic/hugo-theme-learn?tab=readme-ov-file

I replaced it with the recommended new theme https://github.com/McShelby/hugo-theme-relearn

There are some differences.

Also
- updates hugo version
- updates shortcode syntax (because hugo warnings)
