### PR TITLE
tests: change ns

### DIFF
--- a/challenge/dns01/nameserver_test.go
+++ b/challenge/dns01/nameserver_test.go
@@ -24,8 +24,8 @@ func TestLookupNameserversOK(t *testing.T) {
 			nss:  []string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
 		},
 		{
-			fqdn: "physics.georgetown.edu.",
-			nss:  []string{"ns4.georgetown.edu.", "ns5.georgetown.edu.", "ns6.georgetown.edu."},
+			fqdn: "mail.proton.me.",
+			nss:  []string{"ns1.proton.me.", "ns2.proton.me.", "ns3.proton.me."},
 		},
 	}
 


### PR DESCRIPTION
`physics.georgetown.edu.` has changed a nit their NS: "ns.b1ddi.physics.georgetown.edu.", "ns4.georgetown.edu.", "ns5.georgetown.edu.", "ns6.georgetown.edu."

So I switch to more stable NS.