### PR TITLE
Fix selectelv2 provider

### DIFF
--- a/docs/content/dns/zz_gen_selectelv2.md
+++ b/docs/content/dns/zz_gen_selectelv2.md
@@ -26,10 +26,10 @@ Configuration for [Selectel v2](https://selectel.ru).
 Here is an example bash command using the Selectel v2 provider:
 
 ```bash
-SELECTEL_USERNAME=trex \
-SELECTEL_PASSWORD=xxxxx \
-SELECTEL_ACCOUNT_ID=1234567 \
-SELECTEL_PROJECT_ID=111a11111aaa11aa1a11aaa11111aa1a \
+SELECTELV2_USERNAME=trex \
+SELECTELV2_PASSWORD=xxxxx \
+SELECTELV2_ACCOUNT_ID=1234567 \
+SELECTELV2_PROJECT_ID=111a11111aaa11aa1a11aaa11111aa1a \
 lego --email you@example.com --dns selectelv2 --domains my.example.org run
 ```
 

--- a/providers/dns/selectelv2/selectelv2.toml
+++ b/providers/dns/selectelv2/selectelv2.toml
@@ -5,10 +5,10 @@ Code = "selectelv2"
 Since = "v4.17.0"
 
 Example = '''
-SELECTEL_USERNAME=trex \
-SELECTEL_PASSWORD=xxxxx \
-SELECTEL_ACCOUNT_ID=1234567 \
-SELECTEL_PROJECT_ID=111a11111aaa11aa1a11aaa11111aa1a \
+SELECTELV2_USERNAME=trex \
+SELECTELV2_PASSWORD=xxxxx \
+SELECTELV2_ACCOUNT_ID=1234567 \
+SELECTELV2_PROJECT_ID=111a11111aaa11aa1a11aaa11111aa1a \
 lego --email you@example.com --dns selectelv2 --domains my.example.org run
 '''
 


### PR DESCRIPTION
We have discovered trouble with issuing certs for non-ascii domains. This small PR fixes it.  

* Convert retrieved zone and record names to ASCII since API returns them in Unicode, which leads to failed DNS challenge, since zone and records can not be found  
* Update env names in doc example


Here is run with next setup
```bash
#!/bin/bash
SELECTELV2_USERNAME=*** \
SELECTELV2_PASSWORD=***\
SELECTELV2_ACCOUNT_ID=*** \
SELECTELV2_PROJECT_ID=*** \
./dist/lego \
--dns selectelv2 \
--email ***@gmail.com \
-d project-scribbler.art \
-d *.project-scribbler.art \
-d вонни.рф \
-d *.вонни.рф \
run
```

```bash
[14:34] chirkov@chirkov: ~/Repositories/github/lego
$> rm -rf .lego
[14:36] chirkov@chirkov: ~/Repositories/github/lego
$> bash ./test.sh
2024/11/06 14:37:11 No key found for account ***@gmail.com. Generating a P256 key.
2024/11/06 14:37:11 Saved key to /home/chirkov/Repositories/github/lego/.lego/accounts/acme-v02.api.letsencrypt.org/***@gmail.com/keys/***@gmail.com.key
2024/11/06 14:37:11 Please review the TOS at https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf
Do you accept the TOS? Y/n
y
2024/11/06 14:37:13 [INFO] acme: Registering account for ***@gmail.com
!!!! HEADS UP !!!!

Your account credentials have been saved in your Let's Encrypt
configuration directory at "/home/chirkov/Repositories/github/lego/.lego/accounts".

You should make a secure backup of this folder now. This
configuration directory will also contain certificates and
private keys obtained from Let's Encrypt so making regular
backups of this folder is ideal.
2024/11/06 14:37:14 [INFO] [project-scribbler.art, *.project-scribbler.art, xn--b1amoad.xn--p1ai, *.xn--b1amoad.xn--p1ai] acme: Obtaining bundled SAN certificate
2024/11/06 14:37:15 [INFO] [*.project-scribbler.art] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/426353287357
2024/11/06 14:37:15 [INFO] [*.xn--b1amoad.xn--p1ai] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/426353287367
2024/11/06 14:37:15 [INFO] [project-scribbler.art] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/426353287377
2024/11/06 14:37:15 [INFO] [xn--b1amoad.xn--p1ai] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/426353287387
2024/11/06 14:37:15 [INFO] [*.project-scribbler.art] acme: use dns-01 solver
2024/11/06 14:37:15 [INFO] [*.xn--b1amoad.xn--p1ai] acme: use dns-01 solver
2024/11/06 14:37:15 [INFO] [xn--b1amoad.xn--p1ai] acme: Could not find solver for: tls-alpn-01
2024/11/06 14:37:15 [INFO] [xn--b1amoad.xn--p1ai] acme: Could not find solver for: http-01
2024/11/06 14:37:15 [INFO] [xn--b1amoad.xn--p1ai] acme: use dns-01 solver
2024/11/06 14:37:15 [INFO] [project-scribbler.art] acme: Could not find solver for: tls-alpn-01
2024/11/06 14:37:15 [INFO] [project-scribbler.art] acme: Could not find solver for: http-01
2024/11/06 14:37:15 [INFO] [project-scribbler.art] acme: use dns-01 solver
2024/11/06 14:37:15 [INFO] [*.project-scribbler.art] acme: Preparing to solve DNS-01
2024/11/06 14:37:16 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:37:18 [INFO] [*.xn--b1amoad.xn--p1ai] acme: Preparing to solve DNS-01
2024/11/06 14:37:19 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:37:26 [INFO] [xn--b1amoad.xn--p1ai] acme: Preparing to solve DNS-01
2024/11/06 14:37:26 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:37:28 [INFO] [project-scribbler.art] acme: Preparing to solve DNS-01
2024/11/06 14:37:28 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:37:30 [INFO] [*.project-scribbler.art] acme: Trying to solve DNS-01
2024/11/06 14:37:30 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:37:30 [INFO] [*.project-scribbler.art] acme: Checking DNS record propagation. [nameservers=127.0.0.53:53]
2024/11/06 14:37:35 [INFO] Wait for propagation [timeout: 2m0s, interval: 5s]
2024/11/06 14:38:04 [INFO] [*.project-scribbler.art] The server validated our request
2024/11/06 14:38:04 [INFO] [*.xn--b1amoad.xn--p1ai] acme: Trying to solve DNS-01
2024/11/06 14:38:04 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:38:04 [INFO] [*.xn--b1amoad.xn--p1ai] acme: Checking DNS record propagation. [nameservers=127.0.0.53:53]
2024/11/06 14:38:09 [INFO] Wait for propagation [timeout: 2m0s, interval: 5s]
2024/11/06 14:38:15 [INFO] [*.xn--b1amoad.xn--p1ai] The server validated our request
2024/11/06 14:38:15 [INFO] [xn--b1amoad.xn--p1ai] acme: Trying to solve DNS-01
2024/11/06 14:38:15 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:38:15 [INFO] [xn--b1amoad.xn--p1ai] acme: Checking DNS record propagation. [nameservers=127.0.0.53:53]
2024/11/06 14:38:20 [INFO] Wait for propagation [timeout: 2m0s, interval: 5s]
2024/11/06 14:38:47 [INFO] [xn--b1amoad.xn--p1ai] The server validated our request
2024/11/06 14:38:47 [INFO] [project-scribbler.art] acme: Trying to solve DNS-01
2024/11/06 14:38:47 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:38:47 [INFO] [project-scribbler.art] acme: Checking DNS record propagation. [nameservers=127.0.0.53:53]
2024/11/06 14:38:52 [INFO] Wait for propagation [timeout: 2m0s, interval: 5s]
2024/11/06 14:39:18 [INFO] [project-scribbler.art] The server validated our request
2024/11/06 14:39:18 [INFO] [*.project-scribbler.art] acme: Cleaning DNS-01 challenge
2024/11/06 14:39:19 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:39:21 [INFO] [*.xn--b1amoad.xn--p1ai] acme: Cleaning DNS-01 challenge
2024/11/06 14:39:21 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:39:28 [INFO] [xn--b1amoad.xn--p1ai] acme: Cleaning DNS-01 challenge
2024/11/06 14:39:28 [INFO] Found CNAME entry for "_acme-challenge.xn--b1amoad.xn--p1ai.": "xn--b1amoad.xn--p1ai."
2024/11/06 14:39:29 [INFO] [project-scribbler.art] acme: Cleaning DNS-01 challenge
2024/11/06 14:39:30 [INFO] Found CNAME entry for "_acme-challenge.project-scribbler.art.": "project-scribbler.art."
2024/11/06 14:39:32 [INFO] [project-scribbler.art, *.project-scribbler.art, xn--b1amoad.xn--p1ai, *.xn--b1amoad.xn--p1ai] acme: Validations succeeded; requesting certificates
2024/11/06 14:39:33 [INFO] [project-scribbler.art] Server responded with a certificate.
```
@aidansteele 