### PR TITLE
fix(cli): remove extra debug logs

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -69,6 +69,7 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 5
 	retryClient.HTTPClient = config.HTTPClient
+	retryClient.Logger = nil
 
 	config.HTTPClient = retryClient.StandardClient()
 


### PR DESCRIPTION
The logger of the retryable client needs to be explicitly set to nil to avoid extra debug logs.


<details>


```console
2025/01/28 02:55:19 [INFO] [*.example.com, example.com] acme: Obtaining bundled SAN certificate
2025/01/28 02:55:19 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/new-order
2025/01/28 02:55:19 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393534
2025/01/28 02:55:20 [DEBUG] HEAD https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce
2025/01/28 02:55:20 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393544
2025/01/28 02:55:20 [INFO] [*.example.com] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393534
2025/01/28 02:55:20 [INFO] [example.com] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393544
2025/01/28 02:55:20 [INFO] [*.example.com] acme: use dns-01 solver
2025/01/28 02:55:20 [INFO] [example.com] acme: Could not find solver for: tls-alpn-01
2025/01/28 02:55:20 [INFO] [example.com] acme: Could not find solver for: http-01
2025/01/28 02:55:20 [INFO] [example.com] acme: use dns-01 solver
2025/01/28 02:55:20 [INFO] [*.example.com] acme: Preparing to solve DNS-01
2025/01/28 02:55:20 [INFO] [*.example.com] acme: Trying to solve DNS-01
2025/01/28 02:55:20 [INFO] [*.example.com] acme: Checking DNS record propagation.
2025/01/28 02:55:22 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
2025/01/28 02:55:22 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/chall/182137934/15857393534/7Ig5-w
2025/01/28 02:55:22 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393534
2025/01/28 02:55:27 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393534
2025/01/28 02:55:27 [INFO] [*.example.com] The server validated our request
2025/01/28 02:55:27 [INFO] [*.example.com] acme: Cleaning DNS-01 challenge
2025/01/28 02:55:27 [INFO] sequence: wait for 2s
2025/01/28 02:55:29 [INFO] [example.com] acme: Preparing to solve DNS-01
2025/01/28 02:55:29 [INFO] [example.com] acme: Trying to solve DNS-01
2025/01/28 02:55:29 [INFO] [example.com] acme: Checking DNS record propagation.
2025/01/28 02:55:31 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
2025/01/28 02:55:31 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/chall/182137934/15857393544/w5MS2g
2025/01/28 02:55:31 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393544
2025/01/28 02:55:36 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/authz/182137934/15857393544
2025/01/28 02:55:36 [INFO] [example.com] The server validated our request
2025/01/28 02:55:36 [INFO] [example.com] acme: Cleaning DNS-01 challenge
2025/01/28 02:55:36 [INFO] [*.example.com, example.com] acme: Validations succeeded; requesting certificates
2025/01/28 02:55:36 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/finalize/182137934/22257268264
2025/01/28 02:55:37 [INFO] Wait for certificate [timeout: 30s, interval: 500ms]
2025/01/28 02:55:37 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/order/182137934/22257268264
2025/01/28 02:55:37 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/order/182137934/22257268264
2025/01/28 02:55:38 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/order/182137934/22257268264
2025/01/28 02:55:38 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/cert/2b88166f299d17edc129a8dc2fbccf6677ef
2025/01/28 02:55:38 [DEBUG] POST https://acme-staging-v02.api.letsencrypt.org/acme/cert/2b88166f299d17edc129a8dc2fbccf6677ef/1
2025/01/28 02:55:38 [INFO] [*.example.com] Server responded with a certificate.
```


</details>