### PR TITLE
Increase the default response timeout from 30 to 45 seconds

### DIFF
--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -79,7 +79,7 @@ func createDefaultHTTPClient() *http.Client {
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 			TLSHandshakeTimeout:   30 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
+			ResponseHeaderTimeout: 45 * time.Second,
 			TLSClientConfig: &tls.Config{
 				ServerName: os.Getenv(caServerNameEnvVar),
 				RootCAs:    initCertPool(),


### PR DESCRIPTION
This commit increases the amount of time we can wait for the ACME server response from 30 sec to 45 sec before retrying.

The reason for this change is the increasing amount of certificate issuance failures at the order finalization stage.

Example error:

```
2025/05/25 15:30:20 [INFO] [example.com] acme: Validations succeeded; requesting certificates
2025/05/25 15:30:51 Could not obtain certificates:
	error: one or more domains had a problem:
example.com: acme: error: 400 :: POST :: https://acme-v02.api.letsencrypt.org/acme/finalize/1234567890/123456789012 :: urn:ietf:params:acme:error:badNonce :: Unable to validate JWS :: JWS has an invalid anti-replay nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAA-AAAAAAAAAAAAAAAAAAAAAA"
```

The error message reveals that the request was actually processed by the LE servers, but the `lego` client was impatient and retried the request after 30 seconds with the same JWS nonce.

The request timeout value from the Certbot project is used as a reference:

https://github.com/certbot/certbot/blob/v4.0.0/acme/acme/client.py#L33

The increased timeout value helps to successfully issue a certificate when LE servers are slow to respond.