### PR TITLE
certcrypto: compare RSA priv keys ignoring precomputed

### DIFF
--- a/certcrypto/crypto_test.go
+++ b/certcrypto/crypto_test.go
@@ -168,10 +168,12 @@ func TestParsePEMPrivateKey(t *testing.T) {
 
 	pemPrivateKey := PEMEncode(privateKey)
 
-	// Decoding a key should work and create an identical key to the original
+	// Decoding a key should work and create an identical RSA key to the original,
+	// ignoring precomputed values.
 	decoded, err := ParsePEMPrivateKey(pemPrivateKey)
 	require.NoError(t, err)
-	assert.Equal(t, decoded, privateKey)
+	decodedRsaPrivateKey := decoded.(*rsa.PrivateKey)
+	require.True(t, decodedRsaPrivateKey.Equal(privateKey))
 
 	// Decoding a PEM block that doesn't contain a private key should error
 	_, err = ParsePEMPrivateKey(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE"}))


### PR DESCRIPTION
When comparing RSA private keys we want to assert equality based on the core values of the key, not any precomputed intermediaries held for optimization purposes.

This is the job of [`rsa.PrivateKey.Equal`]( https://pkg.go.dev/crypto/rsa@master#PrivateKey.Equal), so we employ that in `TestParsePEMPrivateKey` in place of a deep field-by-field comparison.

Prior to this change running the test with Go 1.24+ and `-count=100` would reliably produce ~2-3 failures out of the 100. With this change in place we can increase to even `-count=1000` without any failures.