### PR TITLE
chore: fix snap name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,7 +145,7 @@ dockers:
       - '--platform=linux/arm/v7'
 
 snapcrafts:
-  - name: lego
+  - name_template: "{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     disable: false
     publish: true
     grade: stable


### PR DESCRIPTION
I feel (I didn't test it) like I should follow the same configuration as goreleaser:

https://github.com/goreleaser/goreleaser/blob/efe8b7089e55ac2de54238b699f2ba18cc339d5f/.goreleaser.yaml#L353C12-L354C85

