### PR TITLE
feat: add dns.propagation-rns option

### DIFF
--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -28,6 +29,13 @@ func DisableCompletePropagationRequirement() ChallengeOption {
 		chlg.preCheck.requireCompletePropagation = false
 		return nil
 	}
+}
+
+func PropagationWaitOnly(wait time.Duration) ChallengeOption {
+	return WrapPreCheck(func(domain, fqdn, value string, check PreCheckFunc) (bool, error) {
+		time.Sleep(wait)
+		return true, nil
+	})
 }
 
 type preCheck struct {

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -24,9 +24,15 @@ func WrapPreCheck(wrap WrapPreCheckFunc) ChallengeOption {
 	}
 }
 
+// DisableCompletePropagationRequirement obsolete.
+// Deprecated: use DisableAuthoritativeNssPropagationRequirement instead.
 func DisableCompletePropagationRequirement() ChallengeOption {
+	return DisableAuthoritativeNssPropagationRequirement()
+}
+
+func DisableAuthoritativeNssPropagationRequirement() ChallengeOption {
 	return func(chlg *Challenge) error {
-		chlg.preCheck.requireCompletePropagation = false
+		chlg.preCheck.requireAuthoritativeNssPropagation = false
 		return nil
 	}
 }
@@ -41,13 +47,14 @@ func PropagationWaitOnly(wait time.Duration) ChallengeOption {
 type preCheck struct {
 	// checks DNS propagation before notifying ACME that the DNS challenge is ready.
 	checkFunc WrapPreCheckFunc
+
 	// require the TXT record to be propagated to all authoritative name servers
-	requireCompletePropagation bool
+	requireAuthoritativeNssPropagation bool
 }
 
 func newPreCheck() preCheck {
 	return preCheck{
-		requireCompletePropagation: true,
+		requireAuthoritativeNssPropagation: true,
 	}
 }
 
@@ -67,7 +74,7 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 		return false, err
 	}
 
-	if !p.requireCompletePropagation {
+	if !p.requireAuthoritativeNssPropagation {
 		return true, nil
 	}
 

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -37,6 +37,13 @@ func DisableAuthoritativeNssPropagationRequirement() ChallengeOption {
 	}
 }
 
