### PR TITLE
acme-dns: allow the HTTP storage server to create the CNAME

### DIFF
--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -183,8 +183,13 @@ func (d *DNSProvider) register(ctx context.Context, domain, fqdn string) error {
 	if err != nil {
 		return err
 	}
+
 	err = d.storage.Save(ctx)
 	if err != nil {
+		if errors.Is(err, internal.ErrCNAMECreated) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -178,19 +178,24 @@ func (d *DNSProvider) register(ctx context.Context, domain, fqdn string) error {
 		return err
 	}
 
+	var cnameCreated bool
+
 	// Store the new account in the storage and call save to persist the data.
 	err = d.storage.Put(ctx, domain, newAcct)
 	if err != nil {
-		if errors.Is(err, internal.ErrCNAMECreated) {
-			return nil
+		cnameCreated = errors.Is(err, internal.ErrCNAMECreated)
+		if !cnameCreated {
+			return err
 		}
-
-		return err
 	}
 
 	err = d.storage.Save(ctx)
 	if err != nil {
 		return err
+	}
+
+	if cnameCreated {
+		return nil
 	}
 
 	// Stop issuance by returning an error.

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -181,15 +181,15 @@ func (d *DNSProvider) register(ctx context.Context, domain, fqdn string) error {
 	// Store the new account in the storage and call save to persist the data.
 	err = d.storage.Put(ctx, domain, newAcct)
 	if err != nil {
+		if errors.Is(err, internal.ErrCNAMECreated) {
+			return nil
+		}
+
 		return err
 	}
 
 	err = d.storage.Save(ctx)
 	if err != nil {
-		if errors.Is(err, internal.ErrCNAMECreated) {
-			return nil
-		}
-
 		return err
 	}
 

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -183,7 +183,7 @@ func (d *DNSProvider) register(ctx context.Context, domain, fqdn string) error {
 	// Store the new account in the storage and call save to persist the data.
 	err = d.storage.Put(ctx, domain, newAcct)
 	if err != nil {
-		cnameCreated = errors.Is(err, internal.ErrCNAMECreated)
+		cnameCreated = errors.Is(err, internal.ErrCNAMEAlreadyCreated)
 		if !cnameCreated {
 			return err
 		}

--- a/providers/dns/acmedns/internal/http_storage.go
+++ b/providers/dns/acmedns/internal/http_storage.go
@@ -18,7 +18,7 @@ import (
 
 var _ goacmedns.Storage = (*HTTPStorage)(nil)
 
-var ErrCNAMECreated = errors.New("the CNAME has already been created")
+var ErrCNAMEAlreadyCreated = errors.New("the CNAME has already been created")
 
 // HTTPStorage is an implementation of [acmedns.Storage] over HTTP.
 type HTTPStorage struct {
@@ -103,7 +103,7 @@ func (s *HTTPStorage) do(req *http.Request, result any) error {
 	if result == nil {
 		// Hack related to `Put`.
 		if resp.StatusCode == http.StatusCreated {
-			return ErrCNAMECreated
+			return ErrCNAMEAlreadyCreated
 		}
 
 		return nil

--- a/providers/dns/acmedns/internal/http_storage.go
+++ b/providers/dns/acmedns/internal/http_storage.go
@@ -39,13 +39,8 @@ func NewHTTPStorage(baseURL string) (*HTTPStorage, error) {
 	}, nil
 }
 
-func (s *HTTPStorage) Save(ctx context.Context) error {
-	req, err := newJSONRequest(ctx, http.MethodPost, s.baseURL, nil)
-	if err != nil {
-		return fmt.Errorf("unable to create request: %w", err)
-	}
-
-	return s.do(req, nil)
+func (s *HTTPStorage) Save(_ context.Context) error {
+	return nil
 }
 
 func (s *HTTPStorage) Put(ctx context.Context, domain string, account goacmedns.Account) error {
@@ -106,7 +101,7 @@ func (s *HTTPStorage) do(req *http.Request, result any) error {
 	}
 
 	if result == nil {
-		// Hack related to `Save`.
+		// Hack related to `Put`.
 		if resp.StatusCode == http.StatusCreated {
 			return ErrCNAMECreated
 		}

--- a/providers/dns/acmedns/internal/http_storage_test.go
+++ b/providers/dns/acmedns/internal/http_storage_test.go
@@ -150,5 +150,5 @@ func TestHTTPStorage_Put_CNAME_created(t *testing.T) {
 	}
 
 	err := storage.Put(context.Background(), "example.com", account)
-	require.ErrorIs(t, err, ErrCNAMECreated)
+	require.ErrorIs(t, err, ErrCNAMEAlreadyCreated)
 }

--- a/providers/dns/acmedns/internal/http_storage_test.go
+++ b/providers/dns/acmedns/internal/http_storage_test.go
@@ -139,7 +139,7 @@ func TestHTTPStorage_Put_error(t *testing.T) {
 }
 
 func TestHTTPStorage_Put_CNAME_created(t *testing.T) {
-	storage := setupTest(t, "POST /", "", http.StatusCreated)
+	storage := setupTest(t, "POST /example.com", "", http.StatusCreated)
 
 	account := goacmedns.Account{
 		FullDomain: "foo.example.com",

--- a/providers/dns/acmedns/internal/http_storage_test.go
+++ b/providers/dns/acmedns/internal/http_storage_test.go
@@ -137,3 +137,18 @@ func TestHTTPStorage_Put_error(t *testing.T) {
 	err := storage.Put(context.Background(), "example.com", account)
 	require.Error(t, err)
 }
+
+func TestHTTPStorage_Put_CNAME_created(t *testing.T) {
+	storage := setupTest(t, "POST /", "", http.StatusCreated)
+
+	account := goacmedns.Account{
+		FullDomain: "foo.example.com",
+		SubDomain:  "foo",
+		Username:   "user",
+		Password:   "secret",
+		ServerURL:  "https://example.com",
+	}
+
+	err := storage.Put(context.Background(), "example.com", account)
+	require.ErrorIs(t, err, ErrCNAMECreated)
+}

--- a/providers/dns/acmedns/internal/readme.md
+++ b/providers/dns/acmedns/internal/readme.md
@@ -61,20 +61,12 @@ Endpoint: `POST <BaseURL>/<domain>`
 
 ### Response
 
-Response status code 200.
+Response status code:
+- 200: the process will be stopped to allow the user to create the CNAME.
+- 201: the process will continue without error (the CNAME should be created during the save)
 
 No expected body.
 
 ## Save
 
-### Request
-
-Endpoint: `POST <BaseURL>/`
-
-### Response
-
-Response status code:
-- 200: the process will be stopped to allow the user to create the CNAME.
-- 201: the process will continue without error (This expect the CNAME to be created during the save)
-
-No expected body.
+No dedicated endpoint.

--- a/providers/dns/acmedns/internal/readme.md
+++ b/providers/dns/acmedns/internal/readme.md
@@ -63,7 +63,7 @@ Endpoint: `POST <BaseURL>/<domain>`
 
 Response status code:
 - 200: the process will be stopped to allow the user to create the CNAME.
-- 201: the process will continue without error (the CNAME should be created during the save)
+- 201: the process will continue without error (the CNAME should be created by the server)
 
 No expected body.
 

--- a/providers/dns/acmedns/internal/readme.md
+++ b/providers/dns/acmedns/internal/readme.md
@@ -67,4 +67,14 @@ No expected body.
 
 ## Save
 
-No dedicated endpoint.
+### Request
+
+Endpoint: `POST <BaseURL>/`
+
+### Response
+
+Response status code:
+- 200: the process will be stopped to allow the user to create the CNAME.
+- 201: the process will continue without error (This expect the CNAME to be created during the save)
+
+No expected body.


### PR DESCRIPTION
This allows the HTTP storage server to control the CNAME creation.

if the `Put` returns a 201, lego expects the CNAME to be created automatically by the server.

Closes #2436