### PR TITLE
fix exoscale record deletion

### DIFF
--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v3"
@@ -215,7 +216,9 @@ func (d *DNSProvider) findExistingRecordID(zoneID egoscale.UUID, recordName stri
 	}
 
 	for _, record := range records.DNSDomainRecords {
-		if record.Name == recordName && record.Type == egoscale.DNSDomainRecordTypeTXT && record.Content == value {
+	    // we must unquote TXT records as exoscale returns "\"123d==\"" when we expect "123d=="
+		content, _ := strconv.Unquote(record.Content)
+		if record.Name == recordName && record.Type == egoscale.DNSDomainRecordTypeTXT && content == value {
 			return record.ID, nil
 		}
 	}


### PR DESCRIPTION
I noticed that the dns record was not delete after the dns challenge.

This is because exoscale returns the content of the record with the double quote when we are comparing with the value which is without double quote