+func RecursiveNSsPropagationRequirement() ChallengeOption {
+	return func(chlg *Challenge) error {
+		chlg.preCheck.requireAuthoritativeNssPropagation = true
+		return nil
+	}
+}
+
 func PropagationWaitOnly(wait time.Duration) ChallengeOption {
 	return WrapPreCheck(func(domain, fqdn, value string, check PreCheckFunc) (bool, error) {
 		time.Sleep(wait)
@@ -50,6 +57,9 @@ type preCheck struct {
 
 	// require the TXT record to be propagated to all authoritative name servers
 	requireAuthoritativeNssPropagation bool
+
+	// require the TXT record to be propagated to all recursive name servers
+	requireRecursiveNssPropagation bool
 }
 
 func newPreCheck() preCheck {
@@ -68,18 +78,25 @@ func (p preCheck) call(domain, fqdn, value string) (bool, error) {
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
 func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
-	// Initial attempt to resolve at the recursive NS
+	// Initial attempt to resolve at the recursive NS (require to get CNAME)
 	r, err := dnsQuery(fqdn, dns.TypeTXT, recursiveNameservers, true)
 	if err != nil {
 		return false, err
 	}
 
-	if !p.requireAuthoritativeNssPropagation {
-		return true, nil
-	}
-
 	if r.Rcode == dns.RcodeSuccess {
 		fqdn = updateDomainWithCName(r, fqdn)
+	}
+
+	if p.requireRecursiveNssPropagation {
+		_, err = checkAuthoritativeNss(fqdn, value, recursiveNameservers, false)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if !p.requireAuthoritativeNssPropagation {
+		return true, nil
 	}
 
 	authoritativeNss, err := lookupNameservers(fqdn)
@@ -87,13 +104,17 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 		return false, err
 	}
 
-	return checkAuthoritativeNss(fqdn, value, authoritativeNss)
+	return checkAuthoritativeNss(fqdn, value, authoritativeNss, true)
 }
 
 // checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
-func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, error) {
+func checkAuthoritativeNss(fqdn, value string, nameservers []string, addPort bool) (bool, error) {
 	for _, ns := range nameservers {
-		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{net.JoinHostPort(ns, "53")}, false)
+		if addPort {
+			ns = net.JoinHostPort(ns, "53")
+		}
+
+		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{ns}, false)
 		if err != nil {
 			return false, err
 		}

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -89,7 +89,7 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 	}
 
 	if p.requireRecursiveNssPropagation {
-		_, err = checkAuthoritativeNss(fqdn, value, recursiveNameservers, false)
+		_, err = checkNameserversPropagation(fqdn, value, recursiveNameservers, false)
 		if err != nil {
 			return false, err
 		}
@@ -104,11 +104,11 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 		return false, err
 	}
 
-	return checkAuthoritativeNss(fqdn, value, authoritativeNss, true)
+	return checkNameserversPropagation(fqdn, value, authoritativeNss, true)
 }
 
-// checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
-func checkAuthoritativeNss(fqdn, value string, nameservers []string, addPort bool) (bool, error) {
+// checkNameserversPropagation queries each of the given nameservers for the expected TXT record.
+func checkNameserversPropagation(fqdn, value string, nameservers []string, addPort bool) (bool, error) {
 	for _, ns := range nameservers {
 		if addPort {
 			ns = net.JoinHostPort(ns, "53")

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -39,7 +39,7 @@ func DisableAuthoritativeNssPropagationRequirement() ChallengeOption {
 
 func RecursiveNSsPropagationRequirement() ChallengeOption {
 	return func(chlg *Challenge) error {
-		chlg.preCheck.requireAuthoritativeNssPropagation = true
+		chlg.preCheck.requireRecursiveNssPropagation = true
 		return nil
 	}
 }

--- a/challenge/dns01/precheck_test.go
+++ b/challenge/dns01/precheck_test.go
@@ -72,7 +72,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 			t.Parallel()
 			ClearFqdnCache()
 
-			ok, _ := checkAuthoritativeNss(test.fqdn, test.value, test.ns, true)
+			ok, _ := checkNameserversPropagation(test.fqdn, test.value, test.ns, true)
 			assert.Equal(t, test.expected, ok, test.fqdn)
 		})
 	}
@@ -106,7 +106,7 @@ func TestCheckAuthoritativeNssErr(t *testing.T) {
 			t.Parallel()
 			ClearFqdnCache()
 
-			_, err := checkAuthoritativeNss(test.fqdn, test.value, test.ns, true)
+			_, err := checkNameserversPropagation(test.fqdn, test.value, test.ns, true)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), test.error)
 		})

--- a/challenge/dns01/precheck_test.go
+++ b/challenge/dns01/precheck_test.go
@@ -72,7 +72,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 			t.Parallel()
 			ClearFqdnCache()
 
-			ok, _ := checkAuthoritativeNss(test.fqdn, test.value, test.ns)
+			ok, _ := checkAuthoritativeNss(test.fqdn, test.value, test.ns, true)
 			assert.Equal(t, test.expected, ok, test.fqdn)
 		})
 	}
