### PR TITLE
cloudflare: add quotation marks to TXT record

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -169,7 +169,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	dnsRecord := cloudflare.CreateDNSRecordParams{
 		Type:    "TXT",
 		Name:    dns01.UnFqdn(info.EffectiveFQDN),
-		Content: "\"" + info.Value + "\"",
+		Content: `"` + info.Value + `"`,
 		TTL:     d.config.TTL,
 	}
 

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -169,7 +169,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	dnsRecord := cloudflare.CreateDNSRecordParams{
 		Type:    "TXT",
 		Name:    dns01.UnFqdn(info.EffectiveFQDN),
-		Content: info.Value,
+		Content: "\"" + info.Value + "\"",
 		TTL:     d.config.TTL,
 	}
 


### PR DESCRIPTION
Cloudflare changed their [TXTRecord API Type](https://developers.cloudflare.com/api/resources/dns/subresources/records/models/txt_record/#(schema))'s `content` property. The new wording states: 

> Text content for the record. The content must consist of quoted "character strings" (RFC 1035), each with a length of up to 255 bytes. Strings exceeding this allowed maximum length are automatically split. 

On their dashboard, they automatically add quotation marks, if the user does not already do so.

This behavior, however, is not present in their API. Therefore, all TXT records added via their API, need to have their content wrapped manually; otherwise, Cloudflare will display a warning for each record about the missing quotation marks.