### PR TITLE
acme-dns: add CNAME provisioned flag for HTTP storage

### DIFF
--- a/providers/dns/acmedns/acmedns.toml
+++ b/providers/dns/acmedns/acmedns.toml
@@ -22,6 +22,7 @@ lego --email you@example.com --dns "acme-dns" -d '*.example.com' -d example.com 
     ACME_DNS_API_BASE  = "The ACME-DNS API address"
     ACME_DNS_STORAGE_PATH = "The ACME-DNS JSON account data file. A per-domain account will be registered/persisted to this file and used for TXT updates."
     ACME_DNS_STORAGE_BASE_URL = "The ACME-DNS JSON account data server."
+    ACME_DNS_CNAME_PROVISIONED = "Hint the CNAME is provisioned in the DNS zone."
 
 [Links]
   API = "https://github.com/joohoi/acme-dns#api"

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -68,7 +68,7 @@ func TestPresent(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)}, false)
 			require.NoError(t, err)
 
 			// override the storage mock if required by the test case.
@@ -97,12 +97,13 @@ func TestPresent(t *testing.T) {
 // TestRegister tests that the ACME-DNS register function works correctly.
 func TestRegister(t *testing.T) {
 	testCases := []struct {
-		Name          string
-		Client        acmeDNSClient
-		Storage       goacmedns.Storage
-		Domain        string
-		FQDN          string
-		ExpectedError error
+		Name             string
+		Client           acmeDNSClient
+		Storage          goacmedns.Storage
+		CNAMEProvisioned bool
+		Domain           string
+		FQDN             string
+		ExpectedError    error
 	}{
 		{
 			Name:          "register when acme-dns client returns an error",
@@ -130,11 +131,16 @@ func TestRegister(t *testing.T) {
 				Target: egTestAccount.FullDomain,
 			},
 		},
+		{
+			Name:             "register when everything works and CNAME provisioned",
+			Client:           mockClient{egTestAccount},
+			CNAMEProvisioned: true,
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
-			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)})
+			dp, err := NewDNSProviderClient(test.Client, mockStorage{make(map[string]goacmedns.Account)}, test.CNAMEProvisioned)
 			require.NoError(t, err)
 
 			// override the storage mock if required by the testcase.


### PR DESCRIPTION
With the new acme-dns HTTP storage feature, it is possible to complete the challenge if the HTTP storage server will also create the CNAME records.  Currently, the acme-dns provider will always return an error indicating that the CNAME must be created.

This adds an environment configuration to tell the acme-dns provider to presume the CNAME record has been added to the DNS zone.  This allows the challenge to complete successfully when the CNAME record is created when a new DNS challenge is registered with acme-dns.  This is mainly useful when using the HTTP storage backend if the server will also create the CNAME record.

Related to (#2393)