### PR TITLE
azion: add pagination support

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -360,6 +360,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "AZION_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
+		ew.writeln(`	- "AZION_PAGE_SIZE":	The page size for the API request (Default: 50)`)
 		ew.writeln(`	- "AZION_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)
 		ew.writeln(`	- "AZION_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 60)`)
 		ew.writeln(`	- "AZION_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)

--- a/docs/content/dns/zz_gen_azion.md
+++ b/docs/content/dns/zz_gen_azion.md
@@ -48,6 +48,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
 | `AZION_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
+| `AZION_PAGE_SIZE` | The page size for the API request (Default: 50) |
 | `AZION_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |
 | `AZION_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 60) |
 | `AZION_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |

--- a/providers/dns/azion/azion.toml
+++ b/providers/dns/azion/azion.toml
@@ -13,11 +13,11 @@ lego --email you@example.com --dns azion -d '*.example.com' -d example.com run
   [Configuration.Credentials]
     AZION_PERSONAL_TOKEN = "Your Azion personal token."
   [Configuration.Additional]
-    AZION_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
     AZION_PAGE_SIZE = "The page size for the API request (Default: 50)"
     AZION_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
     AZION_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 60)"
     AZION_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
+    AZION_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
 
 [Links]
   API = "https://api.azion.com/"

--- a/providers/dns/azion/azion.toml
+++ b/providers/dns/azion/azion.toml
@@ -13,10 +13,11 @@ lego --email you@example.com --dns azion -d '*.example.com' -d example.com run
   [Configuration.Credentials]
     AZION_PERSONAL_TOKEN = "Your Azion personal token."
   [Configuration.Additional]
+    AZION_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
+    AZION_PAGE_SIZE = "The page size for the API request (Default: 50)"
     AZION_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
     AZION_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 60)"
     AZION_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
-    AZION_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
 
 [Links]
   API = "https://api.azion.com/"


### PR DESCRIPTION
* Add pagination support for Azion DNS record lookup with a configurable page size to fix zones with a large number of records.
* Ordering environment variable equal to auto-generated files