### PR TITLE
inwx: delete only the TXT record related to the DNS challenge

### DIFF
--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-	"strconv"
 
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -183,7 +182,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	var lastErr error
 	for _, record := range response.Records {
-		if record.Content == strconv.Quote(challengeInfo.Value) {
+		if record.Content == challengeInfo.Value {
 			err = d.client.Nameservers.DeleteRecord(record.ID)
 			if err != nil {
 				lastErr = fmt.Errorf("inwx: %w", err)

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"strconv"
 
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -182,9 +183,11 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	var lastErr error
 	for _, record := range response.Records {
-		err = d.client.Nameservers.DeleteRecord(record.ID)
-		if err != nil {
-			lastErr = fmt.Errorf("inwx: %w", err)
+		if record.Content == strconv.Quote(challengeInfo.Value) {
+			err = d.client.Nameservers.DeleteRecord(record.ID)
+			if err != nil {
+				lastErr = fmt.Errorf("inwx: %w", err)
+			}
 		}
 	}
 

--- a/providers/dns/inwx/inwx.go
+++ b/providers/dns/inwx/inwx.go
@@ -180,17 +180,26 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("inwx: %w", err)
 	}
 
-	var lastErr error
+	var recordID int
 	for _, record := range response.Records {
-		if record.Content == challengeInfo.Value {
-			err = d.client.Nameservers.DeleteRecord(record.ID)
-			if err != nil {
-				lastErr = fmt.Errorf("inwx: %w", err)
-			}
+		if record.Content != challengeInfo.Value {
+			continue
 		}
+
+		recordID = record.ID
+		break
 	}
 
-	return lastErr
+	if recordID == 0 {
+		return errors.New("inwx: TXT record not found")
+	}
+
+	err = d.client.Nameservers.DeleteRecord(recordID)
+	if err != nil {
+		return fmt.Errorf("inwx: %w", err)
+	}
+
+	return nil
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.


### PR DESCRIPTION
The original implementation deleted all TXT records on the domain. That was not very nice. I took the way the IONOS Implementation is done to only delete the newly generated DNS Challenge records.