### PR TITLE
fix: kill hook when the command is stuck

### DIFF
--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_launchHook_errors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
+
+	testCases := []struct {
+		desc     string
+		hook     string
+		timeout  time.Duration
+		expected string
+	}{
+		{
+			desc:     "kill the hook",
+			hook:     "sleep 5",
+			timeout:  1 * time.Second,
+			expected: "hook timed out",
+		},
+		{
+			desc:     "context timeout on Start",
+			hook:     "echo foo",
+			timeout:  1 * time.Nanosecond,
+			expected: "start command: context deadline exceeded",
+		},
+		{
+			desc:     "multiple short sleeps",
+			hook:     "./testdata/sleepy.sh",
+			timeout:  1 * time.Second,
+			expected: "hook timed out",
+		},
+		{
+			desc:     "long sleep",
+			hook:     "./testdata/sleeping_beauty.sh",
+			timeout:  1 * time.Second,
+			expected: "hook timed out",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := launchHook(test.hook, test.timeout, map[string]string{})
+			require.EqualError(t, err, test.expected)
+		})
+	}
+}

--- a/cmd/testdata/sleeping_beauty.sh
+++ b/cmd/testdata/sleeping_beauty.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sleep 50

--- a/cmd/testdata/sleepy.sh
+++ b/cmd/testdata/sleepy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+for i in `seq 1 10`
+do
+  echo $i
+  sleep 0.2
+done


### PR DESCRIPTION
The `context.WithTimeout` doesn't kill a command when the command is stuck because `CombinedOutput` is waiting for a "pause".

The previous implementation was able to stop the hook if the script was too long, but not stuck on one element (cf test: `sleepy.sh`).

But it was not able to stop the hook if the script was waiting for a long (never-ending) process (cf test: `sleeping_beauty.sh`).

I modified the code to add a timer that kills the current process if the timeout is reached.

This implementation has another advantage: the output of the hook will be live streamed to the console.


Fixes #2468