### PR TITLE
feat: Add service account impersonation support for Google Cloud DNS provider

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1354,6 +1354,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln(`Credentials:`)
 		ew.writeln(`	- "Application Default Credentials":	[Documentation](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application)`)
+		ew.writeln(`	- "GCE_IMPERSONATE_SERVICE_ACCOUNT":	Service account email to impersonate (optional)`)
 		ew.writeln(`	- "GCE_PROJECT":	Project name (by default, the project name is auto-detected by using the metadata service)`)
 		ew.writeln(`	- "GCE_SERVICE_ACCOUNT":	Account`)
 		ew.writeln(`	- "GCE_SERVICE_ACCOUNT_FILE":	Account file path`)

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -13,8 +13,9 @@ dnsprovider:
 <!-- providers/dns/gcloud/gcloud.toml -->
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 
+Supports service account impersonation to access Google Cloud DNS resources across different projects or with restricted permissions.
+When using impersonation, the base service account must have the "Service Account Token Creator" role on the target service account.
 
-Configuration for [Google Cloud](https://cloud.google.com).
 
 
 <!--more-->
@@ -26,8 +27,14 @@ Configuration for [Google Cloud](https://cloud.google.com).
 Here is an example bash command using the Google Cloud provider:
 
 ```bash
+# Using a service account file
 GCE_PROJECT="gc-project-id" \
 GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
+lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
+
+# Using default credentials with impersonation
+GCE_PROJECT="gc-project-id" \
+GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
 lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 ```
 
@@ -39,6 +46,7 @@ lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 | Environment Variable Name | Description |
 |-----------------------|-------------|
 | `Application Default Credentials` | [Documentation](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application) |
+| `GCE_IMPERSONATE_SERVICE_ACCOUNT` | Service account email to impersonate (optional) |
 | `GCE_PROJECT` | Project name (by default, the project name is auto-detected by using the metadata service) |
 | `GCE_SERVICE_ACCOUNT` | Account |
 | `GCE_SERVICE_ACCOUNT_FILE` | Account file path |

--- a/docs/content/dns/zz_gen_gcloud.md
+++ b/docs/content/dns/zz_gen_gcloud.md
@@ -14,7 +14,9 @@ dnsprovider:
 <!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
 
 Supports service account impersonation to access Google Cloud DNS resources across different projects or with restricted permissions.
-When using impersonation, the base service account must have the "Service Account Token Creator" role on the target service account.
+When using impersonation, the source service account must have:
+1. The "Service Account Token Creator" role on the target service account
+2. The "https://www.googleapis.com/auth/cloud-platform" scope (automatically requested by lego)
 
 
 
@@ -34,6 +36,12 @@ lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 
 # Using default credentials with impersonation
 GCE_PROJECT="gc-project-id" \
+GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
+lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
+
+# Using service account key with impersonation
+GCE_PROJECT="gc-project-id" \
+GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
 GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
 lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 ```

--- a/providers/dns/gcloud/gcloud.toml
+++ b/providers/dns/gcloud/gcloud.toml
@@ -1,7 +1,9 @@
 Name = "Google Cloud"
 Description = '''
 Supports service account impersonation to access Google Cloud DNS resources across different projects or with restricted permissions.
-When using impersonation, the base service account must have the "Service Account Token Creator" role on the target service account.
+When using impersonation, the source service account must have:
+1. The "Service Account Token Creator" role on the target service account
+2. The "https://www.googleapis.com/auth/cloud-platform" scope (automatically requested by lego)
 '''
 URL = "https://cloud.google.com"
 Code = "gcloud"
@@ -15,6 +17,12 @@ lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 
 # Using default credentials with impersonation
 GCE_PROJECT="gc-project-id" \
+GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
+lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
+
+# Using service account key with impersonation
+GCE_PROJECT="gc-project-id" \
+GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
 GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
 lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 '''

--- a/providers/dns/gcloud/gcloud.toml
+++ b/providers/dns/gcloud/gcloud.toml
@@ -1,12 +1,21 @@
 Name = "Google Cloud"
-Description = ''''''
+Description = '''
+Supports service account impersonation to access Google Cloud DNS resources across different projects or with restricted permissions.
+When using impersonation, the base service account must have the "Service Account Token Creator" role on the target service account.
+'''
 URL = "https://cloud.google.com"
 Code = "gcloud"
 Since = "v0.3.0"
 
 Example = '''
+# Using a service account file
 GCE_PROJECT="gc-project-id" \
 GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
+lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
+
+# Using default credentials with impersonation
+GCE_PROJECT="gc-project-id" \
+GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
 lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
 '''
 
@@ -16,6 +25,7 @@ lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
     'Application Default Credentials' = "[Documentation](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application)"
     GCE_SERVICE_ACCOUNT_FILE = "Account file path"
     GCE_SERVICE_ACCOUNT = "Account"
+    GCE_IMPERSONATE_SERVICE_ACCOUNT = "Service account email to impersonate (optional)"
   [Configuration.Additional]
     GCE_ALLOW_PRIVATE_ZONE = "Allows requested domain to be in private DNS zone, works only with a private ACME server (by default: false)"
     GCE_ZONE_ID = "Allows to skip the automatic detection of the zone"


### PR DESCRIPTION
## What does this PR do?

Closes #1809 
Adds service account impersonation support to the Google Cloud DNS provider, allowing users to access DNS resources across different projects or with restricted permissions.

## Changes

- Add `GCE_IMPERSONATE_SERVICE_ACCOUNT` environment variable
- Support impersonation in both credential-based and service account key authentication
- Properly handle scopes: source account needs cloud-platform scope, target gets DNS scope
- Add comprehensive tests for the new functionality
- Update documentation with detailed requirements and usage examples
- Maintain backward compatibility with existing authentication methods

## Usage Examples

```bash
# Using a service account file (existing functionality)
GCE_PROJECT="gc-project-id" \
GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run

# Using default credentials with impersonation
GCE_PROJECT="gc-project-id" \
GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run

# Using service account key with impersonation
GCE_PROJECT="gc-project-id" \
GCE_SERVICE_ACCOUNT_FILE="/path/to/svc/account/file.json" \
GCE_IMPERSONATE_SERVICE_ACCOUNT="target-sa@gc-project-id.iam.gserviceaccount.com" \
lego --email you@email.com --dns gcloud -d '*.example.com' -d example.com run
```

## Requirements

When using impersonation, the source service account must have:
1. The "Service Account Token Creator" role on the target service account
2. The "https://www.googleapis.com/auth/cloud-platform" scope (automatically requested by lego)

## Technical Details

- **Source Account**: Uses cloud-platform scope to call the IAM Credentials API
- **Target Account**: Gets DNS scope for actual DNS operations
- **Backward Compatibility**: Existing authentication methods continue to work unchanged
- **Error Handling**: Clear error messages for impersonation failures

## Testing

- [x] Added unit tests for configuration loading
- [x] Added integration test for impersonation functionality
- [x] Verified backward compatibility
- [x] Updated documentation and help text
- [x] Tested scope separation (source vs target)
- [x] Tested DNS ACME challenge/issuance scenarios against live GCP account

## Security

This implementation follows Google Cloud best practices for service account impersonation:
- Uses the official `google.golang.org/api/impersonate` package
- Properly separates scopes between source and target accounts
- Maintains the principle of least privilege