### PR TITLE
allinkl: remove ReturnInfo

### DIFF
--- a/providers/dns/allinkl/internal/client.go
+++ b/providers/dns/allinkl/internal/client.go
@@ -86,23 +86,23 @@ func (c *Client) AddDNSSettings(ctx context.Context, record DNSRequest) (string,
 }
 
 // DeleteDNSSettings Deleting a DNS Resource Record.
-func (c *Client) DeleteDNSSettings(ctx context.Context, recordID string) (bool, error) {
+func (c *Client) DeleteDNSSettings(ctx context.Context, recordID string) (string, error) {
 	requestParams := map[string]string{"record_id": recordID}
 
 	req, err := c.newRequest(ctx, "delete_dns_settings", requestParams)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
 	var g DeleteDNSSettingsAPIResponse
 	err = c.do(req, &g)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
 	c.updateFloodTime(g.Response.KasFloodDelay)
 
-	return g.Response.ReturnInfo, nil
+	return g.Response.ReturnString, nil
 }
 
 func (c *Client) newRequest(ctx context.Context, action string, requestParams any) (*http.Request, error) {

--- a/providers/dns/allinkl/internal/client_test.go
+++ b/providers/dns/allinkl/internal/client_test.go
@@ -131,7 +131,7 @@ func TestClient_DeleteDNSSettings(t *testing.T) {
 	r, err := client.DeleteDNSSettings(mockContext(), "57347450")
 	require.NoError(t, err)
 
-	assert.True(t, r)
+	assert.Equal(t, "TRUE", r)
 }
 
 func testHandler(filename string) http.HandlerFunc {

--- a/providers/dns/allinkl/internal/types_api.go
+++ b/providers/dns/allinkl/internal/types_api.go
@@ -89,6 +89,6 @@ type DeleteDNSSettingsAPIResponse struct {
 
 type DeleteDNSSettingsResponse struct {
 	KasFloodDelay float64 `json:"KasFloodDelay"`
-	ReturnInfo    bool    `json:"ReturnInfo"`
 	ReturnString  string  `json:"ReturnString"`
+	// NOTE: ReturnInfo (!= ReturnString) doesn't seem to have a stable type
 }


### PR DESCRIPTION
The type of `ReturnInfo` doesn't seem "stable".

allinkl doesn't have a real API schema: https://kasapi.kasserver.com/soap/wsdl/KasApi.wsdl

```xml
<message name="KasApiAntwort">
<part name="Result" type="xsd:anyType"/>
</message>
```

```
2025/03/20 12:54:56 [WARN] [*.example.com] acme: cleaning up failed: allinkl: response struct decode: decoding failed due to the following error(s):

'Response.ReturnInfo' expected type '%!s(bool=false)', got unconvertible type '""', value: '""'
```

Related to #2489