### PR TITLE
docs: fix typos in some DNS descriptors

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -771,6 +771,12 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "DNSHOMEDE_CREDENTIALS":	Comma-separated list of domain:password credential pairs`)
 		ew.writeln()
 
+		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "DNSHOMEDE_HTTP_TIMEOUT":	API request timeout`)
+		ew.writeln(`	- "DNSHOMEDE_POLLING_INTERVAL":	Time between DNS propagation checks`)
+		ew.writeln(`	- "DNSHOMEDE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation; defaults to 300s (5 minutes)`)
+		ew.writeln(`	- "DNSHOMEDE_SEQUENCE_INTERVAL":	Time between sequential requests`)
+
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/dnshomede`)
 
@@ -1367,6 +1373,12 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "HURRICANE_TOKENS":	TXT record names and tokens`)
 		ew.writeln()
+
+		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "HURRICANE_HTTP_TIMEOUT":	API request timeout`)
+		ew.writeln(`	- "HURRICANE_POLLING_INTERVAL":	Time between DNS propagation checks`)
+		ew.writeln(`	- "HURRICANE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation; defaults to 300s (5 minutes)`)
+		ew.writeln(`	- "HURRICANE_SEQUENCE_INTERVAL":	Time between sequential requests`)
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/hurricane`)

--- a/docs/content/dns/zz_gen_dnshomede.md
+++ b/docs/content/dns/zz_gen_dnshomede.md
@@ -46,6 +46,17 @@ The environment variable names can be suffixed by `_FILE` to reference a file in
 More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
+## Additional Configuration
+
+| Environment Variable Name | Description |
+|--------------------------------|-------------|
+| `DNSHOMEDE_HTTP_TIMEOUT` | API request timeout |
+| `DNSHOMEDE_POLLING_INTERVAL` | Time between DNS propagation checks |
+| `DNSHOMEDE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation; defaults to 300s (5 minutes) |
+| `DNSHOMEDE_SEQUENCE_INTERVAL` | Time between sequential requests |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
 

--- a/docs/content/dns/zz_gen_hurricane.md
+++ b/docs/content/dns/zz_gen_hurricane.md
@@ -46,6 +46,17 @@ The environment variable names can be suffixed by `_FILE` to reference a file in
 More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 
+## Additional Configuration
+
+| Environment Variable Name | Description |
+|--------------------------------|-------------|
+| `HURRICANE_HTTP_TIMEOUT` | API request timeout |
+| `HURRICANE_POLLING_INTERVAL` | Time between DNS propagation checks |
+| `HURRICANE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation; defaults to 300s (5 minutes) |
+| `HURRICANE_SEQUENCE_INTERVAL` | Time between sequential requests |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 Before using lego to request a certificate for a given domain or wildcard (such as `my.example.org` or `*.my.example.org`),
 create a TXT record named `_acme-challenge.my.example.org`, and enable dynamic updates on it.

--- a/providers/dns/dnshomede/dnshomede.toml
+++ b/providers/dns/dnshomede/dnshomede.toml
@@ -15,7 +15,7 @@ lego --email you@example.com --dns dnshomede --domains my.example.org --domains 
 [Configuration]
   [Configuration.Credentials]
     DNSHOMEDE_CREDENTIALS = "Comma-separated list of domain:password credential pairs"
-  [Configuration.Addtional]
+  [Configuration.Additional]
     DNSHOMEDE_POLLING_INTERVAL = "Time between DNS propagation checks"
     DNSHOMEDE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation; defaults to 300s (5 minutes)"
     DNSHOMEDE_SEQUENCE_INTERVAL = "Time between sequential requests"

--- a/providers/dns/hurricane/hurricane.toml
+++ b/providers/dns/hurricane/hurricane.toml
@@ -38,7 +38,7 @@ HURRICANE_TOKENS=example.org:token
 [Configuration]
   [Configuration.Credentials]
     HURRICANE_TOKENS = "TXT record names and tokens"
-  [Configuration.Addtional]
+  [Configuration.Additional]
     HURRICANE_POLLING_INTERVAL = "Time between DNS propagation checks"
     HURRICANE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation; defaults to 300s (5 minutes)"
     HURRICANE_SEQUENCE_INTERVAL = "Time between sequential requests"


### PR DESCRIPTION
This PR corrects a typo in the documentation for `dnshome.de` and `hurricane` providers, changing `Configuration.Addtional` to `Configuration.Additional`.

The incorrect key was preventing the "Additional Configuration" section from being generated correctly.