### PR TITLE
docs: add installation for OpenBSD

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -63,7 +63,7 @@ docker run goacme/lego -h
   pkg install lego
   ```
 
-- [OpenBSD (Ports)](https://openports.pl/path/security/lego) (official):
+- [OpenBSD (Ports)](https://openports.pl/path/security/lego) (unofficial):
 
   ```bash
   pkg_add lego

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -63,6 +63,13 @@ docker run goacme/lego -h
   pkg install lego
   ```
 
+- [OpenBSD (Ports)](https://openports.pl/path/security/lego) (official):
+
+  ```bash
+  pkg_add lego
+  ```
+
+
 ## From sources
 
 Requirements:


### PR DESCRIPTION
- lego is in official OpenBSD ports tree https://openports.pl/path/security/lego
- install it with `pkg_add lego`