### PR TITLE
Avoid nil pointer in error interface in checkOrderStatus

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -687,6 +687,9 @@ func checkOrderStatus(order acme.ExtendedOrder) (bool, error) {
 	case acme.StatusValid:
 		return true, nil
 	case acme.StatusInvalid:
+		if order.Error == nil {
+			return false, nil
+		}
 		return false, order.Error
 	default:
 		return false, nil


### PR DESCRIPTION
I caught a panic in the affected piece of code:

I had `acme.StatusInvalid` along with `order.Error` is nil (due to rate limitting error). Despite `order.Error` is of type `*ProblemDetails`, when it's returned as an error, it gets wrapped in an error interface. The key is that a nil pointer of a concrete type (*ProblemDetails) becomes a non-nil error interface when returned.
Then, when `Error()` method is called later on in scope of this `For`: https://github.com/go-acme/lego/blob/e644196bfc422de8590c4cd54a2ddf99bb46df0e/certificate/certificates.go#L353, it causes panic. 

