### PR TITLE
cli: add environment variable for specifying email

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -71,6 +71,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    flgEmail,
 			Aliases: []string{"m"},
+			EnvVars: []string{"LEGO_ACCOUNT_EMAIL"},
 			Usage:   "Email used for registration and recovery contact.",
 		},
 		&cli.StringFlag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -71,7 +71,7 @@ func CreateFlags(defaultPath string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    flgEmail,
 			Aliases: []string{"m"},
-			EnvVars: []string{"LEGO_ACCOUNT_EMAIL"},
+			EnvVars: []string{"LEGO_EMAIL"},
 			Usage:   "Email used for registration and recovery contact.",
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Extend the use of LEGO_EMAIL in the renew command to all uses of the --email flag