### PR TITLE
feat: Change renew rc when cert is still valid

### DIFF
--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/go-acme/lego/v4/acme"
 	"github.com/go-acme/lego/v4/log"
 	"github.com/urfave/cli/v2"
@@ -39,6 +41,9 @@ func createRevoke() *cli.Command {
 
 func revoke(ctx *cli.Context) error {
 	acc, client := setup(ctx, NewAccountsStorage(ctx))
+	if client == nil {
+		os.Exit(1)
+	}
 
 	if acc.Registration == nil {
 		log.Fatalf("Account %s is not registered. Use 'run' to register a new account.\n", acc.Email)

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -94,6 +94,9 @@ func run(ctx *cli.Context) error {
 	accountsStorage := NewAccountsStorage(ctx)
 
 	account, client := setup(ctx, accountsStorage)
+	if client == nil {
+		os.Exit(1)
+	}
 	setupChallenges(ctx, client)
 
 	if account.Registration == nil {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -58,7 +58,8 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 
 	client, err := lego.NewClient(config)
 	if err != nil {
-		log.Fatalf("Could not create client: %v", err)
+		log.Warnf("Could not create client: %v", err)
+		return nil
 	}
 
 	if client.GetExternalAccountRequired() && !ctx.IsSet(flgEAB) {


### PR DESCRIPTION
Sometimes the lego Client may fail to contact the CA due to some temporary networking issue on the host. The certificate may otherwise still be valid, and a user may want to ignore this issue.

This change modifies the renew service so that if the lego client is nil, but the certificate is not expired, the exit code of the program will be 2 instead of 1. Crucially it does not change _if_ lego exits, only the exit code itself.

In order to implement this, I had to change the setup function to remove a usage of `log.Fatalf` which in turn required me to introduce explicit `os.Exit` calls in some commands. Although this was the lowest patch delta solution, I also considered refactoring the setup entirely to remove `log.Fatalf`, and return setup errors instead.

As with my previous PR, I performed a full integration test using the NixOS ACME integration test suite. You can run that test locally with this command:

`nix run github:m1cr0man/nixpkgs/lego-offline-renewal-test#nixosTests.acme`

Here's some example log output with this change implemented, sampled from a system with the network disabled:

```
$ lego --accept-tos --path . -d http.example.test --email admin@example.test --key-type ec256 --http --http.port :80 --server https://acme.test/dir renew --no-random-sleep --force-cert-domains --days 30
2024/11/30 23:33:00 [WARN] Could not create client: get directory at 'https://acme.test/dir': Get "https://acme.test/dir": dial tcp: lookup acme.test: Temporary failure in name resolution
2024/11/30 23:33:00 [http.example.test] The certificate expires in 1825 days, the number of days defined to perform the renewal is 30: no renewal.
2024/11/30 23:33:00 [WARN] [http.example.test] Failed to check ARI as there is no client. Check previous error messages for possible initialization issues.
$ echo $?
2
```