### PR TITLE
docs: update least privilege instructions for Cloudflare

### DIFF
--- a/docs/content/dns/zz_gen_cloudflare.md
+++ b/docs/content/dns/zz_gen_cloudflare.md
@@ -98,12 +98,13 @@ Then pass the API token as `CF_DNS_API_TOKEN` to Lego.
 **Alternatively,** if you prefer a more strict set of privileges,
 you can split the access tokens:
 
-* Create one with *Zone / Zone / Read* permissions and scope it to all your zones.
+* Create one with *Zone / Zone / Read* permissions and scope it to all your zones or just the individual zone you need to edit.
   This is needed to resolve domain names to Zone IDs and can be shared among multiple Lego installations.
   Pass this API token as `CF_ZONE_API_TOKEN` to Lego.
 * Create another API token with *Zone / DNS / Edit* permissions and set the scope to the domains you want to manage with a single Lego installation.
   Pass this token as `CF_DNS_API_TOKEN` to Lego.
 * Repeat the previous step for each host you want to run Lego on.
+* It is possible to use the same api token for both variables if it is given `Zone:Read` and `DNS:Edit` permission for the zone.
 
 This "paranoid" setup is mainly interesting for users who manage many zones/domains with a single Cloudflare account.
 It follows the principle of least privilege and limits the possible damage, should one of the hosts become compromised.

--- a/providers/dns/cloudflare/cloudflare.toml
+++ b/providers/dns/cloudflare/cloudflare.toml
@@ -46,12 +46,13 @@ Then pass the API token as `CF_DNS_API_TOKEN` to Lego.
 **Alternatively,** if you prefer a more strict set of privileges,
 you can split the access tokens:
 
-* Create one with *Zone / Zone / Read* permissions and scope it to all your zones.
+* Create one with *Zone / Zone / Read* permissions and scope it to all your zones or just the individual zone you need to edit.
   This is needed to resolve domain names to Zone IDs and can be shared among multiple Lego installations.
   Pass this API token as `CF_ZONE_API_TOKEN` to Lego.
 * Create another API token with *Zone / DNS / Edit* permissions and set the scope to the domains you want to manage with a single Lego installation.
   Pass this token as `CF_DNS_API_TOKEN` to Lego.
 * Repeat the previous step for each host you want to run Lego on.
+* It is possible to use the same api token for both variables if it is given `Zone:Read` and `DNS:Edit` permission for the zone.
 
 This "paranoid" setup is mainly interesting for users who manage many zones/domains with a single Cloudflare account.
 It follows the principle of least privilege and limits the possible damage, should one of the hosts become compromised.


### PR DESCRIPTION
The least privilege instructions for setting up Cloudflare API keys were over-granting permissions. This would allow lego to read all the zones in the account. This was unnecessary. It only requires read access to the individual zones.

Closes #2048

---
note - I'm unsure if this is the correct file to edit, or if it's the docs file (or both)