### PR TITLE
feat: add INFOBLOX_CA_CERTIFICATE option

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1557,6 +1557,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "INFOBLOX_CA_CERTIFICATE":	The path to the CA certificate (PEM encoded)`)
 		ew.writeln(`	- "INFOBLOX_DNS_VIEW":	The view for the TXT records (Default: External)`)
 		ew.writeln(`	- "INFOBLOX_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
 		ew.writeln(`	- "INFOBLOX_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)

--- a/docs/content/dns/zz_gen_infoblox.md
+++ b/docs/content/dns/zz_gen_infoblox.md
@@ -51,6 +51,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `INFOBLOX_CA_CERTIFICATE` | The path to the CA certificate (PEM encoded) |
 | `INFOBLOX_DNS_VIEW` | The view for the TXT records (Default: External) |
 | `INFOBLOX_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
 | `INFOBLOX_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |

--- a/providers/dns/infoblox/infoblox.toml
+++ b/providers/dns/infoblox/infoblox.toml
@@ -25,6 +25,7 @@ When creating an API's user ensure it has the proper permissions for the view yo
     INFOBLOX_WAPI_VERSION = "The version of WAPI being used  (Default: 2.11)"
     INFOBLOX_PORT = "The port for the infoblox grid manager  (Default: 443)"
     INFOBLOX_SSL_VERIFY = "Whether or not to verify the TLS certificate  (Default: true)"
+    INFOBLOX_CA_CERTIFICATE = "The path to the CA certificate (PEM encoded)"
     INFOBLOX_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
     INFOBLOX_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 60)"
     INFOBLOX_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"


### PR DESCRIPTION
The infloblox client uses a weird option: `SSLVerify` can be a boolean or a path to a CA certificate...

https://github.com/infobloxopen/infoblox-go-client/blob/de49b186dc041882af6e6c8e0823c27f103509c8/connector.go#L45-L70