### PR TITLE
feat: add hook-timeout to run and renew commands

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -110,10 +110,10 @@ func createRenew() *cli.Command {
 				Name:  flgRenewHook,
 				Usage: "Define a hook. The hook is executed only when the certificates are effectively renewed.",
 			},
-			&cli.UintFlag{
+			&cli.DurationFlag{
 				Name:  flgRenewHookTimeout,
-				Usage: "Define the timeout in seconds for the hook execution.",
-				Value: 120,
+				Usage: "Define the timeout for the hook execution.",
+				Value: 2 * time.Minute,
 			},
 			&cli.BoolFlag{
 				Name: flgNoRandomSleep,
@@ -260,7 +260,7 @@ func renewForDomains(ctx *cli.Context, account *Account, keyType certcrypto.KeyT
 
 	addPathToMetadata(meta, domain, certRes, certsStorage)
 
-	return launchHook(ctx.String(flgRenewHook), ctx.Uint(flgRenewHookTimeout), meta)
+	return launchHook(ctx.String(flgRenewHook), ctx.Duration(flgRenewHookTimeout), meta)
 }
 
 func renewForCSR(ctx *cli.Context, account *Account, keyType certcrypto.KeyType, certsStorage *CertificatesStorage, bundle bool, meta map[string]string) error {
@@ -343,7 +343,7 @@ func renewForCSR(ctx *cli.Context, account *Account, keyType certcrypto.KeyType,
 
 	addPathToMetadata(meta, domain, certRes, certsStorage)
 
-	return launchHook(ctx.String(flgRenewHook), ctx.Uint(flgRenewHookTimeout), meta)
+	return launchHook(ctx.String(flgRenewHook), ctx.Duration(flgRenewHookTimeout), meta)
 }
 
 func needRenewal(x509Cert *x509.Certificate, domain string, days int) bool {

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -25,6 +25,7 @@ const (
 	flgARIWaitToRenewDuration = "ari-wait-to-renew-duration"
 	flgReuseKey               = "reuse-key"
 	flgRenewHook              = "renew-hook"
+	flgRenewHookTimeout       = "renew-hook-timeout"
 	flgNoRandomSleep          = "no-random-sleep"
 	flgForceCertDomains       = "force-cert-domains"
 )
@@ -108,6 +109,11 @@ func createRenew() *cli.Command {
 			&cli.StringFlag{
 				Name:  flgRenewHook,
 				Usage: "Define a hook. The hook is executed only when the certificates are effectively renewed.",
+			},
+			&cli.UintFlag{
+				Name:  flgRenewHookTimeout,
+				Usage: "Define the timeout in seconds for the hook execution.",
+				Value: 120,
 			},
 			&cli.BoolFlag{
 				Name: flgNoRandomSleep,
@@ -254,7 +260,7 @@ func renewForDomains(ctx *cli.Context, account *Account, keyType certcrypto.KeyT
 
 	addPathToMetadata(meta, domain, certRes, certsStorage)
 
-	return launchHook(ctx.String(flgRenewHook), meta)
+	return launchHook(ctx.String(flgRenewHook), ctx.Uint(flgRenewHookTimeout), meta)
 }
 
 func renewForCSR(ctx *cli.Context, account *Account, keyType certcrypto.KeyType, certsStorage *CertificatesStorage, bundle bool, meta map[string]string) error {
@@ -337,7 +343,7 @@ func renewForCSR(ctx *cli.Context, account *Account, keyType certcrypto.KeyType,
 
 	addPathToMetadata(meta, domain, certRes, certsStorage)
 
-	return launchHook(ctx.String(flgRenewHook), meta)
+	return launchHook(ctx.String(flgRenewHook), ctx.Uint(flgRenewHookTimeout), meta)
 }
 
 func needRenewal(x509Cert *x509.Certificate, domain string, days int) bool {

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -76,10 +76,10 @@ func createRun() *cli.Command {
 				Name:  flgRunHook,
 				Usage: "Define a hook. The hook is executed when the certificates are effectively created.",
 			},
-			&cli.UintFlag{
+			&cli.DurationFlag{
 				Name:  flgRunHookTimeout,
-				Usage: "Define the timeout in seconds for the hook execution.",
-				Value: 120,
+				Usage: "Define the timeout for the hook execution.",
+				Value: 2 * time.Minute,
 			},
 		},
 	}
@@ -135,7 +135,7 @@ func run(ctx *cli.Context) error {
 
 	addPathToMetadata(meta, cert.Domain, cert, certsStorage)
 
-	return launchHook(ctx.String(flgRunHook), ctx.Uint(flgRunHookTimeout), meta)
+	return launchHook(ctx.String(flgRunHook), ctx.Duration(flgRunHookTimeout), meta)
 }
 
 func handleTOS(ctx *cli.Context, client *lego.Client) bool {

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -23,6 +23,7 @@ const (
 	flgPreferredChain                 = "preferred-chain"
 	flgAlwaysDeactivateAuthorizations = "always-deactivate-authorizations"
 	flgRunHook                        = "run-hook"
+	flgRunHookTimeout                 = "run-hook-timeout"
 )
 
 func createRun() *cli.Command {
@@ -74,6 +75,11 @@ func createRun() *cli.Command {
 			&cli.StringFlag{
 				Name:  flgRunHook,
 				Usage: "Define a hook. The hook is executed when the certificates are effectively created.",
+			},
+			&cli.UintFlag{
+				Name:  flgRunHookTimeout,
+				Usage: "Define the timeout in seconds for the hook execution.",
+				Value: 120,
 			},
 		},
 	}
@@ -129,7 +135,7 @@ func run(ctx *cli.Context) error {
 
 	addPathToMetadata(meta, cert.Domain, cert, certsStorage)
 
-	return launchHook(ctx.String(flgRunHook), meta)
+	return launchHook(ctx.String(flgRunHook), ctx.Uint(flgRunHookTimeout), meta)
 }
 
 func handleTOS(ctx *cli.Context, client *lego.Client) bool {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -10,12 +10,12 @@ import (
 	"time"
 )
 
-func launchHook(hook string, hookTimeoutSecs uint, meta map[string]string) error {
+func launchHook(hook string, timeout time.Duration, meta map[string]string) error {
 	if hook == "" {
 		return nil
 	}
 
-	ctxCmd, cancel := context.WithTimeout(context.Background(), time.Duration(hookTimeoutSecs)*time.Second)
+	ctxCmd, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	parts := strings.Fields(hook)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -10,12 +10,12 @@ import (
 	"time"
 )
 
-func launchHook(hook string, meta map[string]string) error {
+func launchHook(hook string, hookTimeoutSecs uint, meta map[string]string) error {
 	if hook == "" {
 		return nil
 	}
 
-	ctxCmd, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctxCmd, cancel := context.WithTimeout(context.Background(), time.Duration(hookTimeoutSecs)*time.Second)
 	defer cancel()
 
 	parts := strings.Fields(hook)

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -74,6 +74,7 @@ OPTIONS:
    --preferred-chain value                   If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --always-deactivate-authorizations value  Force the authorizations to be relinquished even if the certificate request was successful.
    --run-hook value                          Define a hook. The hook is executed when the certificates are effectively created.
+   --run-hook-timeout value                  Define the timeout in seconds for the hook execution. (default: 120)
    --help, -h                                show help
 """
 
@@ -98,6 +99,7 @@ OPTIONS:
    --preferred-chain value                   If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --always-deactivate-authorizations value  Force the authorizations to be relinquished even if the certificate request was successful.
    --renew-hook value                        Define a hook. The hook is executed only when the certificates are effectively renewed.
+   --renew-hook-timeout value                Define the timeout in seconds for the hook execution. (default: 120)
    --no-random-sleep                         Do not add a random sleep before the renewal. We do not recommend using this flag if you are doing your renewals in an automated way. (default: false)
    --force-cert-domains                      Check and ensure that the cert's domain list matches those passed in the domains argument. (default: false)
    --help, -h                                show help

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -74,7 +74,7 @@ OPTIONS:
    --preferred-chain value                   If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --always-deactivate-authorizations value  Force the authorizations to be relinquished even if the certificate request was successful.
    --run-hook value                          Define a hook. The hook is executed when the certificates are effectively created.
-   --run-hook-timeout value                  Define the timeout in seconds for the hook execution. (default: 120)
+   --run-hook-timeout value                  Define the timeout for the hook execution. (default: 2m0s)
    --help, -h                                show help
 """
 
@@ -99,7 +99,7 @@ OPTIONS:
    --preferred-chain value                   If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --always-deactivate-authorizations value  Force the authorizations to be relinquished even if the certificate request was successful.
    --renew-hook value                        Define a hook. The hook is executed only when the certificates are effectively renewed.
-   --renew-hook-timeout value                Define the timeout in seconds for the hook execution. (default: 120)
+   --renew-hook-timeout value                Define the timeout for the hook execution. (default: 2m0s)
    --no-random-sleep                         Do not add a random sleep before the renewal. We do not recommend using this flag if you are doing your renewals in an automated way. (default: false)
    --force-cert-domains                      Check and ensure that the cert's domain list matches those passed in the domains argument. (default: false)
    --help, -h                                show help


### PR DESCRIPTION
Add the option `--run-hook-timeout` and `--renewal-hook-timeout` which lets you configure how long lego should wait for the hook to finish. The default of `120` seconds may be too short in some cases.

Background:

We have a setup in which we run lego periodically with a systemd service/timer combo.
When we execute the run/renewal hook we have multiple tasks which we would execute with the hook script, those tasks may in some cases exceed the 120s timeout. The option added in this PR lets us configure this timeout and successfully finish all tasks with the script.