### PR TITLE
feat: skip the TLS verification of the ACME server

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -38,7 +38,7 @@ const (
 	flgDNSPropagationRNS        = "dns.propagation-rns"
 	flgDNSResolvers             = "dns.resolvers"
 	flgHTTPTimeout              = "http-timeout"
-	flgHTTPSkipVerify           = "http-skip-verify"
+	flgTLSSkipVerify            = "tls-skip-verify"
 	flgDNSTimeout               = "dns-timeout"
 	flgPEM                      = "pem"
 	flgPFX                      = "pfx"
@@ -177,7 +177,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Usage: "Set the HTTP timeout value to a specific value in seconds.",
 		},
 		&cli.BoolFlag{
-			Name:  flgHTTPSkipVerify,
+			Name:  flgTLSSkipVerify,
 			Usage: "Skip the TLS verification of the ACME server.",
 		},
 		&cli.IntFlag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -38,6 +38,7 @@ const (
 	flgDNSPropagationRNS        = "dns.propagation-rns"
 	flgDNSResolvers             = "dns.resolvers"
 	flgHTTPTimeout              = "http-timeout"
+	flgHTTPSkipVerify           = "http-skip-verify"
 	flgDNSTimeout               = "dns-timeout"
 	flgPEM                      = "pem"
 	flgPFX                      = "pfx"
@@ -174,6 +175,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		&cli.IntFlag{
 			Name:  flgHTTPTimeout,
 			Usage: "Set the HTTP timeout value to a specific value in seconds.",
+		},
+		&cli.BoolFlag{
+			Name:  flgHTTPSkipVerify,
+			Usage: "Skip the TLS verification of the ACME server.",
 		},
 		&cli.IntFlag{
 			Name:  flgDNSTimeout,

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -46,6 +48,12 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 
 	if ctx.IsSet(flgHTTPTimeout) {
 		config.HTTPClient.Timeout = time.Duration(ctx.Int(flgHTTPTimeout)) * time.Second
+	}
+
+	if ctx.Bool(flgHTTPSkipVerify) {
+		config.HTTPClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
 	}
 
 	client, err := lego.NewClient(config)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -50,7 +50,7 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 		config.HTTPClient.Timeout = time.Duration(ctx.Int(flgHTTPTimeout)) * time.Second
 	}
 
-	if ctx.Bool(flgHTTPSkipVerify) {
+	if ctx.Bool(flgTLSSkipVerify) {
 		config.HTTPClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -45,6 +45,7 @@ GLOBAL OPTIONS:
    --dns.propagation-wait value                                 By setting this flag, disables all the propagation checks of the TXT record and uses a wait duration instead. (default: 0s)
    --dns.resolvers value [ --dns.resolvers value ]              Set the resolvers to use for performing (recursive) CNAME resolving and apex domain determination. For DNS-01 challenge verification, the authoritative DNS server is queried directly. Supported: host:port. The default is to use the system resolvers, or Google's DNS resolvers if the system's cannot be determined.
    --http-timeout value                                         Set the HTTP timeout value to a specific value in seconds. (default: 0)
+   --tls-skip-verify                                            Skip the TLS verification of the ACME server. (default: false)
    --dns-timeout value                                          Set the DNS timeout value to a specific value in seconds. Used only when performing authoritative name server queries. (default: 10)
    --pem                                                        Generate an additional .pem (base64) file by concatenating the .key and .crt files together. (default: false)
    --pfx                                                        Generate an additional .pfx (PKCS#12) file by concatenating the .key and .crt and issuer .crt files together. (default: false) [$LEGO_PFX]


### PR DESCRIPTION
Adds an option to skip the TLS verification of the ACME server.

Fixes https://github.com/go-acme/lego/discussions/2334