### PR TITLE
Prepare release v4.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.23.1](https://github.com/go-acme/lego/releases/tag/v4.23.1) (2025-04-16)
+
+Due to an error related to Snapcraft, some artifacts of the v4.23.0 release have not been published.
+
+This release contains the same things as v4.23.0. 
+
 ## [v4.23.0](https://github.com/go-acme/lego/releases/tag/v4.23.0) (2025-04-16)
 
 ### Added

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -4,10 +4,10 @@ package sender
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme/4.23.0"
+	ourUserAgent = "xenolf-acme/4.23.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -9,5 +9,5 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )

--- a/cmd/lego/zz_gen_version.go
+++ b/cmd/lego/zz_gen_version.go
@@ -2,7 +2,7 @@
 
 package main
 
-const defaultVersion = "v4.23.0+dev-detach"
+const defaultVersion = "v4.23.1+dev-release"
 
 var version = ""
 

--- a/cmd/lego/zz_gen_version.go
+++ b/cmd/lego/zz_gen_version.go
@@ -2,7 +2,7 @@
 
 package main
 
-const defaultVersion = "v4.23.1+dev-release"
+const defaultVersion = "v4.23.1+dev-detach"
 
 var version = ""
 

--- a/providers/dns/internal/useragent/useragent.go
+++ b/providers/dns/internal/useragent/useragent.go
@@ -15,7 +15,7 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )
 
 // Get builds and returns the User-Agent string.

--- a/providers/dns/internal/useragent/useragent.go
+++ b/providers/dns/internal/useragent/useragent.go
@@ -10,12 +10,12 @@ import (
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "goacme-lego/4.23.0"
+	ourUserAgent = "goacme-lego/4.23.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )
 
 // Get builds and returns the User-Agent string.


### PR DESCRIPTION
First failure:
```
   • docker images
  ⨯ release failed after 55m5s              
    error=
    │ docker build failed: failed to copy artifact: failed to copy: write /tmp/goreleaserdocker2826257344/lego: copy_file_range: no space left on device
    │ Learn more at https://goreleaser.com/errors/docker-build
```

I cleaned the cache, and second failure:

```
⨯ release failed after 59m10s             
error=
│ 1 error occurred:
│ 	* snapcraft packages: failed to push dist/lego_386.snap package: exit status 1: Exported credentials are no longer valid for the Snap Store.
│ Recommended resolution: Run export-login and update SNAPCRAFT_STORE_CREDENTIALS.
│ For more information, check out: https://snapcraft.io/docs/snapcraft-authentication
│ Full execution log: '/home/runner/.local/state/snapcraft/log/snapcraft-20250416-140018.448193.log'
```
