### PR TITLE
chore: related timer with context.Done

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -49,7 +49,7 @@ func launchHook(hook string, timeout time.Duration, meta map[string]string) erro
 	}
 
 	go func() {
-		<-ctxCmd.Done():
+		<-ctxCmd.Done()
 		if ctxCmd.Err() != nil {
 			_ = cmd.Process.Kill()
 			_ = stdout.Close()

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -49,12 +49,10 @@ func launchHook(hook string, timeout time.Duration, meta map[string]string) erro
 	}
 
 	go func() {
-		select {
-		case <-ctxCmd.Done():
-			if ctxCmd.Err() != nil {
-				_ = cmd.Process.Kill()
-				_ = stdout.Close()
-			}
+		<-ctxCmd.Done():
+		if ctxCmd.Err() != nil {
+			_ = cmd.Process.Kill()
+			_ = stdout.Close()
 		}
 	}()
 

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_launchHook(t *testing.T) {
+	err := launchHook("echo foo", 1*time.Second, map[string]string{})
+	require.NoError(t, err)
+}
+
 func Test_launchHook_errors(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test on Windows")


### PR DESCRIPTION
In fact, we don't need a timer, a go routine on `context.DOne()` is enough.

Related to #2469