### PR TITLE
chore: use go1.23

### DIFF
--- a/acme/api/order_test.go
+++ b/acme/api/order_test.go
@@ -20,7 +20,7 @@ func TestOrderService_NewWithOptions(t *testing.T) {
 	mux, apiURL := tester.SetupFakeAPI(t)
 
 	// small value keeps test fast
-	privateKey, errK := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, errK := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, errK, "Could not generate test key")
 
 	mux.HandleFunc("/newOrder", func(w http.ResponseWriter, r *http.Request) {

--- a/certcrypto/crypto_test.go
+++ b/certcrypto/crypto_test.go
@@ -22,7 +22,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 }
 
 func TestGenerateCSR(t *testing.T) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Error generating private key")
 
 	type expected struct {
@@ -43,7 +43,7 @@ func TestGenerateCSR(t *testing.T) {
 				Domain:     "lego.acme",
 				MustStaple: true,
 			},
-			expected: expected{len: 245},
+			expected: expected{len: 379},
 		},
 		{
 			desc:       "without SAN (empty)",
@@ -53,7 +53,7 @@ func TestGenerateCSR(t *testing.T) {
 				SAN:        []string{},
 				MustStaple: true,
 			},
-			expected: expected{len: 245},
+			expected: expected{len: 379},
 		},
 		{
 			desc:       "with SAN",
@@ -63,7 +63,7 @@ func TestGenerateCSR(t *testing.T) {
 				SAN:        []string{"a.lego.acme", "b.lego.acme", "c.lego.acme"},
 				MustStaple: true,
 			},
-			expected: expected{len: 296},
+			expected: expected{len: 430},
 		},
 		{
 			desc:       "no domain",
@@ -72,7 +72,7 @@ func TestGenerateCSR(t *testing.T) {
 				Domain:     "",
 				MustStaple: true,
 			},
-			expected: expected{len: 225},
+			expected: expected{len: 359},
 		},
 		{
 			desc:       "no domain with SAN",
@@ -82,7 +82,7 @@ func TestGenerateCSR(t *testing.T) {
 				SAN:        []string{"a.lego.acme", "b.lego.acme", "c.lego.acme"},
 				MustStaple: true,
 			},
-			expected: expected{len: 276},
+			expected: expected{len: 409},
 		},
 		{
 			desc:       "private key nil",
@@ -101,7 +101,7 @@ func TestGenerateCSR(t *testing.T) {
 				SAN:            []string{"example.org"},
 				EmailAddresses: []string{"foo@example.com", "bar@example.com"},
 			},
-			expected: expected{len: 287},
+			expected: expected{len: 421},
 		},
 	}
 
@@ -124,16 +124,13 @@ func TestGenerateCSR(t *testing.T) {
 }
 
 func TestPEMEncode(t *testing.T) {
-	buf := bytes.NewBufferString("TestingRSAIsSoMuchFun")
-
-	reader := MockRandReader{b: buf}
-	key, err := rsa.GenerateKey(reader, 32)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Error generating private key")
 
 	data := PEMEncode(key)
 	require.NotNil(t, data)
 
-	exp := regexp.MustCompile(`^-----BEGIN RSA PRIVATE KEY-----\s+\S{60,}\s+-----END RSA PRIVATE KEY-----\s+`)
+	exp := regexp.MustCompile(`^-----BEGIN RSA PRIVATE KEY-----\s+[\S\s]{60,}\s+-----END RSA PRIVATE KEY-----\s+`)
 	assert.Regexp(t, exp, string(data))
 }
 
@@ -185,12 +182,4 @@ func TestParsePEMPrivateKey(t *testing.T) {
 	// Decoding non-PEM input should return an error
 	_, err = ParsePEMPrivateKey([]byte("This is not PEM"))
 	require.Errorf(t, err, "Expected to return an error for non-PEM input")
-}
-
-type MockRandReader struct {
-	b *bytes.Buffer
-}
-
-func (r MockRandReader) Read(p []byte) (int, error) {
-	return r.b.Read(p)
 }

--- a/certcrypto/crypto_test.go
+++ b/certcrypto/crypto_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/pem"
-	"regexp"
 	"testing"
 	"time"
 
