### PR TITLE
chore: fix readme generator

### DIFF
--- a/internal/dns/docs/readme.md.tmpl
+++ b/internal/dns/docs/readme.md.tmpl
@@ -3,7 +3,7 @@
 {{- range . -}}
 <tr>
   {{- range . }}
-  <td><a href="https://go-acme.github.io/lego/dns/{{ .Code }}/">{{ .Name }}</a></td>
+  <td>{{if .Code }}<a href="https://go-acme.github.io/lego/dns/{{ .Code }}/">{{ .Name }}</a>{{end}}</td>
   {{- end }}
 </tr>
 {{- end -}}


### PR DESCRIPTION
If the number of providers is odd then it generates non-empty cells:
```
<td><a href="https://go-acme.github.io/lego/dns//"></a></td>
```

https://github.com/go-acme/lego/pull/1967/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5