### PR TITLE
feat(cli): add LEGO_DEBUG_ACME_HTTP_CLIENT to debug the calls to the ACME server

### DIFF
--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -52,7 +52,7 @@ func (c *Certifier) deactivateAuthorizations(order acme.ExtendedOrder, force boo
 	for _, authzURL := range order.Authorizations {
 		auth, err := c.core.Authorizations.Get(authzURL)
 		if err != nil {
-			log.Infof("Unable to get the authorization for: %s", authzURL)
+			log.Infof("Unable to get the authorization for %s: %v", authzURL, err)
 			continue
 		}
 

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -92,12 +92,12 @@ func createRun() *cli.Command {
 
 const rootPathWarningMessage = `!!!! HEADS UP !!!!
 
-Your account credentials have been saved in your Let's Encrypt
+Your account credentials have been saved in your
 configuration directory at "%s".
 
 You should make a secure backup of this folder now. This
 configuration directory will also contain certificates and
-private keys obtained from Let's Encrypt so making regular
+private keys obtained from the ACME server so making regular
 backups of this folder is ideal.
 `
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -71,6 +71,10 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 	retryClient.HTTPClient = config.HTTPClient
 	retryClient.Logger = nil
 
+	if _, v := os.LookupEnv("LEGO_DEBUG_ACME_HTTP_CLIENT"); v {
+		retryClient.Logger = log.Logger
+	}
+
 	config.HTTPClient = retryClient.StandardClient()
 
 	client, err := lego.NewClient(config)

--- a/docs/content/usage/cli/Options.md
+++ b/docs/content/usage/cli/Options.md
@@ -142,3 +142,13 @@ Example:
 ```bash
 LEGO_DEBUG_CLIENT_VERBOSE_ERROR=true
 ```
+
+### LEGO_DEBUG_ACME_HTTP_CLIENT
+
+The environment variable `LEGO_DEBUG_ACME_HTTP_CLIENT` allows debug the calls to the ACME server.
+
+Example:
+
+```bash
+LEGO_DEBUG_ACME_HTTP_CLIENT=true
+```

--- a/e2e/challenges_test.go
+++ b/e2e/challenges_test.go
@@ -29,6 +29,7 @@ var load = loader.EnvLoader{
 	},
 	LegoOptions: []string{
 		"LEGO_CA_CERTIFICATES=./fixtures/certs/pebble.minica.pem",
+		"LEGO_DEBUG_ACME_HTTP_CLIENT=1",
 	},
 }
 

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -28,6 +28,7 @@ var load = loader.EnvLoader{
 	LegoOptions: []string{
 		"LEGO_CA_CERTIFICATES=../fixtures/certs/pebble.minica.pem",
 		"EXEC_PATH=../fixtures/update-dns.sh",
+		"LEGO_DEBUG_ACME_HTTP_CLIENT=1",
 	},
 	ChallSrv: &loader.CmdOption{
 		Args: []string{"-http01", ":5012", "-tlsalpn01", ":5011"},


### PR DESCRIPTION
Adds `LEGO_DEBUG_ACME_HTTP_CLIENT` to debug the calls to the ACME server.