### PR TITLE
edgedns: add account switch key option

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1064,6 +1064,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "AKAMAI_ACCOUNT_SWITCH_KEY":	Target account ID when the DNS zone and credentials belong to different accounts`)
 		ew.writeln(`	- "AKAMAI_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 15)`)
 		ew.writeln(`	- "AKAMAI_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 180)`)
 		ew.writeln(`	- "AKAMAI_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)

--- a/docs/content/dns/zz_gen_edgedns.md
+++ b/docs/content/dns/zz_gen_edgedns.md
@@ -55,6 +55,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `AKAMAI_ACCOUNT_SWITCH_KEY` | Target account ID when the DNS zone and credentials belong to different accounts |
 | `AKAMAI_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 15) |
 | `AKAMAI_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 180) |
 | `AKAMAI_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
@@ -88,6 +89,7 @@ See also:
 - [.edgerc Format](https://developer.akamai.com/legacy/introduction/Conf_Client.html#edgercformat)
 - [API Client Authentication](https://developer.akamai.com/legacy/introduction/Client_Auth.html)
 - [Config from Env](https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/master/pkg/edgegrid/config.go#L118)
+- [Manage many accounts](https://techdocs.akamai.com/developer/docs/manage-many-accounts-with-one-api-client)
 
 
 

--- a/providers/dns/edgedns/edgedns.go
+++ b/providers/dns/edgedns/edgedns.go
@@ -31,6 +31,7 @@ const (
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
+	EnvAccountSwitchKey   = envNamespace + "ACCOUNT_SWITCH_KEY"
 )
 
 const (
@@ -79,6 +80,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 	rcPath := env.GetOrDefaultString(EnvEdgeRc, "")
 	rcSection := env.GetOrDefaultString(EnvEdgeRcSection, "")
+	accountSwitchKey := env.GetOrDefaultString(EnvAccountSwitchKey, "")
 
 	conf, err := edgegrid.Init(rcPath, rcSection)
 	if err != nil {
@@ -86,6 +88,10 @@ func NewDNSProvider() (*DNSProvider, error) {
 	}
 
 	conf.MaxBody = maxBody
+
+	if accountSwitchKey != "" {
+		conf.AccountKey = accountSwitchKey
+	}
 
 	config.Config = conf
 

--- a/providers/dns/edgedns/edgedns.go
+++ b/providers/dns/edgedns/edgedns.go
@@ -28,10 +28,11 @@ const (
 	EnvClientSecret = envNamespace + "CLIENT_SECRET"
 	EnvAccessToken  = envNamespace + "ACCESS_TOKEN"
 
+	EnvAccountSwitchKey = envNamespace + "ACCOUNT_SWITCH_KEY"
+
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
-	EnvAccountSwitchKey   = envNamespace + "ACCOUNT_SWITCH_KEY"
 )
 
 const (

--- a/providers/dns/edgedns/edgedns.toml
+++ b/providers/dns/edgedns/edgedns.toml
@@ -42,6 +42,7 @@ See also:
 - [.edgerc Format](https://developer.akamai.com/legacy/introduction/Conf_Client.html#edgercformat)
 - [API Client Authentication](https://developer.akamai.com/legacy/introduction/Client_Auth.html)
 - [Config from Env](https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/master/pkg/edgegrid/config.go#L118)
+- [Manage many accounts](https://techdocs.akamai.com/developer/docs/manage-many-accounts-with-one-api-client)
 '''
 
 [Configuration]
@@ -53,10 +54,10 @@ See also:
     AKAMAI_EDGERC = "Path to the .edgerc file, managed by the Akamai EdgeGrid client"
     AKAMAI_EDGERC_SECTION = "Configuration section, managed by the Akamai EdgeGrid client"
   [Configuration.Additional]
+    AKAMAI_ACCOUNT_SWITCH_KEY = "Target account ID when the DNS zone and credentials belong to different accounts"
     AKAMAI_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 15)"
     AKAMAI_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 180)"
     AKAMAI_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
-    AKAMAI_ACCOUNT_SWITCH_KEY = "Target account ID when the DNS zone and credentials belong to different accounts"
 
 [Links]
   API = "https://developer.akamai.com/api/cloud_security/edge_dns_zone_management/v2.html"

--- a/providers/dns/edgedns/edgedns.toml
+++ b/providers/dns/edgedns/edgedns.toml
@@ -56,6 +56,7 @@ See also:
     AKAMAI_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 15)"
     AKAMAI_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 180)"
     AKAMAI_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
+    AKAMAI_ACCOUNT_SWITCH_KEY = "Target account ID when the DNS zone and credentials belong to different accounts"
 
 [Links]
   API = "https://developer.akamai.com/api/cloud_security/edge_dns_zone_management/v2.html"

--- a/providers/dns/edgedns/edgedns_test.go
+++ b/providers/dns/edgedns/edgedns_test.go
@@ -25,6 +25,7 @@ var envTest = tester.NewEnvTest(
 	EnvClientToken,
 	EnvClientSecret,
 	EnvAccessToken,
+	EnvAccountSwitchKey,
 	EnvEdgeRc,
 	EnvEdgeRcSection,
 	envTestHost,
@@ -55,6 +56,24 @@ func TestNewDNSProvider_FromEnv(t *testing.T) {
 				ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 				AccessToken:  "akac-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
 				MaxBody:      maxBody,
+			},
+		},
+		{
+			desc: "with account switch key",
+			envVars: map[string]string{
+				EnvHost:             "akaa-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx.luna.akamaiapis.net",
+				EnvClientToken:      "akab-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
+				EnvClientSecret:     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				EnvAccessToken:      "akac-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
+				EnvAccountSwitchKey: "F-AC-1234",
+			},
+			expectedConfig: &edgegrid.Config{
+				Host:         "akaa-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx.luna.akamaiapis.net",
+				ClientToken:  "akab-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
+				ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				AccessToken:  "akac-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
+				MaxBody:      maxBody,
+				AccountKey:   "F-AC-1234",
 			},
 		},
 		{
@@ -204,20 +223,6 @@ func TestNewDefaultConfig(t *testing.T) {
 				EnvTTL:                "99",
 				EnvPropagationTimeout: "60",
 				EnvPollingInterval:    "60",
-			},
-			expected: &Config{
-				TTL:                99,
-				PropagationTimeout: 60 * time.Second,
-				PollingInterval:    60 * time.Second,
-				Config: edgegrid.Config{
-					MaxBody: maxBody,
-				},
-			},
-		},
-		{
-			desc: "with account switch key",
-			envVars: map[string]string{
-				EnvAccountSwitchKey: "F-AC-1234",
 			},
 			expected: &Config{
 				TTL:                99,

--- a/providers/dns/edgedns/edgedns_test.go
+++ b/providers/dns/edgedns/edgedns_test.go
@@ -214,6 +214,20 @@ func TestNewDefaultConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with account switch key",
+			envVars: map[string]string{
+				EnvAccountSwitchKey: "F-AC-1234",
+			},
+			expected: &Config{
+				TTL:                99,
+				PropagationTimeout: 60 * time.Second,
+				PollingInterval:    60 * time.Second,
+				Config: edgegrid.Config{
+					MaxBody: maxBody,
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
An Akamai EdgeDNS API client may have permission to manage multiple accounts. In such cases, specifying an account switch key allows the API client to edit DNS zones belonging to other Akamai accounts. Support for this account switch key has been implemented.
ref. https://techdocs.akamai.com/developer/docs/manage-many-accounts-with-one-api-client