### PR TITLE
docs: update installation for FreeBSD

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -37,7 +37,7 @@ docker run goacme/lego -h
   ```
   Note: The snap can only write to the `/var/snap/lego/common/.lego` directory.
 
-- [FreeBSD (Ports)](https://www.freshports.org/security/lego) (official):
+- [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):
 
   ```bash
   pkg install lego

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -37,10 +37,10 @@ docker run goacme/lego -h
   ```
   Note: The snap can only write to the `/var/snap/lego/common/.lego` directory.
 
-- [FreeBSD (Ports)](https://www.freshports.org/security/lego) (unofficial):
+- [FreeBSD (Ports)](https://www.freshports.org/security/lego) (official):
 
   ```bash
-  cd /usr/ports/security/lego && make install clean
+  pkg install lego
   ```
 
 - [Gentoo](https://gitweb.gentoo.org/repo/proj/guru.git/tree/app-crypt/lego) (unofficial):


### PR DESCRIPTION
- lego is in official FreeBSD ports tree: https://www.freshports.org/security/lego
- use `pkg install` to install package