### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      GOLANGCI_LINT_VERSION: v1.63.3
+      GOLANGCI_LINT_VERSION: v1.64.2
       HUGO_VERSION: 0.131.0
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
     - nonamedreturns
     - musttag # false-positive https://github.com/junk1tm/musttag/issues/17
     - gosmopolitan  # not relevant
-    - exportloopref # Useless with go1.22
     - canonicalheader # Can create side effects in the context of API clients
     - usestdlibvars # false-positive https://github.com/sashamelentyev/usestdlibvars/issues/96
 
@@ -138,6 +137,7 @@ linters-settings:
 
 run:
   timeout: 10m
+  relative-path-mode: cfg
 
 output:
   show-stats: true


### PR DESCRIPTION
Update golangci-lint to v1.64.0