### PR TITLE
acme-dns: add option to use an existing account

### DIFF
--- a/providers/dns/acmedns/acmedns.toml
+++ b/providers/dns/acmedns/acmedns.toml
@@ -9,12 +9,27 @@ Example = '''
 ACME_DNS_API_BASE=http://10.0.0.8:4443 \
 ACME_DNS_STORAGE_PATH=/root/.lego-acme-dns-accounts.json \
 lego --email you@example.com --dns "acme-dns" -d '*.example.com' -d example.com run
+
+# or
+ACME_DNS_API_BASE=http://10.0.0.8:4443 \
+ACME_DNS_SUBDOMAIN=8e5700ea-a4bf-41c7-8a77-e990661dcc6a \
+ACME_DNS_USERNAME=c36f50e8-4632-44f0-83fe-e070fef28a10 \
+ACME_DNS_PASSWORD=htB9mR9DYgcu9bX_afHF62erXaH2TS7bg9KW3F7Z \
+lego --email you@example.com --dns "acme-dns" -d '*.example.com' -d example.com run
 '''
 
 [Configuration]
   [Configuration.Credentials]
+    # Registering a per-domain ACME-DNS Account through lego
     ACME_DNS_API_BASE  = "The ACME-DNS API address"
-    ACME_DNS_STORAGE_PATH = "The ACME-DNS JSON account data file. A per-domain account will be registered/persisted to this file and used for TXT updates."
+    ACME_DNS_STORAGE_PATH = "The ACME-DNS JSON account data file. The per-domain account will be persisted to this file and used for TXT updates."
+
+    # Using an already existing ACME-DNS Account for all domains
+    ACME_DNS_API_BASE  = "The ACME-DNS API address"
+    ACME_DNS_SUBDOMAIN = "The subdomain of the account"
+    ACME_DNS_USERNAME = "The username of the account"
+    ACME_DNS_PASSWORD = "The password of the account"
+
 
 [Links]
   API = "https://github.com/joohoi/acme-dns#api"

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -169,7 +169,6 @@ func TestPresent(t *testing.T) {
 	testCases := []struct {
 		Name          string
 		Client        acmeDNSClient
-		Account       *goacmedns.Account
 		Storage       goacmedns.Storage
 		ExpectedError error
 	}{
@@ -202,13 +201,13 @@ func TestPresent(t *testing.T) {
 		{
 			Name:    "present when using an existing account",
 			Client:  mockClient{egTestAccount},
-			Account: &egTestAccount,
+			Storage: &SingleAccountStorage{&egTestAccount},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, test.Account, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
 			require.NoError(t, err)
 
 			// override the storage mock if required by the test case.
@@ -274,7 +273,7 @@ func TestRegister(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, nil, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
 			require.NoError(t, err)
 
 			// override the storage mock if required by the testcase.

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -169,6 +169,7 @@ func TestPresent(t *testing.T) {
 	testCases := []struct {
 		Name          string
 		Client        acmeDNSClient
+		Account       *goacmedns.Account
 		Storage       goacmedns.Storage
 		ExpectedError error
 	}{
@@ -194,15 +195,20 @@ func TestPresent(t *testing.T) {
 			ExpectedError: errorClientErr,
 		},
 		{
-			Name:    "present when everything works",
+			Name:    "present when having a valid client and the domain is already in storage",
 			Storage: validAccountStorage,
 			Client:  validUpdateClient,
+		},
+		{
+			Name:    "present when using an existing account",
+			Client:  mockClient{egTestAccount},
+			Account: &egTestAccount,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, test.Account, mockStorage{make(map[string]goacmedns.Account)})
 			require.NoError(t, err)
 
 			// override the storage mock if required by the test case.
@@ -268,7 +274,7 @@ func TestRegister(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, nil, mockStorage{make(map[string]goacmedns.Account)})
 			require.NoError(t, err)
 
 			// override the storage mock if required by the testcase.


### PR DESCRIPTION
While using acme-dns, add the option to use an existing account in addition to registering one per-domain.

Background:
We currently have a use case where we are required to have one acme-dns account per customer instead of having one per domain.

Thanks!