### PR TITLE
regru: update authentication method

### DIFF
--- a/providers/dns/regru/internal/client.go
+++ b/providers/dns/regru/internal/client.go
@@ -76,17 +76,14 @@ func (c Client) AddTXTRecord(ctx context.Context, domain, subDomain, content str
 func (c Client) doRequest(ctx context.Context, request any, fragments ...string) (*APIResponse, error) {
 	endpoint := c.baseURL.JoinPath(fragments...)
 
-	query := endpoint.Query()
-	query.Set("username", c.username)
-	query.Set("password", c.password)
-	endpoint.RawQuery = query.Encode()
-
 	inputData, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create input data: %w", err)
 	}
 
 	data := url.Values{}
+	data.Set("username", c.username)
+	data.Set("password", c.password)
 	data.Set("input_data", string(inputData))
 	data.Set("input_format", "json")
 


### PR DESCRIPTION
Hi! Recently I've faced an issue with obtaining certificate via dns challenge for domain hosted by provider regru. This provider has updated API, so now authentication via query params is not allowed.  
You can check it with simple request from API [docs](https://www.reg.ru/reseller/api2doc#common_nop):
```
curl -X POST "https://api.reg.ru/api/regru2/nop?password=test&username=test"
```
API will respod with
```
{
   "charset" : "utf-8",
   "error_code" : "QUERY_PARAMS_DISALLOWED",
   "error_params" : {
      "command_name" : "nop"
   },
   "error_text" : "Query string parameters are disallowed. Pass parameters in form data.",
   "messagestore" : null,
   "result" : "error"
}
```
But if we send creds in form data like this:
```
curl -X POST -F "username=test" -F "password=test" "https://api.reg.ru/api/regru2/nop"
```
API will respond correctly
```
{
   "answer" : {
      "login" : "test",
      "user_id" : 0
   },
   "charset" : "utf-8",
   "messagestore" : null,
   "result" : "success"
}
```
So this PR is about changing authentication method from query params to form data.