@@ -106,7 +106,7 @@ func TestCheckAuthoritativeNssErr(t *testing.T) {
 			t.Parallel()
 			ClearFqdnCache()
 
-			_, err := checkAuthoritativeNss(test.fqdn, test.value, test.ns)
+			_, err := checkAuthoritativeNss(test.fqdn, test.value, test.ns, true)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), test.error)
 		})

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -151,7 +151,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		},
 		&cli.DurationFlag{
 			Name:  flgDNSPropagationWait,
-			Usage: "By setting this flag, disables all the propagation checks and uses a wait duration instead.",
+			Usage: "By setting this flag, disables all the propagation checks of the TXT record and uses a wait duration instead.",
 		},
 		&cli.StringSliceFlag{
 			Name: flgDNSResolvers,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-acme/lego/v4/certificate"
@@ -11,38 +12,39 @@ import (
 
 // Flag names.
 const (
-	flgDomains             = "domains"
-	flgServer              = "server"
-	flgAcceptTOS           = "accept-tos"
-	flgEmail               = "email"
-	flgCSR                 = "csr"
-	flgEAB                 = "eab"
-	flgKID                 = "kid"
-	flgHMAC                = "hmac"
-	flgKeyType             = "key-type"
-	flgFilename            = "filename"
-	flgPath                = "path"
-	flgHTTP                = "http"
-	flgHTTPPort            = "http.port"
-	flgHTTPProxyHeader     = "http.proxy-header"
-	flgHTTPWebroot         = "http.webroot"
-	flgHTTPMemcachedHost   = "http.memcached-host"
-	flgHTTPS3Bucket        = "http.s3-bucket"
-	flgTLS                 = "tls"
-	flgTLSPort             = "tls.port"
-	flgDNS                 = "dns"
-	flgDNSDisableCP        = "dns.disable-cp"
-	flgDNSPropagationWait  = "dns.propagation-wait"
-	flgDNSResolvers        = "dns.resolvers"
-	flgHTTPTimeout         = "http-timeout"
-	flgDNSTimeout          = "dns-timeout"
-	flgPEM                 = "pem"
-	flgPFX                 = "pfx"
-	flgPFXPass             = "pfx.pass"
-	flgPFXFormat           = "pfx.format"
-	flgCertTimeout         = "cert.timeout"
-	flgOverallRequestLimit = "overall-request-limit"
-	flgUserAgent           = "user-agent"
+	flgDomains                  = "domains"
+	flgServer                   = "server"
+	flgAcceptTOS                = "accept-tos"
+	flgEmail                    = "email"
+	flgCSR                      = "csr"
+	flgEAB                      = "eab"
+	flgKID                      = "kid"
+	flgHMAC                     = "hmac"
+	flgKeyType                  = "key-type"
+	flgFilename                 = "filename"
+	flgPath                     = "path"
+	flgHTTP                     = "http"
+	flgHTTPPort                 = "http.port"
+	flgHTTPProxyHeader          = "http.proxy-header"
+	flgHTTPWebroot              = "http.webroot"
+	flgHTTPMemcachedHost        = "http.memcached-host"
+	flgHTTPS3Bucket             = "http.s3-bucket"
+	flgTLS                      = "tls"
+	flgTLSPort                  = "tls.port"
+	flgDNS                      = "dns"
+	flgDNSDisableCP             = "dns.disable-cp"
+	flgDNSPropagationWait       = "dns.propagation-wait"
+	flgDNSPropagationDisableANS = "dns.propagation-disable-ans"
+	flgDNSResolvers             = "dns.resolvers"
+	flgHTTPTimeout              = "http-timeout"
+	flgDNSTimeout               = "dns-timeout"
+	flgPEM                      = "pem"
+	flgPFX                      = "pfx"
+	flgPFXPass                  = "pfx.pass"
+	flgPFXFormat                = "pfx.format"
+	flgCertTimeout              = "cert.timeout"
+	flgOverallRequestLimit      = "overall-request-limit"
+	flgUserAgent                = "user-agent"
 )
 
 func CreateFlags(defaultPath string) []cli.Flag {
@@ -147,6 +149,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  flgDNSDisableCP,
+			Usage: fmt.Sprintf("(deprecated) use %s instead.", flgDNSPropagationDisableANS),
+		},
+		&cli.BoolFlag{
+			Name:  flgDNSPropagationDisableANS,
 			Usage: "By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers.",
 		},
 		&cli.DurationFlag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -35,6 +35,7 @@ const (
 	flgDNSDisableCP             = "dns.disable-cp"
 	flgDNSPropagationWait       = "dns.propagation-wait"
 	flgDNSPropagationDisableANS = "dns.propagation-disable-ans"
+	flgDNSPropagationRNS        = "dns.propagation-rns"
 	flgDNSResolvers             = "dns.resolvers"
 	flgHTTPTimeout              = "http-timeout"
 	flgDNSTimeout               = "dns-timeout"
@@ -154,6 +155,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:  flgDNSPropagationDisableANS,
 			Usage: "By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers.",
+		},
+		&cli.BoolFlag{
+			Name:  flgDNSPropagationRNS,
+			Usage: "By setting this flag, use all the recursive nameservers to check the propagation of the TXT record.",
 		},
 		&cli.DurationFlag{
 			Name:  flgDNSPropagationWait,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -158,7 +158,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  flgDNSPropagationRNS,
-			Usage: "By setting this flag, use all the recursive nameservers to check the propagation of the TXT record.",
+			Usage: "By setting this flag to true, use all the recursive nameservers to check the propagation of the TXT record.",
 		},
 		&cli.DurationFlag{
 			Name:  flgDNSPropagationWait,

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -145,6 +145,9 @@ func setupDNS(ctx *cli.Context, client *lego.Client) error {
 		dns01.CondOption(ctx.Duration(flgDNSPropagationWait) > 0,
 			dns01.PropagationWaitOnly(wait)),
 
+		dns01.CondOption(ctx.Bool(flgDNSPropagationRNS),
+			dns01.RecursiveNSsPropagationRequirement()),
+
 		dns01.CondOption(ctx.IsSet(flgDNSTimeout),
 			dns01.AddDNSTimeout(time.Duration(ctx.Int(flgDNSTimeout))*time.Second)),
 	)
@@ -159,6 +162,10 @@ func checkPropagationExclusiveOptions(ctx *cli.Context) error {
 
 	if (isSetBool(ctx, flgDNSDisableCP) || isSetBool(ctx, flgDNSPropagationDisableANS)) && ctx.IsSet(flgDNSPropagationWait) {
 		return fmt.Errorf("'%s' and '%s' are mutually exclusive", flgDNSPropagationDisableANS, flgDNSPropagationWait)
+	}
+
+	if isSetBool(ctx, flgDNSPropagationRNS) && ctx.IsSet(flgDNSPropagationWait) {
+		return fmt.Errorf("'%s' and '%s' are mutually exclusive", flgDNSPropagationRNS, flgDNSPropagationWait)
 	}
 
 	return nil

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -141,12 +141,8 @@ func setupDNS(ctx *cli.Context, client *lego.Client) error {
 		dns01.CondOption(ctx.Bool(flgDNSDisableCP),
 			dns01.DisableCompletePropagationRequirement()),
 
-		dns01.CondOption(ctx.IsSet(flgDNSPropagationWait), dns01.WrapPreCheck(
-			func(domain, fqdn, value string, check dns01.PreCheckFunc) (bool, error) {
-				time.Sleep(wait)
-				return true, nil
-			},
-		)),
+		dns01.CondOption(ctx.Duration(flgDNSPropagationWait) > 0,
+			dns01.PropagationWaitOnly(wait)),
 
 		dns01.CondOption(ctx.IsSet(flgDNSTimeout),
 			dns01.AddDNSTimeout(time.Duration(ctx.Int(flgDNSTimeout))*time.Second)),

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -39,8 +39,10 @@ GLOBAL OPTIONS:
    --tls                                                        Use the TLS-ALPN-01 challenge to solve challenges. Can be mixed with other types of challenges. (default: false)
    --tls.port value                                             Set the port and interface to use for TLS-ALPN-01 based challenges to listen on. Supported: interface:port or :port. (default: ":443")
    --dns value                                                  Solve a DNS-01 challenge using the specified provider. Can be mixed with other types of challenges. Run 'lego dnshelp' for help on usage.
-   --dns.disable-cp                                             By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers. (default: false)
-   --dns.propagation-wait value                                 By setting this flag, disables all the propagation checks and uses a wait duration instead. (default: 0s)
+   --dns.disable-cp                                             (deprecated) use dns.propagation-disable-ans instead. (default: false)
+   --dns.propagation-disable-ans                                By setting this flag to true, disables the need to await propagation of the TXT record to all authoritative name servers. (default: false)
+   --dns.propagation-rns                                        By setting this flag, use all the recursive nameservers to check the propagation of the TXT record. (default: false)
+   --dns.propagation-wait value                                 By setting this flag, disables all the propagation checks of the TXT record and uses a wait duration instead. (default: 0s)
    --dns.resolvers value [ --dns.resolvers value ]              Set the resolvers to use for performing (recursive) CNAME resolving and apex domain determination. For DNS-01 challenge verification, the authoritative DNS server is queried directly. Supported: host:port. The default is to use the system resolvers, or Google's DNS resolvers if the system's cannot be determined.
    --http-timeout value                                         Set the HTTP timeout value to a specific value in seconds. (default: 0)
    --dns-timeout value                                          Set the DNS timeout value to a specific value in seconds. Used only when performing authoritative name server queries. (default: 10)

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -94,7 +94,7 @@ func TestChallengeDNS_Client_Obtain(t *testing.T) {
 
 	err = client.Challenge.SetDNS01Provider(provider,
 		dns01.AddRecursiveNameservers([]string{":8053"}),
-		dns01.DisableCompletePropagationRequirement())
+		dns01.DisableAuthoritativeNssPropagationRequirement())
 	require.NoError(t, err)
 
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})


### PR DESCRIPTION
- deprecation of `dns.disable-cp`, replaced by `dns.propagation-disable-ans`.
- add `dns.propagation-rns` option to check all the authoritative nameservers.

Fixes #2276