### PR TITLE
designate: speed up API requests by using filters

### DIFF
--- a/providers/dns/designate/designate.go
+++ b/providers/dns/designate/designate.go
@@ -248,10 +248,12 @@ func (d *DNSProvider) getZoneID(wanted string) (string, error) {
 	listOpts := zones.ListOpts{
 		Name: wanted,
 	}
+
 	allPages, err := zones.List(d.client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}
+
 	allZones, err := zones.ExtractZones(allPages)
 	if err != nil {
 		return "", err
@@ -262,6 +264,7 @@ func (d *DNSProvider) getZoneID(wanted string) (string, error) {
 			return zone.ID, nil
 		}
 	}
+
 	return "", fmt.Errorf("zone id not found for %s", wanted)
 }
 
@@ -270,10 +273,12 @@ func (d *DNSProvider) getRecord(zoneID, wanted string) (*recordsets.RecordSet, e
 		Name: wanted,
 		Type: "TXT",
 	}
+
 	allPages, err := recordsets.ListByZone(d.client, zoneID, listOpts).AllPages()
 	if err != nil {
 		return nil, err
 	}
+
 	allRecords, err := recordsets.ExtractRecordSets(allPages)
 	if err != nil {
 		return nil, err

--- a/providers/dns/designate/designate.go
+++ b/providers/dns/designate/designate.go
@@ -245,7 +245,10 @@ func (d *DNSProvider) updateRecord(record *recordsets.RecordSet, value string) e
 }
 
 func (d *DNSProvider) getZoneID(wanted string) (string, error) {
-	allPages, err := zones.List(d.client, nil).AllPages()
+	listOpts := zones.ListOpts{
+		Name: wanted,
+	}
+	allPages, err := zones.List(d.client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}
@@ -263,7 +266,11 @@ func (d *DNSProvider) getZoneID(wanted string) (string, error) {
 }
 
 func (d *DNSProvider) getRecord(zoneID, wanted string) (*recordsets.RecordSet, error) {
-	allPages, err := recordsets.ListByZone(d.client, zoneID, nil).AllPages()
+	listOpts := recordsets.ListOpts{
+		Name: wanted,
+		Type: "TXT",
+	}
+	allPages, err := recordsets.ListByZone(d.client, zoneID, listOpts).AllPages()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When searching for an object in OpenStack we can let the API do the heavy lifting by applying filters (i.e. ListOpts). This helps speeding up the API requests for projects that have a large number of zones or zones that have a large number of records.

---
In a larger test project this speeds up the API calls from about 30s to 1.5s for filtered vs unfiltered API calls.