### PR TITLE
chore: update links of liara provider API doc

### DIFF
--- a/docs/content/dns/zz_gen_liara.md
+++ b/docs/content/dns/zz_gen_liara.md
@@ -60,7 +60,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 ## More information
 
-- [API documentation](https://dns-service.iran.liara.ir/swagger)
+- [API documentation](https://openapi.liara.ir/?urls.primaryName=DNS)
 
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 <!-- providers/dns/liara/liara.toml -->

--- a/providers/dns/liara/internal/client.go
+++ b/providers/dns/liara/internal/client.go
@@ -34,7 +34,7 @@ func NewClient(hc *http.Client) *Client {
 }
 
 // GetRecords gets the records of a domain.
-// https://dns-service.iran.liara.ir/swagger
+// https://openapi.liara.ir/?urls.primaryName=DNS
 func (c Client) GetRecords(ctx context.Context, domainName string) ([]Record, error) {
 	endpoint := c.baseURL.JoinPath("api", "v1", "zones", domainName, "dns-records")
 

--- a/providers/dns/liara/liara.toml
+++ b/providers/dns/liara/liara.toml
@@ -19,4 +19,4 @@ lego --email you@example.com --dns liara -d '*.example.com' -d example.com run
     LIARA_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
 
 [Links]
-  API = "https://dns-service.iran.liara.ir/swagger"
+  API = "https://openapi.liara.ir/?urls.primaryName=DNS"


### PR DESCRIPTION
Hello,

The documentation link for the Liara DNS provider has changed from https://dns-service.iran.liara.ir/swagger to https://openapi.liara.ir/?urls.primaryName=DNS. I have updated the link and submitted a pull request.

I would appreciate it if you could review and consider the update.

Thank you! 