### PR TITLE
feat: attempt to check ARI unless explicitly disabled

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -20,7 +20,7 @@ import (
 // Flag names.
 const (
 	flgDays                   = "days"
-	flgARIEnable              = "ari-enable"
+	flgARIDisable             = "ari-disable"
 	flgARIWaitToRenewDuration = "ari-wait-to-renew-duration"
 	flgReuseKey               = "reuse-key"
 	flgRenewHook              = "renew-hook"
@@ -61,8 +61,8 @@ func createRenew() *cli.Command {
 				Usage: "The number of days left on a certificate to renew it.",
 			},
 			&cli.BoolFlag{
-				Name:  flgARIEnable,
-				Usage: "Use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed.",
+				Name:  flgARIDisable,
+				Usage: "Do not use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed.",
 			},
 			&cli.DurationFlag{
 				Name:  flgARIWaitToRenewDuration,
@@ -151,7 +151,7 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 	cert := certificates[0]
 
 	var ariRenewalTime *time.Time
-	if ctx.Bool(flgARIEnable) {
+	if !ctx.Bool(flgARIDisable) {
 		ariRenewalTime = getARIRenewalTime(ctx, cert, domain, client)
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
@@ -209,7 +209,7 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		AlwaysDeactivateAuthorizations: ctx.Bool(flgAlwaysDeactivateAuthorizations),
 	}
 
-	if ctx.Bool(flgARIEnable) {
+	if !ctx.Bool(flgARIDisable) {
 		request.ReplacesCertID, err = certificate.MakeARICertID(cert)
 		if err != nil {
 			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)
@@ -250,7 +250,7 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 	cert := certificates[0]
 
 	var ariRenewalTime *time.Time
-	if ctx.Bool(flgARIEnable) {
+	if !ctx.Bool(flgARIDisable) {
 		ariRenewalTime = getARIRenewalTime(ctx, cert, domain, client)
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
@@ -279,7 +279,7 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 		AlwaysDeactivateAuthorizations: ctx.Bool(flgAlwaysDeactivateAuthorizations),
 	}
 
-	if ctx.Bool(flgARIEnable) {
+	if !ctx.Bool(flgARIDisable) {
 		request.ReplacesCertID, err = certificate.MakeARICertID(cert)
 		if err != nil {
 			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -151,15 +151,23 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 	cert := certificates[0]
 
 	var ariRenewalTime *time.Time
+	var replacesCertID string
+
 	if !ctx.Bool(flgARIDisable) {
 		ariRenewalTime = getARIRenewalTime(ctx, cert, domain, client)
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
+
 			// Figure out if we need to sleep before renewing.
 			if ariRenewalTime.After(now) {
 				log.Infof("[%s] Sleeping %s until renewal time %s", domain, ariRenewalTime.Sub(now), ariRenewalTime)
 				time.Sleep(ariRenewalTime.Sub(now))
 			}
+		}
+
+		replacesCertID, err = certificate.MakeARICertID(cert)
+		if err != nil {
+			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)
 		}
 	}
 
@@ -209,11 +217,8 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		AlwaysDeactivateAuthorizations: ctx.Bool(flgAlwaysDeactivateAuthorizations),
 	}
 
-	if !ctx.Bool(flgARIDisable) {
-		request.ReplacesCertID, err = certificate.MakeARICertID(cert)
-		if err != nil {
-			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)
-		}
+	if replacesCertID != "" {
+		request.ReplacesCertID = replacesCertID
 	}
 
 	certRes, err := client.Certificate.Obtain(request)
@@ -250,15 +255,23 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 	cert := certificates[0]
 
 	var ariRenewalTime *time.Time
+	var replacesCertID string
+
 	if !ctx.Bool(flgARIDisable) {
 		ariRenewalTime = getARIRenewalTime(ctx, cert, domain, client)
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
+
 			// Figure out if we need to sleep before renewing.
 			if ariRenewalTime.After(now) {
 				log.Infof("[%s] Sleeping %s until renewal time %s", domain, ariRenewalTime.Sub(now), ariRenewalTime)
 				time.Sleep(ariRenewalTime.Sub(now))
 			}
+		}
+
+		replacesCertID, err = certificate.MakeARICertID(cert)
+		if err != nil {
+			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)
 		}
 	}
 
@@ -279,11 +292,8 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 		AlwaysDeactivateAuthorizations: ctx.Bool(flgAlwaysDeactivateAuthorizations),
 	}
 
-	if !ctx.Bool(flgARIDisable) {
-		request.ReplacesCertID, err = certificate.MakeARICertID(cert)
-		if err != nil {
-			log.Fatalf("Error while construction the ARI CertID for domain %s\n\t%v", domain, err)
-		}
+	if replacesCertID != "" {
+		request.ReplacesCertID = replacesCertID
 	}
 
 	certRes, err := client.Certificate.ObtainForCSR(request)

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -88,7 +88,7 @@ USAGE:
 
 OPTIONS:
    --days value                              The number of days left on a certificate to renew it. (default: 30)
-   --ari-enable                              Use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed. (default: false)
+   --ari-disable                             Do not use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed. (default: false)
    --ari-wait-to-renew-duration value        The maximum duration you're willing to sleep for a renewal time returned by the renewalInfo endpoint. (default: 0s)
    --reuse-key                               Used to indicate you want to reuse your current private key for the new certificate. (default: false)
    --no-bundle                               Do not create a certificate bundle by adding the issuers certificate to the new certificate. (default: false)


### PR DESCRIPTION
With [draft-ietf-acme-ari](https://datatracker.ietf.org/doc/draft-ietf-acme-ari/) now in IETF Working Group Last Call—the final step before becoming an RFC—it is reasonable to enable ARI checks by default.