### PR TITLE
feat(cli): add dns.propagation-wait flag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -113,6 +113,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Name:  "dns.disable-cp",
 			Usage: "By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers.",
 		},
+		&cli.DurationFlag{
+			Name:  "dns.propagation-wait",
+			Usage: "By setting this flag, disables all the propagation checks and uses a wait duration instead.",
+		},
 		&cli.StringSliceFlag{
 			Name: "dns.resolvers",
 			Usage: "Set the resolvers to use for performing (recursive) CNAME resolving and apex domain determination." +

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -40,6 +40,7 @@ GLOBAL OPTIONS:
    --tls.port value                                             Set the port and interface to use for TLS-ALPN-01 based challenges to listen on. Supported: interface:port or :port. (default: ":443")
    --dns value                                                  Solve a DNS-01 challenge using the specified provider. Can be mixed with other types of challenges. Run 'lego dnshelp' for help on usage.
    --dns.disable-cp                                             By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers. (default: false)
+   --dns.propagation-wait value                                 By setting this flag, disables all the propagation checks and uses a wait duration instead. (default: 0s)
    --dns.resolvers value [ --dns.resolvers value ]              Set the resolvers to use for performing (recursive) CNAME resolving and apex domain determination. For DNS-01 challenge verification, the authoritative DNS server is queried directly. Supported: host:port. The default is to use the system resolvers, or Google's DNS resolvers if the system's cannot be determined.
    --http-timeout value                                         Set the HTTP timeout value to a specific value in seconds. (default: 0)
    --dns-timeout value                                          Set the DNS timeout value to a specific value in seconds. Used only when performing authoritative name server queries. (default: 10)


### PR DESCRIPTION
The flags system doesn't allow having a "mixed" type flag (bool/duration): using `GenericFlag` doesn't work because you are forced to set a value, this means that using `--dns.disable-cp` without an explicit value will break.
So it's not possible to use `dns.disable-cp` to handle the wait.

Also the flag name `dns.disable-cp` is inaccurate because it will not disable all the propagation checks but only the checks on the nameservers.

Fixes #2030