### PR TITLE
namesilo: restrict CleanUp

### DIFF
--- a/providers/dns/namesilo/namesilo.go
+++ b/providers/dns/namesilo/namesilo.go
@@ -100,11 +100,6 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("namesilo: %w", err)
 	}
 
-	err = d.CleanUp(domain, token, keyAuth)
-	if err != nil {
-		return err
-	}
-
 	_, err = d.client.DnsAddRecord(&namesilo.DnsAddRecordParams{
 		Domain: zoneName,
 		Type:   "TXT",

--- a/providers/dns/namesilo/namesilo.go
+++ b/providers/dns/namesilo/namesilo.go
@@ -141,7 +141,7 @@ func (d *DNSProvider) CleanUp(domain, _, keyAuth string) error {
 
 	var lastErr error
 	for _, r := range resp.Reply.ResourceRecord {
-		if r.Type == "TXT" && (r.Host == subdomain || r.Host == dns01.UnFqdn(info.EffectiveFQDN)) {
+		if r.Type == "TXT" && r.Value == info.Value && (r.Host == subdomain || r.Host == dns01.UnFqdn(info.EffectiveFQDN)) {
 			_, err := d.client.DnsDeleteRecord(&namesilo.DnsDeleteRecordParams{Domain: zoneName, ID: r.RecordID})
 			if err != nil {
 				lastErr = fmt.Errorf("namesilo: %w", err)

--- a/providers/dns/namesilo/namesilo.go
+++ b/providers/dns/namesilo/namesilo.go
@@ -134,16 +134,18 @@ func (d *DNSProvider) CleanUp(domain, _, keyAuth string) error {
 		return fmt.Errorf("namesilo: %w", err)
 	}
 
-	var lastErr error
 	for _, r := range resp.Reply.ResourceRecord {
 		if r.Type == "TXT" && r.Value == info.Value && (r.Host == subdomain || r.Host == dns01.UnFqdn(info.EffectiveFQDN)) {
 			_, err := d.client.DnsDeleteRecord(&namesilo.DnsDeleteRecordParams{Domain: zoneName, ID: r.RecordID})
 			if err != nil {
-				lastErr = fmt.Errorf("namesilo: %w", err)
+				return fmt.Errorf("namesilo: %w", err)
 			}
+
+			return nil
 		}
 	}
-	return lastErr
+
+	return fmt.Errorf("namesilo: no TXT record to delete for %s (%s)", info.EffectiveFQDN, info.Value)
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.


### PR DESCRIPTION
I restricted the `CleanUp` to only delete the record with a specific value instead of all TXT records.
Because of this restriction, it's useless to call the `CleanUp` during the `Present` because the value will never be the same.

Fixes #2286
Revert #1833