### PR TITLE
fix: Parse printf verbs in log line output

### DIFF
--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -159,7 +159,7 @@ func setupDNS(ctx *cli.Context, client *lego.Client) error {
 
 func checkPropagationExclusiveOptions(ctx *cli.Context) error {
 	if ctx.IsSet(flgDNSDisableCP) {
-		log.Printf("The flag '%s' is deprecated use '%s' instead.\n", flgDNSDisableCP, flgDNSPropagationDisableANS)
+		log.Printf("The flag '%s' is deprecated use '%s' instead.", flgDNSDisableCP, flgDNSPropagationDisableANS)
 	}
 
 	if (isSetBool(ctx, flgDNSDisableCP) || isSetBool(ctx, flgDNSPropagationDisableANS)) && ctx.IsSet(flgDNSPropagationWait) {

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -159,7 +159,7 @@ func setupDNS(ctx *cli.Context, client *lego.Client) error {
 
 func checkPropagationExclusiveOptions(ctx *cli.Context) error {
 	if ctx.IsSet(flgDNSDisableCP) {
-		log.Println("The flag '%s' is deprecated use '%s' instead.", flgDNSDisableCP, flgDNSPropagationDisableANS)
+		log.Printf("The flag '%s' is deprecated use '%s' instead.\n", flgDNSDisableCP, flgDNSPropagationDisableANS)
 	}
 
 	if (isSetBool(ctx, flgDNSDisableCP) || isSetBool(ctx, flgDNSPropagationDisableANS)) && ctx.IsSet(flgDNSPropagationWait) {


### PR DESCRIPTION
Current log output in `setup_challenges.go` looks like this:

```
Nov 01 01:05:07 xxx lego[1548788]: 2024/11/01 01:05:07 The flag '%s' is deprecated use '%s' instead. dns.disable-cp dns.propagation-disable-ans
```

This MR fixes the output.