### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      GOLANGCI_LINT_VERSION: v2.1.1
+      GOLANGCI_LINT_VERSION: v2.2.1
       HUGO_VERSION: 0.131.0
       CGO_ENABLED: 0
       LEGO_E2E_TESTS: CI

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ formatters:
 linters:
   default: all
   disable:
+    - wsl # Deprecated
     - bodyclose
     - canonicalheader
     - contextcheck
@@ -33,6 +34,7 @@ linters:
     - nilnil # not relevant
     - nlreturn # not relevant
     - noctx
+    - noinlineerr # too strict
     - nonamedreturns
     - paralleltest # not relevant
     - prealloc # too many false-positive
@@ -44,7 +46,8 @@ linters:
     - usestdlibvars # false-positive https://github.com/sashamelentyev/usestdlibvars/issues/96
     - varnamelen # not relevant
     - wrapcheck
-    - wsl # should be enabled it the future.
+    - wsl_v5 # should be enabled the future.
+    - embeddedstructfieldcheck # should be enabled the future.
 
   settings:
     depguard:


### PR DESCRIPTION
Update golangci-lint to v2.2.1