### PR TITLE
perf: reducing the lock strength of the soa cache entry

### DIFF
--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -17,8 +17,7 @@ import (
 const defaultResolvConf = "/etc/resolv.conf"
 
 var (
-	fqdnSoaCache   = map[string]*soaCacheEntry{}
-	muFqdnSoaCache sync.Mutex
+	fqdnSoaCache sync.Map
 )
 
 var defaultNameservers = []string{
@@ -51,9 +50,7 @@ func (cache *soaCacheEntry) isExpired() bool {
 
 // ClearFqdnCache clears the cache of fqdn to zone mappings. Primarily used in testing.
 func ClearFqdnCache() {
-	muFqdnSoaCache.Lock()
-	fqdnSoaCache = map[string]*soaCacheEntry{}
-	muFqdnSoaCache.Unlock()
+	fqdnSoaCache = sync.Map{}
 }
 
 func AddDNSTimeout(timeout time.Duration) ChallengeOption {
@@ -153,12 +150,13 @@ func FindZoneByFqdnCustom(fqdn string, nameservers []string) (string, error) {
 }
 
 func lookupSoaByFqdn(fqdn string, nameservers []string) (*soaCacheEntry, error) {
-	muFqdnSoaCache.Lock()
-	defer muFqdnSoaCache.Unlock()
-
 	// Do we have it cached and is it still fresh?
-	if ent := fqdnSoaCache[fqdn]; ent != nil && !ent.isExpired() {
-		return ent, nil
+	entAny, ok := fqdnSoaCache.Load(fqdn)
+	if ok && entAny != nil {
+		ent, ok1 := entAny.(*soaCacheEntry)
+		if ok1 && !ent.isExpired() {
+			return ent, nil
+		}
 	}
 
 	ent, err := fetchSoaByFqdn(fqdn, nameservers)
@@ -166,7 +164,8 @@ func lookupSoaByFqdn(fqdn string, nameservers []string) (*soaCacheEntry, error) 
 		return nil, err
 	}
 
-	fqdnSoaCache[fqdn] = ent
+	fqdnSoaCache.Store(fqdn, ent)
+
 	return ent, nil
 }
 

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -16,9 +16,7 @@ import (
 
 const defaultResolvConf = "/etc/resolv.conf"
 
-var (
-	fqdnSoaCache = &sync.Map{}
-)
+var fqdnSoaCache = &sync.Map{}
 
 var defaultNameservers = []string{
 	"google-public-dns-a.google.com:53",
@@ -50,7 +48,7 @@ func (cache *soaCacheEntry) isExpired() bool {
 
 // ClearFqdnCache clears the cache of fqdn to zone mappings. Primarily used in testing.
 func ClearFqdnCache() {
-	fqdnSoaCache = &sync.Map{}
+	fqdnSoaCache.Clear()
 }
 
 func AddDNSTimeout(timeout time.Duration) ChallengeOption {


### PR DESCRIPTION
When a large number of applications are made, there will be a large number of lock seizures and lower performance