### PR TITLE
dnsmadeeasy: use default transport

### DIFF
--- a/providers/dns/dnsmadeeasy/dnsmadeeasy.go
+++ b/providers/dns/dnsmadeeasy/dnsmadeeasy.go
@@ -47,15 +47,22 @@ type Config struct {
 
 // NewDefaultConfig returns a default configuration for the DNSProvider.
 func NewDefaultConfig() *Config {
+	tr := &http.Transport{}
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if ok {
+		tr = defaultTransport.Clone()
+	}
+
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	return &Config{
 		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			Timeout:   env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+			Transport: tr,
 		},
 	}
 }


### PR DESCRIPTION
This provider is one of them that uses a "custom" Transport.

I cloned the default Transport instead of creating a new one, so the default Transport options will be applied.

Fixes #2361