@@ -129,9 +128,6 @@ func TestPEMEncode(t *testing.T) {
 
 	data := PEMEncode(key)
 	require.NotNil(t, data)
-
-	exp := regexp.MustCompile(`^-----BEGIN RSA PRIVATE KEY-----\s+[\S\s]{60,}\s+-----END RSA PRIVATE KEY-----\s+`)
-	assert.Regexp(t, exp, string(data))
 
 	p, rest := pem.Decode(data)
 

--- a/certcrypto/crypto_test.go
+++ b/certcrypto/crypto_test.go
@@ -132,6 +132,12 @@ func TestPEMEncode(t *testing.T) {
 
 	exp := regexp.MustCompile(`^-----BEGIN RSA PRIVATE KEY-----\s+[\S\s]{60,}\s+-----END RSA PRIVATE KEY-----\s+`)
 	assert.Regexp(t, exp, string(data))
+
+	p, rest := pem.Decode(data)
+
+	assert.Equal(t, "RSA PRIVATE KEY", p.Type)
+	assert.Empty(t, rest)
+	assert.Empty(t, p.Headers)
 }
 
 func TestParsePEMCertificate(t *testing.T) {

--- a/challenge/dns01/dns_challenge_test.go
+++ b/challenge/dns01/dns_challenge_test.go
@@ -34,7 +34,7 @@ func (p *providerTimeoutMock) Timeout() (time.Duration, time.Duration)     { ret
 func TestChallenge_PreSolve(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -116,7 +116,7 @@ func TestChallenge_PreSolve(t *testing.T) {
 func TestChallenge_Solve(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -203,7 +203,7 @@ func TestChallenge_Solve(t *testing.T) {
 func TestChallenge_CleanUp(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -97,7 +97,7 @@ func TestChallenge(t *testing.T) {
 		return nil
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -166,7 +166,7 @@ func TestChallengeUnix(t *testing.T) {
 		return nil
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -190,7 +190,7 @@ func TestChallengeUnix(t *testing.T) {
 func TestChallengeInvalidPort(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 128)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -411,7 +411,7 @@ func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectErro
 		return nil
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)

--- a/challenge/resolver/solver_manager_test.go
+++ b/challenge/resolver/solver_manager_test.go
@@ -36,7 +36,7 @@ func TestValidate(t *testing.T) {
 
 	var statuses []string
 
-	privateKey, _ := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 1024)
 
 	mux.HandleFunc("/chlg", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -66,7 +66,7 @@ func TestChallenge(t *testing.T) {
 		return nil
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -95,7 +95,7 @@ func TestChallenge(t *testing.T) {
 func TestChallengeInvalidPort(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 128)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)
@@ -167,7 +167,7 @@ func TestChallengeIPaddress(t *testing.T) {
 		return nil
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", privateKey)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-acme/lego/v4
 
-go 1.22.0
+go 1.23.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/lego/client_test.go
+++ b/lego/client_test.go
@@ -15,8 +15,7 @@ import (
 func TestNewClient(t *testing.T) {
 	_, apiURL := tester.SetupFakeAPI(t)
 
-	keyBits := 32 // small value keeps test fast
-	key, err := rsa.GenerateKey(rand.Reader, keyBits)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	user := mockUser{

--- a/providers/dns/hyperone/internal/token_test.go
+++ b/providers/dns/hyperone/internal/token_test.go
@@ -1,30 +1,17 @@
 package internal
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-const privateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIICWgIBAAKBgGFfgMY+DuO8l0RYrMLhcl6U/NigNIiOVhoo/xnYyoQALpWxBaBR
-+iVJiBUYunQjKA33yAiY0AasCfSn1JB6asayQvGGn73xztLjkeCVLT+9e4nJ0A/o
-dK8SOKBg9FFe70KJrWjJd626el0aVDJjtCE+QxJExA0UZbQp+XIyveQXAgMBAAEC
-gYBHcL1XNWLRPaWx9GlUVfoGYMMd4HSKl/ueF+QKP59dt5B2LTnWhS7FOqzH5auu
-17hkfx3ZCNzfeEuZn6T6F4bMtsQ6A5iT/DeRlG8tOPiCVZ/L0j6IFM78iIUT8XyA
-miwnSy1xGSBA67yUmsLxFg2DtGCjamAkY0C5pccadaB7oQJBAKsIPpMXMni+Oo1I
-kVxRyoIZgDxsMJiihG2YLVqo8rPtdErl+Lyg3ziVyg9KR6lFMaTBkYBTLoCPof3E
-AB/jyucCQQCRv1cVnYNx+bfnXsBlcsCFDV2HkEuLTpxj7hauD4P3GcyLidSsUkn1
-PiPunZqKpsQaIoxc/BzTOCcP19ifgqdRAkBJ8Cp9FE4xfKt7YJ/WtVVCoRubA3qO
-wdNWPa99vgQOXN0lc/3wLevSXo8XxRjtyIgJndT1EQDNe0qglhcnsiaJAkBziAcR
-/VAq0tZys2szf6kYTyXqxfj8Lo5NsHeN9oKXJ346xkEtb/VsT5vQFGJishsU1HoL
-Y1W+IO7l4iW3G6xhAkACNwtqxSRRbVsNCUMENpKmYhsyN8QXJ8V+o2A9s+pl21Kz
-HIIm179mUYCgO6iAHmkqxlFHFwprUBKdPrmP8qF9
------END RSA PRIVATE KEY-----`
 
 type Header struct {
 	Algorithm string `json:"alg"`
@@ -33,7 +20,10 @@ type Header struct {
 }
 
 func TestPayload_buildToken(t *testing.T) {
-	signer, err := getRSASigner(privateKey, "sampleKeyId")
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	signer, err := getRSASigner(string(certcrypto.PEMEncode(key)), "sampleKeyId")
 	require.NoError(t, err)
 
 	payload := Payload{IssuedAt: 1234, Expiry: 4321, Audience: "api.url", Issuer: "issuer", Subject: "subject"}

--- a/providers/dns/oraclecloud/oraclecloud_test.go
+++ b/providers/dns/oraclecloud/oraclecloud_test.go
@@ -320,7 +320,7 @@ func mustGeneratePrivateKeyFile(pwd string) string {
 }
 
 func generatePrivateKey(pwd string) (*pem.Block, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 512)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, err
 	}

--- a/registration/registar_test.go
+++ b/registration/registar_test.go
@@ -27,7 +27,7 @@ func TestRegistrar_ResolveAccountByKey(t *testing.T) {
 		}
 	})
 
-	key, err := rsa.GenerateKey(rand.Reader, 512)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
 	user := mockUser{


### PR DESCRIPTION
The tests have been updated because go1.24 will produce an error with a bit size lower than 1024.

https://go.dev/doc/go1.24#cryptorsapkgcryptorsa

The behavior can be tested by adding the following line inside the `go.mod`:
```
godebug rsa1024min=1
```