### PR TITLE
chore: update to go1.24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,11 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
 
 linters:
   default: all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ formatters:
     - gofumpt
     - goimports
   settings:
+    gofumpt:
+      extra-rules: true
     gofmt:
       rewrite-rules:
         - pattern: 'interface{}'

--- a/acme/api/api.go
+++ b/acme/api/api.go
@@ -60,7 +60,7 @@ func New(httpClient *http.Client, userAgent, caDirURL, kid string, privateKey cr
 
 // post performs an HTTP POST request and parses the response body as JSON,
 // into the provided respBody object.
-func (a *Core) post(uri string, reqBody, response interface{}) (*http.Response, error) {
+func (a *Core) post(uri string, reqBody, response any) (*http.Response, error) {
 	content, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, errors.New("failed to marshal message")
@@ -71,11 +71,11 @@ func (a *Core) post(uri string, reqBody, response interface{}) (*http.Response, 
 
 // postAsGet performs an HTTP POST ("POST-as-GET") request.
 // https://www.rfc-editor.org/rfc/rfc8555.html#section-6.3
-func (a *Core) postAsGet(uri string, response interface{}) (*http.Response, error) {
+func (a *Core) postAsGet(uri string, response any) (*http.Response, error) {
 	return a.retrievablePost(uri, []byte{}, response)
 }
 
-func (a *Core) retrievablePost(uri string, content []byte, response interface{}) (*http.Response, error) {
+func (a *Core) retrievablePost(uri string, content []byte, response any) (*http.Response, error) {
 	// during tests, allow to support ~90% of bad nonce with a minimum of attempts.
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 200 * time.Millisecond
@@ -111,7 +111,7 @@ func (a *Core) retrievablePost(uri string, content []byte, response interface{})
 	return resp, nil
 }
 
-func (a *Core) signedPost(uri string, content []byte, response interface{}) (*http.Response, error) {
+func (a *Core) signedPost(uri string, content []byte, response any) (*http.Response, error) {
 	signedContent, err := a.jws.SignContent(uri, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to post JWS message: failed to sign content: %w", err)

--- a/acme/api/internal/secure/jws.go
+++ b/acme/api/internal/secure/jws.go
@@ -54,7 +54,7 @@ func (j *JWS) SignContent(url string, content []byte) (*jose.JSONWebSignature, e
 
 	options := jose.SignerOptions{
 		NonceSource: j.nonces,
-		ExtraHeaders: map[jose.HeaderKey]interface{}{
+		ExtraHeaders: map[jose.HeaderKey]any{
 			"url": url,
 		},
 	}
@@ -87,7 +87,7 @@ func (j *JWS) SignEABContent(url, kid string, hmac []byte) (*jose.JSONWebSignatu
 		jose.SigningKey{Algorithm: jose.HS256, Key: hmac},
 		&jose.SignerOptions{
 			EmbedJWK: false,
-			ExtraHeaders: map[jose.HeaderKey]interface{}{
+			ExtraHeaders: map[jose.HeaderKey]any{
 				"kid": kid,
 				"url": url,
 			},

--- a/acme/api/internal/sender/sender.go
+++ b/acme/api/internal/sender/sender.go
@@ -35,7 +35,7 @@ func NewDoer(client *http.Client, userAgent string) *Doer {
 
 // Get performs a GET request with a proper User-Agent string.
 // If "response" is not provided, callers should close resp.Body when done reading from it.
-func (d *Doer) Get(url string, response interface{}) (*http.Response, error) {
+func (d *Doer) Get(url string, response any) (*http.Response, error) {
 	req, err := d.newRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (d *Doer) Head(url string) (*http.Response, error) {
 
 // Post performs a POST request with a proper User-Agent string.
 // If "response" is not provided, callers should close resp.Body when done reading from it.
-func (d *Doer) Post(url string, body io.Reader, bodyType string, response interface{}) (*http.Response, error) {
+func (d *Doer) Post(url string, body io.Reader, bodyType string, response any) (*http.Response, error) {
 	req, err := d.newRequest(http.MethodPost, url, body, contentType(bodyType))
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (d *Doer) newRequest(method, uri string, body io.Reader, opts ...RequestOpt
 	return req, nil
 }
 
-func (d *Doer) do(req *http.Request, response interface{}) (*http.Response, error) {
+func (d *Doer) do(req *http.Request, response any) (*http.Response, error) {
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -179,11 +179,11 @@ func CreateCSR(privateKey crypto.PrivateKey, opts CSROptions) ([]byte, error) {
 	return x509.CreateCertificateRequest(rand.Reader, &template, privateKey)
 }
 
-func PEMEncode(data interface{}) []byte {
+func PEMEncode(data any) []byte {
 	return pem.EncodeToMemory(PEMBlock(data))
 }
 
-func PEMBlock(data interface{}) *pem.Block {
+func PEMBlock(data any) *pem.Block {
 	var pemBlock *pem.Block
 	switch key := data.(type) {
 	case *ecdsa.PrivateKey:

--- a/challenge/dns01/fqdn.go
+++ b/challenge/dns01/fqdn.go
@@ -1,5 +1,11 @@
 package dns01
 
+import (
+	"iter"
+
+	"github.com/miekg/dns"
+)
+
 // ToFqdn converts the name into a fqdn appending a trailing dot.
 func ToFqdn(name string) string {
 	n := len(name)
@@ -16,4 +22,34 @@ func UnFqdn(name string) string {
 		return name[:n-1]
 	}
 	return name
+}
+
+// UnFqdnDomainsSeq generates a sequence of "unFQDNed" domain names derived from a domain (FQDN or not) in descending order.
+func UnFqdnDomainsSeq(fqdn string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if fqdn == "" {
+			return
+		}
+
+		for _, index := range dns.Split(fqdn) {
+			if !yield(UnFqdn(fqdn[index:])) {
+				return
+			}
+		}
+	}
+}
+
+// DomainsSeq generates a sequence of domain names derived from a domain (FQDN or not) in descending order.
+func DomainsSeq(fqdn string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if fqdn == "" {
+			return
+		}
+
+		for _, index := range dns.Split(fqdn) {
+			if !yield(fqdn[index:]) {
+				return
+			}
+		}
+	}
 }

--- a/challenge/dns01/fqdn_test.go
+++ b/challenge/dns01/fqdn_test.go
@@ -1,6 +1,7 @@
 package dns01
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,106 @@ func TestUnFqdn(t *testing.T) {
 			domain := UnFqdn(test.fqdn)
 
 			assert.Equal(t, test.expected, domain)
+		})
+	}
+}
+
+func TestUnFqdnDomainsSeq(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		fqdn     string
+		expected []string
+	}{
+		{
+			desc:     "empty",
+			fqdn:     "",
+			expected: nil,
+		},
+		{
+			desc:     "TLD",
+			fqdn:     "com",
+			expected: []string{"com"},
+		},
+		{
+			desc:     "2 levels",
+			fqdn:     "example.com",
+			expected: []string{"example.com", "com"},
+		},
+		{
+			desc:     "3 levels",
+			fqdn:     "foo.example.com",
+			expected: []string{"foo.example.com", "example.com", "com"},
+		},
+	}
+
+	for _, test := range testCases {
+		for name, suffix := range map[string]string{"": "", " FQDN": "."} { //nolint:gocritic
+			t.Run(test.desc+name, func(t *testing.T) {
+				t.Parallel()
+
+				actual := slices.Collect(UnFqdnDomainsSeq(test.fqdn + suffix))
+
+				assert.Equal(t, test.expected, actual)
+			})
+		}
+	}
+}
+
+func TestDomainsSeq(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		fqdn     string
+		expected []string
+	}{
+		{
+			desc:     "empty",
+			fqdn:     "",
+			expected: nil,
+		},
+		{
+			desc:     "empty FQDN",
+			fqdn:     ".",
+			expected: nil,
+		},
+		{
+			desc:     "TLD FQDN",
+			fqdn:     "com",
+			expected: []string{"com"},
+		},
+		{
+			desc:     "TLD",
+			fqdn:     "com.",
+			expected: []string{"com."},
+		},
+		{
+			desc:     "2 levels",
+			fqdn:     "example.com",
+			expected: []string{"example.com", "com"},
+		},
+		{
+			desc:     "2 levels FQDN",
+			fqdn:     "example.com.",
+			expected: []string{"example.com.", "com."},
+		},
+		{
+			desc:     "3 levels",
+			fqdn:     "foo.example.com",
+			expected: []string{"foo.example.com", "example.com", "com"},
+		},
+		{
+			desc:     "3 levels FQDN",
+			fqdn:     "foo.example.com.",
+			expected: []string{"foo.example.com.", "example.com.", "com."},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual := slices.Collect(DomainsSeq(test.fqdn))
+
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -175,8 +175,7 @@ func fetchSoaByFqdn(fqdn string, nameservers []string) (*soaCacheEntry, error) {
 	var err error
 	var r *dns.Msg
 
-	labelIndexes := dns.Split(fqdn)
-	for _, index := range labelIndexes {
+	for _, index := range dns.Split(fqdn) {
 		domain := fqdn[index:]
 
 		r, err = dnsQuery(domain, dns.TypeSOA, nameservers, true)

--- a/challenge/dns01/nameserver.go
+++ b/challenge/dns01/nameserver.go
@@ -175,9 +175,7 @@ func fetchSoaByFqdn(fqdn string, nameservers []string) (*soaCacheEntry, error) {
 	var err error
 	var r *dns.Msg
 
-	for _, index := range dns.Split(fqdn) {
-		domain := fqdn[index:]
-
+	for domain := range DomainsSeq(fqdn) {
 		r, err = dnsQuery(domain, dns.TypeSOA, nameservers, true)
 		if err != nil {
 			continue

--- a/cmd/cmd_dnshelp.go
+++ b/cmd/cmd_dnshelp.go
@@ -58,7 +58,7 @@ type errWriter struct {
 	err error
 }
 
-func (ew *errWriter) writeln(a ...interface{}) {
+func (ew *errWriter) writeln(a ...any) {
 	if ew.err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (ew *errWriter) writeln(a ...interface{}) {
 	_, ew.err = fmt.Fprintln(ew.w, a...)
 }
 
-func (ew *errWriter) writef(format string, a ...interface{}) {
+func (ew *errWriter) writef(format string, a ...any) {
 	if ew.err != nil {
 		return
 	}

--- a/e2e/loader/loader.go
+++ b/e2e/loader/loader.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-acme/lego/v4/platform/wait"
+	"github.com/ldez/grignotin/goenv"
 )
 
 const (
@@ -311,8 +313,13 @@ func goTool() (string, error) {
 		exeSuffix = ".exe"
 	}
 
-	path := filepath.Join(runtime.GOROOT(), "bin", "go"+exeSuffix)
-	if _, err := os.Stat(path); err == nil {
+	goRoot, err := goenv.GetOne(context.Background(), goenv.GOROOT)
+	if err != nil {
+		return "", fmt.Errorf("cannot find go root: %w", err)
+	}
+
+	path := filepath.Join(goRoot, "bin", "go"+exeSuffix)
+	if _, err = os.Stat(path); err == nil {
 		return path, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/iij/doapi v0.0.0-20190504054126-0bbf12d6d7df
 	github.com/infobloxopen/infoblox-go-client/v2 v2.9.0
 	github.com/labbsr0x/bindman-dns-webhook v1.0.2
+	github.com/ldez/grignotin v0.9.0
 	github.com/linode/linodego v1.48.1
 	github.com/liquidweb/liquidweb-go v1.6.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-acme/lego/v4
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -597,6 +597,8 @@ github.com/labbsr0x/bindman-dns-webhook v1.0.2 h1:I7ITbmQPAVwrDdhd6dHKi+MYJTJqPC
 github.com/labbsr0x/bindman-dns-webhook v1.0.2/go.mod h1:p6b+VCXIR8NYKpDr8/dg1HKfQoRHCdcsROXKvmoehKA=
 github.com/labbsr0x/goh v1.0.1 h1:97aBJkDjpyBZGPbQuOK5/gHcSFbcr5aRsq3RSRJFpPk=
 github.com/labbsr0x/goh v1.0.1/go.mod h1:8K2UhVoaWXcCU7Lxoa2omWnC8gyW8px7/lmO61c027w=
+github.com/ldez/grignotin v0.9.0 h1:MgOEmjZIVNn6p5wPaGp/0OKWyvq42KnzAt/DAb8O4Ow=
+github.com/ldez/grignotin v0.9.0/go.mod h1:uaVTr0SoZ1KBii33c47O1M8Jp3OP3YDwhZCmzT9GHEk=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/linode/linodego v1.48.1 h1:Ojw1S+K5jJr1dggO8/H6r4FINxXnJbOU5GkbpaTfmhU=

--- a/internal/dns/docs/generator.go
+++ b/internal/dns/docs/generator.go
@@ -96,7 +96,7 @@ func generateCLIHelp(models *descriptors.Providers) error {
 
 	b := &bytes.Buffer{}
 	err = template.Must(
-		template.New(filepath.Base(cliTemplate)).Funcs(map[string]interface{}{
+		template.New(filepath.Base(cliTemplate)).Funcs(map[string]any{
 			"safe": func(src string) string {
 				return strings.ReplaceAll(src, "`", "'")
 			},

--- a/internal/dns/providers/generator.go
+++ b/internal/dns/providers/generator.go
@@ -47,7 +47,7 @@ func generate() error {
 
 	b := &bytes.Buffer{}
 	err = template.Must(
-		template.New("").Funcs(map[string]interface{}{
+		template.New("").Funcs(map[string]any{
 			"cleanName": func(src string) string {
 				return strings.ReplaceAll(src, "-", "")
 			},

--- a/internal/releaser/generator.go
+++ b/internal/releaser/generator.go
@@ -33,7 +33,7 @@ type Generator struct {
 	targetFile   string
 }
 
-func NewGenerator(templatePath string, targetFile string) *Generator {
+func NewGenerator(templatePath, targetFile string) *Generator {
 	return &Generator{templatePath: templatePath, targetFile: targetFile}
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -10,50 +10,50 @@ var Logger StdLogger = log.New(os.Stderr, "", log.LstdFlags)
 
 // StdLogger interface for Standard Logger.
 type StdLogger interface {
-	Fatal(args ...interface{})
-	Fatalln(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Print(args ...interface{})
-	Println(args ...interface{})
-	Printf(format string, args ...interface{})
+	Fatal(args ...any)
+	Fatalln(args ...any)
+	Fatalf(format string, args ...any)
+	Print(args ...any)
+	Println(args ...any)
+	Printf(format string, args ...any)
 }
 
 // Fatal writes a log entry.
 // It uses Logger if not nil, otherwise it uses the default log.Logger.
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	Logger.Fatal(args...)
 }
 
 // Fatalf writes a log entry.
 // It uses Logger if not nil, otherwise it uses the default log.Logger.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Logger.Fatalf(format, args...)
 }
 
 // Print writes a log entry.
 // It uses Logger if not nil, otherwise it uses the default log.Logger.
-func Print(args ...interface{}) {
+func Print(args ...any) {
 	Logger.Print(args...)
 }
 
 // Println writes a log entry.
 // It uses Logger if not nil, otherwise it uses the default log.Logger.
-func Println(args ...interface{}) {
+func Println(args ...any) {
 	Logger.Println(args...)
 }
 
 // Printf writes a log entry.
 // It uses Logger if not nil, otherwise it uses the default log.Logger.
-func Printf(format string, args ...interface{}) {
+func Printf(format string, args ...any) {
 	Logger.Printf(format, args...)
 }
 
 // Warnf writes a log entry.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Printf("[WARN] "+format, args...)
 }
 
 // Infof writes a log entry.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Printf("[INFO] "+format, args...)
 }

--- a/platform/config/env/env.go
+++ b/platform/config/env/env.go
@@ -184,3 +184,20 @@ func ParseString(s string) (string, error) {
 
 	return s, nil
 }
+
+// ParsePairs parses a raw string of comma-separated key-value pairs into a map.
+// Keys and values are separated by a colon and are trimmed of whitespace.
+func ParsePairs(raw string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for pair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
+		data := strings.Split(pair, ":")
+		if len(data) != 2 {
+			return nil, fmt.Errorf("incorrect pair: %s", pair)
+		}
+
+		result[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
+	}
+
+	return result, nil
+}

--- a/platform/config/env/env.go
+++ b/platform/config/env/env.go
@@ -107,7 +107,7 @@ func getOneWithFallback(main string, names ...string) (string, string) {
 
 // GetOrDefaultString returns the given environment variable value as a string.
 // Returns the default if the env var cannot be found.
-func GetOrDefaultString(envVar string, defaultValue string) string {
+func GetOrDefaultString(envVar, defaultValue string) string {
 	return getOrDefault(envVar, defaultValue, ParseString)
 }
 

--- a/platform/config/env/env_test.go
+++ b/platform/config/env/env_test.go
@@ -408,3 +408,77 @@ func TestGetOrFile_PrefersEnvVars(t *testing.T) {
 
 	assert.Equal(t, "lego_env", value)
 }
+
+func TestParsePairs(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		value    string
+		expected map[string]string
+	}{
+		{
+			desc:     "one pair",
+			value:    "foo:bar",
+			expected: map[string]string{"foo": "bar"},
+		},
+		{
+			desc:     "multiple pairs",
+			value:    "foo:bar,a:b,c:d",
+			expected: map[string]string{"a": "b", "c": "d", "foo": "bar"},
+		},
+		{
+			desc:     "multiple pairs with spaces",
+			value:    "foo:bar, a:b , c: d",
+			expected: map[string]string{"a": "b", "c": "d", "foo": "bar"},
+		},
+		{
+			desc:     "empty value pair",
+			value:    "foo:",
+			expected: map[string]string{"foo": ""},
+		},
+		{
+			desc:     "empty key pair",
+			value:    ":bar",
+			expected: map[string]string{"": "bar"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			pairs, err := ParsePairs(test.value)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, pairs)
+		})
+	}
+}
+
+func TestParsePairs_error(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		value string
+	}{
+		{
+			desc:  "empty value",
+			value: "",
+		},
+		{
+			desc:  "multiple colons",
+			value: "foo:bar:bir",
+		},
+		{
+			desc:  "valid pair and multiple colons",
+			value: "a:b,foo:bar:bir",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParsePairs(test.value)
+			require.Error(t, err)
+		})
+	}
+}

--- a/platform/tester/api.go
+++ b/platform/tester/api.go
@@ -52,7 +52,7 @@ func SetupFakeAPI(t *testing.T) (*http.ServeMux, string) {
 }
 
 // WriteJSONResponse marshals the body as JSON and writes it to the response.
-func WriteJSONResponse(w http.ResponseWriter, body interface{}) error {
+func WriteJSONResponse(w http.ResponseWriter, body any) error {
 	bs, err := json.Marshal(body)
 	if err != nil {
 		return err

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -1,7 +1,6 @@
 package acmedns
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -133,7 +132,7 @@ func TestRegister(t *testing.T) {
 				p.storage = test.Storage
 			}
 
-			acc, err := p.register(context.Background(), egDomain, egFQDN)
+			acc, err := p.register(t.Context(), egDomain, egFQDN)
 			if test.ExpectedError != nil {
 				assert.Equal(t, test.ExpectedError, err)
 			} else {
@@ -242,7 +241,7 @@ func TestRegister_httpStorage(t *testing.T) {
 				w.WriteHeader(test.StatusCode)
 			})
 
-			acc, err := p.register(context.Background(), egDomain, egFQDN)
+			acc, err := p.register(t.Context(), egDomain, egFQDN)
 			if test.ExpectedError != nil {
 				assert.Equal(t, test.ExpectedError, err)
 			} else {

--- a/providers/dns/acmedns/internal/http_storage_test.go
+++ b/providers/dns/acmedns/internal/http_storage_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -54,7 +53,7 @@ func setupTest(t *testing.T, pattern, filename string, statusCode int) *HTTPStor
 func TestHTTPStorage_Fetch(t *testing.T) {
 	storage := setupTest(t, "GET /example.com", "fetch.json", http.StatusOK)
 
-	account, err := storage.Fetch(context.Background(), "example.com")
+	account, err := storage.Fetch(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := goacmedns.Account{
@@ -71,14 +70,14 @@ func TestHTTPStorage_Fetch(t *testing.T) {
 func TestHTTPStorage_Fetch_error(t *testing.T) {
 	storage := setupTest(t, "GET /example.com", "error.json", http.StatusInternalServerError)
 
-	_, err := storage.Fetch(context.Background(), "example.com")
+	_, err := storage.Fetch(t.Context(), "example.com")
 	require.Error(t, err)
 }
 
 func TestHTTPStorage_FetchAll(t *testing.T) {
 	storage := setupTest(t, "GET /", "fetch-all.json", http.StatusOK)
 
-	account, err := storage.FetchAll(context.Background())
+	account, err := storage.FetchAll(t.Context())
 	require.NoError(t, err)
 
 	expected := map[string]goacmedns.Account{
@@ -104,7 +103,7 @@ func TestHTTPStorage_FetchAll(t *testing.T) {
 func TestHTTPStorage_FetchAll_error(t *testing.T) {
 	storage := setupTest(t, "GET /", "error.json", http.StatusInternalServerError)
 
-	_, err := storage.FetchAll(context.Background())
+	_, err := storage.FetchAll(t.Context())
 	require.Error(t, err)
 }
 
@@ -119,7 +118,7 @@ func TestHTTPStorage_Put(t *testing.T) {
 		ServerURL:  "https://example.com",
 	}
 
-	err := storage.Put(context.Background(), "example.com", account)
+	err := storage.Put(t.Context(), "example.com", account)
 	require.NoError(t, err)
 }
 
@@ -134,7 +133,7 @@ func TestHTTPStorage_Put_error(t *testing.T) {
 		ServerURL:  "https://example.com",
 	}
 
-	err := storage.Put(context.Background(), "example.com", account)
+	err := storage.Put(t.Context(), "example.com", account)
 	require.Error(t, err)
 }
 
@@ -149,6 +148,6 @@ func TestHTTPStorage_Put_CNAME_created(t *testing.T) {
 		ServerURL:  "https://example.com",
 	}
 
-	err := storage.Put(context.Background(), "example.com", account)
+	err := storage.Put(t.Context(), "example.com", account)
 	require.ErrorIs(t, err, ErrCNAMEAlreadyCreated)
 }

--- a/providers/dns/allinkl/internal/client_test.go
+++ b/providers/dns/allinkl/internal/client_test.go
@@ -23,7 +23,7 @@ func TestClient_GetDNSSettings(t *testing.T) {
 	client := NewClient("user")
 	client.baseURL = server.URL
 
-	records, err := client.GetDNSSettings(mockContext(), "example.com", "")
+	records, err := client.GetDNSSettings(mockContext(t), "example.com", "")
 	require.NoError(t, err)
 
 	expected := []ReturnInfo{
@@ -112,7 +112,7 @@ func TestClient_AddDNSSettings(t *testing.T) {
 		RecordData: "abcdefgh",
 	}
 
-	recordID, err := client.AddDNSSettings(mockContext(), record)
+	recordID, err := client.AddDNSSettings(mockContext(t), record)
 	require.NoError(t, err)
 
 	assert.Equal(t, "57347444", recordID)
@@ -128,7 +128,7 @@ func TestClient_DeleteDNSSettings(t *testing.T) {
 	client := NewClient("user")
 	client.baseURL = server.URL
 
-	r, err := client.DeleteDNSSettings(mockContext(), "57347450")
+	r, err := client.DeleteDNSSettings(mockContext(t), "57347450")
 	require.NoError(t, err)
 
 	assert.Equal(t, "TRUE", r)

--- a/providers/dns/allinkl/internal/identity.go
+++ b/providers/dns/allinkl/internal/identity.go
@@ -29,7 +29,7 @@ type Identifier struct {
 }
 
 // NewIdentifier creates a new Identifier.
-func NewIdentifier(login string, password string) *Identifier {
+func NewIdentifier(login, password string) *Identifier {
 	return &Identifier{
 		login:        login,
 		password:     password,

--- a/providers/dns/allinkl/internal/identity_test.go
+++ b/providers/dns/allinkl/internal/identity_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext() context.Context {
-	return context.WithValue(context.Background(), tokenKey, "593959ca04f0de9689b586c6a647d15d")
+func mockContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return context.WithValue(t.Context(), tokenKey, "593959ca04f0de9689b586c6a647d15d")
 }
 
 func TestIdentifier_Authentication(t *testing.T) {
@@ -24,7 +26,7 @@ func TestIdentifier_Authentication(t *testing.T) {
 	client := NewIdentifier("user", "secret")
 	client.authEndpoint = server.URL
 
-	credentialToken, err := client.Authentication(context.Background(), 60, false)
+	credentialToken, err := client.Authentication(t.Context(), 60, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "593959ca04f0de9689b586c6a647d15d", credentialToken)
@@ -40,6 +42,6 @@ func TestIdentifier_Authentication_error(t *testing.T) {
 	client := NewIdentifier("user", "secret")
 	client.authEndpoint = server.URL
 
-	_, err := client.Authentication(context.Background(), 60, false)
+	_, err := client.Authentication(t.Context(), 60, false)
 	require.Error(t, err)
 }

--- a/providers/dns/arvancloud/internal/client_test.go
+++ b/providers/dns/arvancloud/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,7 +60,7 @@ func TestClient_GetTxtRecord(t *testing.T) {
 		}
 	})
 
-	_, err := client.GetTxtRecord(context.Background(), domain, "_acme-challenge", "txtxtxt")
+	_, err := client.GetTxtRecord(t.Context(), domain, "_acme-challenge", "txtxtxt")
 	require.NoError(t, err)
 }
 
@@ -106,7 +105,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		TTL:   600,
 	}
 
-	newRecord, err := client.CreateRecord(context.Background(), domain, record)
+	newRecord, err := client.CreateRecord(t.Context(), domain, record)
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
@@ -147,6 +146,6 @@ func TestClient_DeleteRecord(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteRecord(context.Background(), domain, recordID)
+	err := client.DeleteRecord(t.Context(), domain, recordID)
 	require.NoError(t, err)
 }

--- a/providers/dns/arvancloud/internal/client_test.go
+++ b/providers/dns/arvancloud/internal/client_test.go
@@ -112,7 +112,7 @@ func TestClient_CreateRecord(t *testing.T) {
 	expected := &DNSRecord{
 		ID:            "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 		Type:          "txt",
-		Value:         map[string]interface{}{"text": "txtxtxt"},
+		Value:         map[string]any{"text": "txtxtxt"},
 		Name:          "_acme-challenge",
 		TTL:           120,
 		UpstreamHTTPS: "default",

--- a/providers/dns/autodns/internal/client.go
+++ b/providers/dns/autodns/internal/client.go
@@ -31,7 +31,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username string, password string, clientContext int) *Client {
+func NewClient(username, password string, clientContext int) *Client {
 	baseURL, _ := url.Parse(DefaultEndpoint)
 
 	return &Client{

--- a/providers/dns/autodns/internal/client_test.go
+++ b/providers/dns/autodns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,7 +66,7 @@ func TestClient_AddTxtRecords(t *testing.T) {
 
 	records := []*ResourceRecord{{}}
 
-	zone, err := client.AddTxtRecords(context.Background(), "example.com", records)
+	zone, err := client.AddTxtRecords(t.Context(), "example.com", records)
 	require.NoError(t, err)
 
 	expected := &Zone{
@@ -91,6 +90,6 @@ func TestClient_RemoveTXTRecords(t *testing.T) {
 
 	records := []*ResourceRecord{{}}
 
-	err := client.RemoveTXTRecords(context.Background(), "example.com", records)
+	err := client.RemoveTXTRecords(t.Context(), "example.com", records)
 	require.NoError(t, err)
 }

--- a/providers/dns/axelname/internal/client_test.go
+++ b/providers/dns/axelname/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +54,7 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 func TestClient_ListRecords(t *testing.T) {
 	client := setupTest(t, "GET /dns_list", http.StatusOK, "dns_list.json")
 
-	records, err := client.ListRecords(context.Background(), "example.com")
+	records, err := client.ListRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -71,7 +70,7 @@ func TestClient_ListRecords(t *testing.T) {
 func TestClient_ListRecords_error(t *testing.T) {
 	client := setupTest(t, "GET /dns_list", http.StatusNotFound, "dns_list_error.json")
 
-	_, err := client.ListRecords(context.Background(), "example.com")
+	_, err := client.ListRecords(t.Context(), "example.com")
 	require.EqualError(t, err, "error: Domain not found (1)")
 }
 
@@ -80,7 +79,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 	record := Record{ID: "74749"}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -89,7 +88,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 
 	record := Record{ID: "74749"}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "error: Domain not found (1)")
 }
 
@@ -98,7 +97,7 @@ func TestClient_AddRecord(t *testing.T) {
 
 	record := Record{ID: "74749"}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -107,6 +106,6 @@ func TestClient_AddRecord_error(t *testing.T) {
 
 	record := Record{ID: "74749"}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "error: Domain not found (1)")
 }

--- a/providers/dns/azion/azion.go
+++ b/providers/dns/azion/azion.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aziontech/azionapi-go-sdk/idns"
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
-	"github.com/miekg/dns"
 )
 
 // Environment variables names.
@@ -247,11 +246,7 @@ func (d *DNSProvider) findZone(ctx context.Context, fqdn string) (*idns.Zone, er
 		return nil, errors.New("get zones: no results")
 	}
 
-	labelIndexes := dns.Split(fqdn)
-
-	for _, index := range labelIndexes {
-		domain := dns01.UnFqdn(fqdn[index:])
-
+	for domain := range dns01.UnFqdnDomainsSeq(fqdn) {
 		for _, zone := range resp.GetResults() {
 			if zone.GetDomain() == domain {
 				return &zone, nil

--- a/providers/dns/bluecat/internal/client.go
+++ b/providers/dns/bluecat/internal/client.go
@@ -36,7 +36,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(baseURL string, username, password string) *Client {
+func NewClient(baseURL, username, password string) *Client {
 	bu, _ := url.Parse(baseURL)
 
 	return &Client{

--- a/providers/dns/bluecat/internal/client_test.go
+++ b/providers/dns/bluecat/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +34,7 @@ func TestClient_LookupParentZoneID(t *testing.T) {
 		http.Error(rw, "{}", http.StatusOK)
 	})
 
-	parentID, name, err := client.LookupParentZoneID(context.Background(), 2, "foo.example.com")
+	parentID, name, err := client.LookupParentZoneID(t.Context(), 2, "foo.example.com")
 	require.NoError(t, err)
 
 	assert.EqualValues(t, 2, parentID)

--- a/providers/dns/bluecat/internal/identity_test.go
+++ b/providers/dns/bluecat/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +47,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 		}
 	})
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	at := getToken(ctx)

--- a/providers/dns/bookmyname/internal/client_test.go
+++ b/providers/dns/bookmyname/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,7 +61,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Value:    "test",
 	}
 
-	err := client.AddRecord(context.Background(), record)
+	err := client.AddRecord(t.Context(), record)
 	require.NoError(t, err)
 }
 
@@ -76,7 +75,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Value:    "test",
 	}
 
-	err := client.AddRecord(context.Background(), record)
+	err := client.AddRecord(t.Context(), record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "unexpected response: notfqdn: Host _acme-challenge.sub.example.com. malformed / vhn")
@@ -92,7 +91,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 		Value:    "test",
 	}
 
-	err := client.RemoveRecord(context.Background(), record)
+	err := client.RemoveRecord(t.Context(), record)
 	require.NoError(t, err)
 }
 
@@ -106,7 +105,7 @@ func TestClient_RemoveRecord_error(t *testing.T) {
 		Value:    "test",
 	}
 
-	err := client.RemoveRecord(context.Background(), record)
+	err := client.RemoveRecord(t.Context(), record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "unexpected response: notfqdn: Host _acme-challenge.sub.example.com. malformed / vhn")

--- a/providers/dns/brandit/internal/client_test.go
+++ b/providers/dns/brandit/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +45,7 @@ func setupTest(t *testing.T, filename string) *Client {
 func TestClient_StatusDomain(t *testing.T) {
 	client := setupTest(t, "status-domain.json")
 
-	domain, err := client.StatusDomain(context.Background(), "example.com")
+	domain, err := client.StatusDomain(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := &StatusResponse{
@@ -82,14 +81,14 @@ func TestClient_StatusDomain(t *testing.T) {
 func TestClient_StatusDomain_error(t *testing.T) {
 	client := setupTest(t, "error.json")
 
-	_, err := client.StatusDomain(context.Background(), "example.com")
+	_, err := client.StatusDomain(t.Context(), "example.com")
 	require.ErrorIs(t, err, APIError{Code: 402, Status: "error", Message: "Invalid user."})
 }
 
 func TestClient_ListRecords(t *testing.T) {
 	client := setupTest(t, "list-records.json")
 
-	resp, err := client.ListRecords(context.Background(), "example", "example.com")
+	resp, err := client.ListRecords(t.Context(), "example", "example.com")
 	require.NoError(t, err)
 
 	expected := &ListRecordsResponse{
@@ -108,7 +107,7 @@ func TestClient_ListRecords(t *testing.T) {
 func TestClient_ListRecords_error(t *testing.T) {
 	client := setupTest(t, "error.json")
 
-	_, err := client.ListRecords(context.Background(), "example", "example.com")
+	_, err := client.ListRecords(t.Context(), "example", "example.com")
 	require.ErrorIs(t, err, APIError{Code: 402, Status: "error", Message: "Invalid user."})
 }
 
@@ -122,7 +121,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Content: "txttxttxt",
 		TTL:     600,
 	}
-	resp, err := client.AddRecord(context.Background(), "example.com", "test", "2565", testRecord)
+	resp, err := client.AddRecord(t.Context(), "example.com", "test", "2565", testRecord)
 	require.NoError(t, err)
 
 	expected := &AddRecord{
@@ -150,20 +149,20 @@ func TestClient_AddRecord_error(t *testing.T) {
 		TTL:     600,
 	}
 
-	_, err := client.AddRecord(context.Background(), "example.com", "test", "2565", testRecord)
+	_, err := client.AddRecord(t.Context(), "example.com", "test", "2565", testRecord)
 	require.ErrorIs(t, err, APIError{Code: 402, Status: "error", Message: "Invalid user."})
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "delete-record.json")
 
-	err := client.DeleteRecord(context.Background(), "example.com", "test", "example.com 600 IN TXT txttxttxt", "2374")
+	err := client.DeleteRecord(t.Context(), "example.com", "test", "example.com 600 IN TXT txttxttxt", "2374")
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "error.json")
 
-	err := client.DeleteRecord(context.Background(), "example.com", "test", "example.com 600 IN TXT txttxttxt", "2374")
+	err := client.DeleteRecord(t.Context(), "example.com", "test", "example.com 600 IN TXT txttxttxt", "2374")
 	require.ErrorIs(t, err, APIError{Code: 402, Status: "error", Message: "Invalid user."})
 }

--- a/providers/dns/bunny/bunny.go
+++ b/providers/dns/bunny/bunny.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/providers/dns/internal/ptr"
-	"github.com/miekg/dns"
 	"github.com/nrdcg/bunny-go"
 	"golang.org/x/net/publicsuffix"
 )
@@ -201,14 +200,13 @@ func possibleDomains(domain string) []string {
 	var domains []string
 
 	tld, _ := publicsuffix.PublicSuffix(domain)
-
-	for _, index := range dns.Split(domain) {
-		if tld == domain[index:] {
+	for d := range dns01.DomainsSeq(domain) {
+		if tld == d {
 			// skip the TLD
 			break
 		}
 
-		domains = append(domains, dns01.UnFqdn(domain[index:]))
+		domains = append(domains, dns01.UnFqdn(d))
 	}
 
 	return domains

--- a/providers/dns/bunny/bunny.go
+++ b/providers/dns/bunny/bunny.go
@@ -200,10 +200,9 @@ func findZone(zones *bunny.DNSZones, domain string) *bunny.DNSZone {
 func possibleDomains(domain string) []string {
 	var domains []string
 
-	labelIndexes := dns.Split(domain)
+	tld, _ := publicsuffix.PublicSuffix(domain)
 
-	for _, index := range labelIndexes {
-		tld, _ := publicsuffix.PublicSuffix(domain)
+	for _, index := range dns.Split(domain) {
 		if tld == domain[index:] {
 			// skip the TLD
 			break

--- a/providers/dns/checkdomain/internal/client_test.go
+++ b/providers/dns/checkdomain/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -67,7 +66,7 @@ func TestClient_GetDomainIDByName(t *testing.T) {
 		}
 	})
 
-	id, err := client.GetDomainIDByName(context.Background(), "test.com")
+	id, err := client.GetDomainIDByName(t.Context(), "test.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, id)
@@ -103,7 +102,7 @@ func TestClient_CheckNameservers(t *testing.T) {
 		}
 	})
 
-	err := client.CheckNameservers(context.Background(), 1)
+	err := client.CheckNameservers(t.Context(), 1)
 	require.NoError(t, err)
 }
 
@@ -141,7 +140,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		Value: "value",
 	}
 
-	err := client.CreateRecord(context.Background(), 1, record)
+	err := client.CreateRecord(t.Context(), 1, record)
 	require.NoError(t, err)
 }
 
@@ -256,6 +255,6 @@ func TestClient_DeleteTXTRecord(t *testing.T) {
 	})
 
 	info := dns01.GetChallengeInfo(domainName, "abc")
-	err := client.DeleteTXTRecord(context.Background(), 1, info.EffectiveFQDN, recordValue)
+	err := client.DeleteTXTRecord(t.Context(), 1, info.EffectiveFQDN, recordValue)
 	require.NoError(t, err)
 }

--- a/providers/dns/clouddns/internal/client_test.go
+++ b/providers/dns/clouddns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -62,7 +61,7 @@ func TestClient_AddRecord(t *testing.T) {
 		}
 	})
 
-	err := client.AddRecord(context.Background(), "example.com", "_acme-challenge.example.com", "txt")
+	err := client.AddRecord(t.Context(), "example.com", "_acme-challenge.example.com", "txt")
 	require.NoError(t, err)
 }
 
@@ -124,7 +123,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		}
 	})
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	err = client.DeleteRecord(ctx, "example.com", "_acme-challenge.example.com")

--- a/providers/dns/clouddns/internal/identity_test.go
+++ b/providers/dns/clouddns/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -35,7 +34,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 		}
 	})
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	at := getAccessToken(ctx)

--- a/providers/dns/cloudns/internal/client_test.go
+++ b/providers/dns/cloudns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -134,7 +133,7 @@ func TestClient_GetZone(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			client := setupTest(t, "", handlerMock(http.MethodGet, []byte(test.apiResponse)))
 
-			zone, err := client.GetZone(context.Background(), test.authFQDN)
+			zone, err := client.GetZone(t.Context(), test.authFQDN)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)
@@ -241,7 +240,7 @@ func TestClient_FindTxtRecord(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			client := setupTest(t, "", handlerMock(http.MethodGet, []byte(test.apiResponse)))
 
-			txtRecord, err := client.FindTxtRecord(context.Background(), test.zoneName, test.authFQDN)
+			txtRecord, err := client.FindTxtRecord(t.Context(), test.zoneName, test.authFQDN)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)
@@ -350,7 +349,7 @@ func TestClient_ListTxtRecord(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			client := setupTest(t, "", handlerMock(http.MethodGet, []byte(test.apiResponse)))
 
-			txtRecords, err := client.ListTxtRecords(context.Background(), test.zoneName, test.authFQDN)
+			txtRecords, err := client.ListTxtRecords(t.Context(), test.zoneName, test.authFQDN)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)
@@ -455,7 +454,7 @@ func TestClient_AddTxtRecord(t *testing.T) {
 				handlerMock(http.MethodPost, []byte(test.apiResponse))(rw, req)
 			})
 
-			err := client.AddTxtRecord(context.Background(), test.zoneName, test.authFQDN, test.value, test.ttl)
+			err := client.AddTxtRecord(t.Context(), test.zoneName, test.authFQDN, test.value, test.ttl)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)
@@ -528,7 +527,7 @@ func TestClient_RemoveTxtRecord(t *testing.T) {
 
 			client.BaseURL, _ = url.Parse(server.URL)
 
-			err = client.RemoveTxtRecord(context.Background(), test.id, test.zoneName)
+			err = client.RemoveTxtRecord(t.Context(), test.id, test.zoneName)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)
@@ -598,7 +597,7 @@ func TestClient_GetUpdateStatus(t *testing.T) {
 
 			client.BaseURL, _ = url.Parse(server.URL)
 
-			syncProgress, err := client.GetUpdateStatus(context.Background(), test.zoneName)
+			syncProgress, err := client.GetUpdateStatus(t.Context(), test.zoneName)
 
 			if test.expected.errorMsg != "" {
 				require.EqualError(t, err, test.expected.errorMsg)

--- a/providers/dns/cloudru/internal/client_test.go
+++ b/providers/dns/cloudru/internal/client_test.go
@@ -58,7 +58,7 @@ func writeFixtureHandler(method, filename string) http.HandlerFunc {
 func TestClient_GetZones(t *testing.T) {
 	client := setupTest(t, "/zones", writeFixtureHandler(http.MethodGet, "zones.json"))
 
-	ctx := mockContext()
+	ctx := mockContext(t)
 
 	zones, err := client.GetZones(ctx, "xxx")
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestClient_GetZones(t *testing.T) {
 func TestClient_GetRecords(t *testing.T) {
 	client := setupTest(t, "/zones/zzz/records", writeFixtureHandler(http.MethodGet, "records.json"))
 
-	ctx := mockContext()
+	ctx := mockContext(t)
 
 	records, err := client.GetRecords(ctx, "zzz")
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestClient_GetRecords(t *testing.T) {
 func TestClient_CreateRecord(t *testing.T) {
 	client := setupTest(t, "/zones/zzz/records", writeFixtureHandler(http.MethodPost, "record.json"))
 
-	ctx := mockContext()
+	ctx := mockContext(t)
 
 	recordReq := Record{
 		Name:   "www.example.com.",
@@ -152,7 +152,7 @@ func TestClient_CreateRecord(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/zones/zzz/records/example.com/TXT", writeFixtureHandler(http.MethodDelete, "record.json"))
 
-	ctx := mockContext()
+	ctx := mockContext(t)
 
 	err := client.DeleteRecord(ctx, "zzz", "example.com", "TXT")
 	require.NoError(t, err)

--- a/providers/dns/cloudru/internal/identity_test.go
+++ b/providers/dns/cloudru/internal/identity_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext() context.Context {
-	return context.WithValue(context.Background(), tokenKey, &Token{AccessToken: "xxx"})
+func mockContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return context.WithValue(t.Context(), tokenKey, &Token{AccessToken: "xxx"})
 }
 
 func tokenHandler(rw http.ResponseWriter, req *http.Request) {
@@ -60,7 +62,7 @@ func TestClient_obtainToken(t *testing.T) {
 
 	assert.Nil(t, client.token)
 
-	tok, err := client.obtainToken(context.Background())
+	tok, err := client.obtainToken(t.Context())
 	require.NoError(t, err)
 
 	assert.NotNil(t, tok)
@@ -81,7 +83,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 
 	assert.Nil(t, client.token)
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	tok := getToken(ctx)

--- a/providers/dns/conoha/internal/client.go
+++ b/providers/dns/conoha/internal/client.go
@@ -25,7 +25,7 @@ type Client struct {
 }
 
 // NewClient returns a client instance logged into the ConoHa service.
-func NewClient(region string, token string) (*Client, error) {
+func NewClient(region, token string) (*Client, error) {
 	baseURL, err := url.Parse(fmt.Sprintf(dnsServiceBaseURL, region))
 	if err != nil {
 		return nil, err

--- a/providers/dns/conoha/internal/client_test.go
+++ b/providers/dns/conoha/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,7 +105,7 @@ func TestClient_GetDomainID(t *testing.T) {
 
 			mux.Handle("/v1/domains", test.handler)
 
-			domainID, err := client.GetDomainID(context.Background(), test.domainName)
+			domainID, err := client.GetDomainID(t.Context(), test.domainName)
 
 			if test.expected.error {
 				require.Error(t, err)
@@ -177,7 +176,7 @@ func TestClient_CreateRecord(t *testing.T) {
 				TTL:  300,
 			}
 
-			err := client.CreateRecord(context.Background(), domainID, record)
+			err := client.CreateRecord(t.Context(), domainID, record)
 			test.assert(t, err)
 		})
 	}
@@ -189,7 +188,7 @@ func TestClient_GetRecordID(t *testing.T) {
 	mux.HandleFunc("/v1/domains/89acac79-38e7-497d-807c-a011e1310438/records",
 		writeFixtureHandler(http.MethodGet, "domains-records_GET.json"))
 
-	recordID, err := client.GetRecordID(context.Background(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
+	recordID, err := client.GetRecordID(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
 	require.NoError(t, err)
 
 	assert.Equal(t, "2e32e609-3a4f-45ba-bdef-e50eacd345ad", recordID)
@@ -207,6 +206,6 @@ func TestClient_DeleteRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	})
 
-	err := client.DeleteRecord(context.Background(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
+	err := client.DeleteRecord(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
 	require.NoError(t, err)
 }

--- a/providers/dns/conoha/internal/identity_test.go
+++ b/providers/dns/conoha/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -32,7 +31,7 @@ func TestNewClient(t *testing.T) {
 		},
 	}
 
-	token, err := identifier.GetToken(context.Background(), auth)
+	token, err := identifier.GetToken(t.Context(), auth)
 	require.NoError(t, err)
 
 	expected := &IdentityResponse{Access: Access{Token: Token{ID: "sample00d88246078f2bexample788f7"}}}

--- a/providers/dns/conohav3/internal/client.go
+++ b/providers/dns/conohav3/internal/client.go
@@ -25,7 +25,7 @@ type Client struct {
 }
 
 // NewClient returns a client instance logged into the ConoHa service.
-func NewClient(region string, token string) (*Client, error) {
+func NewClient(region, token string) (*Client, error) {
 	baseURL, err := url.Parse(fmt.Sprintf(dnsServiceBaseURL, region))
 	if err != nil {
 		return nil, err

--- a/providers/dns/conohav3/internal/client_test.go
+++ b/providers/dns/conohav3/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,7 +105,7 @@ func TestClient_GetDomainID(t *testing.T) {
 
 			mux.Handle("/v1/domains", test.handler)
 
-			domainID, err := client.GetDomainID(context.Background(), test.domainName)
+			domainID, err := client.GetDomainID(t.Context(), test.domainName)
 
 			if test.expected.error {
 				require.Error(t, err)
@@ -177,7 +176,7 @@ func TestClient_CreateRecord(t *testing.T) {
 				TTL:  300,
 			}
 
-			err := client.CreateRecord(context.Background(), domainID, record)
+			err := client.CreateRecord(t.Context(), domainID, record)
 			test.assert(t, err)
 		})
 	}
@@ -189,7 +188,7 @@ func TestClient_GetRecordID(t *testing.T) {
 	mux.HandleFunc("/v1/domains/89acac79-38e7-497d-807c-a011e1310438/records",
 		writeFixtureHandler(http.MethodGet, "domains-records_GET.json"))
 
-	recordID, err := client.GetRecordID(context.Background(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
+	recordID, err := client.GetRecordID(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
 	require.NoError(t, err)
 
 	assert.Equal(t, "2e32e609-3a4f-45ba-bdef-e50eacd345ad", recordID)
@@ -207,6 +206,6 @@ func TestClient_DeleteRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	})
 
-	err := client.DeleteRecord(context.Background(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
+	err := client.DeleteRecord(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
 	require.NoError(t, err)
 }

--- a/providers/dns/conohav3/internal/identity_test.go
+++ b/providers/dns/conohav3/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -45,7 +44,7 @@ func TestGetToken_HeaderToken(t *testing.T) {
 		},
 	}
 
-	token, err := identifier.GetToken(context.Background(), auth)
+	token, err := identifier.GetToken(t.Context(), auth)
 	require.NoError(t, err)
 
 	assert.Equal(t, "sample-header-token-123", token)

--- a/providers/dns/constellix/internal/domains_test.go
+++ b/providers/dns/constellix/internal/domains_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +47,7 @@ func TestDomainService_GetAll(t *testing.T) {
 		}
 	})
 
-	data, err := client.Domains.GetAll(context.Background(), nil)
+	data, err := client.Domains.GetAll(t.Context(), nil)
 	require.NoError(t, err)
 
 	expected := []Domain{
@@ -84,7 +83,7 @@ func TestDomainService_Search(t *testing.T) {
 		}
 	})
 
-	data, err := client.Domains.Search(context.Background(), Exact, "lego.wtf")
+	data, err := client.Domains.Search(t.Context(), Exact, "lego.wtf")
 	require.NoError(t, err)
 
 	expected := []Domain{

--- a/providers/dns/constellix/internal/txtrecords_test.go
+++ b/providers/dns/constellix/internal/txtrecords_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -35,7 +34,7 @@ func TestTxtRecordService_Create(t *testing.T) {
 		}
 	})
 
-	records, err := client.TxtRecords.Create(context.Background(), 12345, RecordRequest{})
+	records, err := client.TxtRecords.Create(t.Context(), 12345, RecordRequest{})
 	require.NoError(t, err)
 
 	recordsJSON, err := json.Marshal(records)
@@ -70,7 +69,7 @@ func TestTxtRecordService_GetAll(t *testing.T) {
 		}
 	})
 
-	records, err := client.TxtRecords.GetAll(context.Background(), 12345)
+	records, err := client.TxtRecords.GetAll(t.Context(), 12345)
 	require.NoError(t, err)
 
 	recordsJSON, err := json.Marshal(records)
@@ -105,7 +104,7 @@ func TestTxtRecordService_Get(t *testing.T) {
 		}
 	})
 
-	record, err := client.TxtRecords.Get(context.Background(), 12345, 6789)
+	record, err := client.TxtRecords.Get(t.Context(), 12345, 6789)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -146,7 +145,7 @@ func TestTxtRecordService_Update(t *testing.T) {
 		}
 	})
 
-	msg, err := client.TxtRecords.Update(context.Background(), 12345, 6789, RecordRequest{})
+	msg, err := client.TxtRecords.Update(t.Context(), 12345, 6789, RecordRequest{})
 	require.NoError(t, err)
 
 	expected := &SuccessMessage{Success: "Record  updated successfully"}
@@ -169,7 +168,7 @@ func TestTxtRecordService_Delete(t *testing.T) {
 		}
 	})
 
-	msg, err := client.TxtRecords.Delete(context.Background(), 12345, 6789)
+	msg, err := client.TxtRecords.Delete(t.Context(), 12345, 6789)
 	require.NoError(t, err)
 
 	expected := &SuccessMessage{Success: "Record  deleted successfully"}
@@ -199,7 +198,7 @@ func TestTxtRecordService_Search(t *testing.T) {
 		}
 	})
 
-	records, err := client.TxtRecords.Search(context.Background(), 12345, Exact, "test")
+	records, err := client.TxtRecords.Search(t.Context(), 12345, Exact, "test")
 	require.NoError(t, err)
 
 	recordsJSON, err := json.Marshal(records)

--- a/providers/dns/corenetworks/internal/client_test.go
+++ b/providers/dns/corenetworks/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -92,7 +91,7 @@ func TestClient_CreateAuthenticationToken(t *testing.T) {
 
 	mux.HandleFunc("/auth/token", testHandlerAuth(http.MethodPost, http.StatusOK, "auth.json"))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	token, err := client.CreateAuthenticationToken(ctx)
 	require.NoError(t, err)
@@ -109,7 +108,7 @@ func TestClient_ListZone(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/", testHandler(http.MethodGet, http.StatusOK, "ListZone.json"))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	zones, err := client.ListZone(ctx)
 	require.NoError(t, err)
@@ -127,7 +126,7 @@ func TestClient_GetZoneDetails(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/example.com", testHandler(http.MethodGet, http.StatusOK, "GetZoneDetails.json"))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	zone, err := client.GetZoneDetails(ctx, "example.com")
 	require.NoError(t, err)
@@ -147,7 +146,7 @@ func TestClient_ListRecords(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/example.com/records/", testHandler(http.MethodGet, http.StatusOK, "ListRecords.json"))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	records, err := client.ListRecords(ctx, "example.com")
 	require.NoError(t, err)
@@ -181,7 +180,7 @@ func TestClient_AddRecord(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/example.com/records/", testHandler(http.MethodPost, http.StatusNoContent, ""))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	record := Record{Name: "www", TTL: 3600, Type: "A", Data: "127.0.0.1"}
 
@@ -194,7 +193,7 @@ func TestClient_DeleteRecords(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/example.com/records/delete", testHandler(http.MethodPost, http.StatusNoContent, ""))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	record := Record{Name: "www", Type: "A", Data: "127.0.0.1"}
 
@@ -207,7 +206,7 @@ func TestClient_CommitRecords(t *testing.T) {
 
 	mux.HandleFunc("/dnszones/example.com/records/commit", testHandler(http.MethodPost, http.StatusNoContent, ""))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := client.CommitRecords(ctx, "example.com")
 	require.NoError(t, err)

--- a/providers/dns/cpanel/internal/cpanel/client.go
+++ b/providers/dns/cpanel/internal/cpanel/client.go
@@ -24,7 +24,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(baseURL string, username string, token string) (*Client, error) {
+func NewClient(baseURL, username, token string) (*Client, error) {
 	apiEndpoint, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err

--- a/providers/dns/cpanel/internal/cpanel/client_test.go
+++ b/providers/dns/cpanel/internal/cpanel/client_test.go
@@ -1,7 +1,6 @@
 package cpanel
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +54,7 @@ func setupTest(t *testing.T, pattern, filename string) *Client {
 func TestClient_FetchZoneInformation(t *testing.T) {
 	client := setupTest(t, "/execute/DNS/parse_zone", "zone-info.json")
 
-	zoneInfo, err := client.FetchZoneInformation(context.Background(), "example.com")
+	zoneInfo, err := client.FetchZoneInformation(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []shared.ZoneRecord{{
@@ -73,7 +72,7 @@ func TestClient_FetchZoneInformation(t *testing.T) {
 func TestClient_FetchZoneInformation_error(t *testing.T) {
 	client := setupTest(t, "/execute/DNS/parse_zone", "zone-info_error.json")
 
-	zoneInfo, err := client.FetchZoneInformation(context.Background(), "example.com")
+	zoneInfo, err := client.FetchZoneInformation(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Nil(t, zoneInfo)
@@ -89,7 +88,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.AddRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.AddRecord(t.Context(), 123456, "example.com", record)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -107,7 +106,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.AddRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.AddRecord(t.Context(), 123456, "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)
@@ -124,7 +123,7 @@ func TestClient_EditRecord(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.EditRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.EditRecord(t.Context(), 123456, "example.com", record)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -143,7 +142,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.EditRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.EditRecord(t.Context(), 123456, "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)
@@ -152,7 +151,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/execute/DNS/mass_edit_zone", "update-zone.json")
 
-	zoneSerial, err := client.DeleteRecord(context.Background(), 123456, "example.com", 0)
+	zoneSerial, err := client.DeleteRecord(t.Context(), 123456, "example.com", 0)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -163,7 +162,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/execute/DNS/mass_edit_zone", "update-zone_error.json")
 
-	zoneSerial, err := client.DeleteRecord(context.Background(), 123456, "example.com", 0)
+	zoneSerial, err := client.DeleteRecord(t.Context(), 123456, "example.com", 0)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)

--- a/providers/dns/cpanel/internal/cpanel/client_test.go
+++ b/providers/dns/cpanel/internal/cpanel/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTest(t *testing.T, pattern string, filename string) *Client {
+func setupTest(t *testing.T, pattern, filename string) *Client {
 	t.Helper()
 
 	mux := http.NewServeMux()

--- a/providers/dns/cpanel/internal/whm/client.go
+++ b/providers/dns/cpanel/internal/whm/client.go
@@ -24,7 +24,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(baseURL string, username string, token string) (*Client, error) {
+func NewClient(baseURL, username, token string) (*Client, error) {
 	apiEndpoint, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err

--- a/providers/dns/cpanel/internal/whm/client_test.go
+++ b/providers/dns/cpanel/internal/whm/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTest(t *testing.T, pattern string, filename string) *Client {
+func setupTest(t *testing.T, pattern, filename string) *Client {
 	t.Helper()
 
 	mux := http.NewServeMux()

--- a/providers/dns/cpanel/internal/whm/client_test.go
+++ b/providers/dns/cpanel/internal/whm/client_test.go
@@ -1,7 +1,6 @@
 package whm
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +54,7 @@ func setupTest(t *testing.T, pattern, filename string) *Client {
 func TestClient_FetchZoneInformation(t *testing.T) {
 	client := setupTest(t, "/json-api/parse_dns_zone", "zone-info.json")
 
-	zoneInfo, err := client.FetchZoneInformation(context.Background(), "example.com")
+	zoneInfo, err := client.FetchZoneInformation(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []shared.ZoneRecord{{
@@ -73,7 +72,7 @@ func TestClient_FetchZoneInformation(t *testing.T) {
 func TestClient_FetchZoneInformation_error(t *testing.T) {
 	client := setupTest(t, "/json-api/parse_dns_zone", "zone-info_error.json")
 
-	zoneInfo, err := client.FetchZoneInformation(context.Background(), "example.com")
+	zoneInfo, err := client.FetchZoneInformation(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Nil(t, zoneInfo)
@@ -89,7 +88,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.AddRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.AddRecord(t.Context(), 123456, "example.com", record)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -107,7 +106,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.AddRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.AddRecord(t.Context(), 123456, "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)
@@ -124,7 +123,7 @@ func TestClient_EditRecord(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.EditRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.EditRecord(t.Context(), 123456, "example.com", record)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -143,7 +142,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 		Data:       []string{"string1", "string2"},
 	}
 
-	zoneSerial, err := client.EditRecord(context.Background(), 123456, "example.com", record)
+	zoneSerial, err := client.EditRecord(t.Context(), 123456, "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)
@@ -152,7 +151,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/json-api/mass_edit_dns_zone", "update-zone.json")
 
-	zoneSerial, err := client.DeleteRecord(context.Background(), 123456, "example.com", 0)
+	zoneSerial, err := client.DeleteRecord(t.Context(), 123456, "example.com", 0)
 	require.NoError(t, err)
 
 	expected := &shared.ZoneSerial{NewSerial: "2021031903"}
@@ -163,7 +162,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/json-api/mass_edit_dns_zone", "update-zone_error.json")
 
-	zoneSerial, err := client.DeleteRecord(context.Background(), 123456, "example.com", 0)
+	zoneSerial, err := client.DeleteRecord(t.Context(), 123456, "example.com", 0)
 	require.Error(t, err)
 
 	assert.Nil(t, zoneSerial)

--- a/providers/dns/derak/internal/client.go
+++ b/providers/dns/derak/internal/client.go
@@ -61,7 +61,7 @@ func (c Client) GetRecords(ctx context.Context, zoneID string, params *GetRecord
 }
 
 // GetRecord gets a record by ID.
-func (c Client) GetRecord(ctx context.Context, zoneID string, recordID string) (*Record, error) {
+func (c Client) GetRecord(ctx context.Context, zoneID, recordID string) (*Record, error) {
 	endpoint := c.baseURL.JoinPath("zones", zoneID, "dnsrecords", recordID)
 
 	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
@@ -97,7 +97,7 @@ func (c Client) CreateRecord(ctx context.Context, zoneID string, record Record) 
 }
 
 // EditRecord edits an existing record.
-func (c Client) EditRecord(ctx context.Context, zoneID string, recordID string, record Record) (*Record, error) {
+func (c Client) EditRecord(ctx context.Context, zoneID, recordID string, record Record) (*Record, error) {
 	endpoint := c.baseURL.JoinPath("zones", zoneID, "dnsrecords", recordID)
 
 	req, err := newJSONRequest(ctx, http.MethodPatch, endpoint, record)
@@ -115,7 +115,7 @@ func (c Client) EditRecord(ctx context.Context, zoneID string, recordID string, 
 }
 
 // DeleteRecord deletes an existing record.
-func (c Client) DeleteRecord(ctx context.Context, zoneID string, recordID string) error {
+func (c Client) DeleteRecord(ctx context.Context, zoneID, recordID string) error {
 	endpoint := c.baseURL.JoinPath("zones", zoneID, "dnsrecords", recordID)
 
 	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)

--- a/providers/dns/derak/internal/client_test.go
+++ b/providers/dns/derak/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,7 +76,7 @@ func TestGetRecords(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords",
 		testHandler(http.MethodGet, http.StatusOK, "records-GET.json"))
 
-	records, err := client.GetRecords(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", &GetRecordsParameters{DNSType: "TXT", Content: `"test"'`})
+	records, err := client.GetRecords(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", &GetRecordsParameters{DNSType: "TXT", Content: `"test"'`})
 	require.NoError(t, err)
 
 	excepted := &GetRecordsResponse{Data: []Record{
@@ -140,7 +139,7 @@ func TestGetRecords_error(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords",
 		testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetRecords(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", &GetRecordsParameters{DNSType: "TXT", Content: `"test"'`})
+	_, err := client.GetRecords(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", &GetRecordsParameters{DNSType: "TXT", Content: `"test"'`})
 	require.Error(t, err)
 }
 
@@ -150,7 +149,7 @@ func TestGetRecord(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/812bee17a0b440b0bd5ee099a78b839c",
 		testHandler(http.MethodGet, http.StatusOK, "record-GET.json"))
 
-	record, err := client.GetRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "812bee17a0b440b0bd5ee099a78b839c")
+	record, err := client.GetRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "812bee17a0b440b0bd5ee099a78b839c")
 	require.NoError(t, err)
 
 	excepted := &Record{
@@ -169,7 +168,7 @@ func TestGetRecord_error(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/812bee17a0b440b0bd5ee099a78b839c",
 		testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "812bee17a0b440b0bd5ee099a78b839c")
+	_, err := client.GetRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "812bee17a0b440b0bd5ee099a78b839c")
 	require.Error(t, err)
 }
 
@@ -186,7 +185,7 @@ func TestCreateRecord(t *testing.T) {
 		TTL:     120,
 	}
 
-	record, err := client.CreateRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", r)
+	record, err := client.CreateRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", r)
 	require.NoError(t, err)
 
 	excepted := &Record{
@@ -212,7 +211,7 @@ func TestCreateRecord_error(t *testing.T) {
 		TTL:     120,
 	}
 
-	_, err := client.CreateRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", r)
+	_, err := client.CreateRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", r)
 	require.Error(t, err)
 }
 
@@ -222,7 +221,7 @@ func TestEditRecord(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/eebc813de2f94d67b09d91e10e2d65c2",
 		testHandler(http.MethodPatch, http.StatusOK, "record-PATCH.json"))
 
-	record, err := client.EditRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "eebc813de2f94d67b09d91e10e2d65c2", Record{
+	record, err := client.EditRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "eebc813de2f94d67b09d91e10e2d65c2", Record{
 		Content: "foo",
 	})
 	require.NoError(t, err)
@@ -243,7 +242,7 @@ func TestEditRecord_error(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/eebc813de2f94d67b09d91e10e2d65c2",
 		testHandler(http.MethodPatch, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.EditRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "eebc813de2f94d67b09d91e10e2d65c2", Record{
+	_, err := client.EditRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "eebc813de2f94d67b09d91e10e2d65c2", Record{
 		Content: "foo",
 	})
 	require.Error(t, err)
@@ -255,7 +254,7 @@ func TestDeleteRecord(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/653464211b7447a1bee6b8fcb9fb86df",
 		testHandler(http.MethodDelete, http.StatusOK, "record-DELETE.json"))
 
-	err := client.DeleteRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "653464211b7447a1bee6b8fcb9fb86df")
+	err := client.DeleteRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "653464211b7447a1bee6b8fcb9fb86df")
 	require.NoError(t, err)
 }
 
@@ -265,7 +264,7 @@ func TestDeleteRecord_error(t *testing.T) {
 	mux.HandleFunc("/zones/47c0ecf6c91243308c649ad1d2d618dd/dnsrecords/653464211b7447a1bee6b8fcb9fb86df",
 		testHandler(http.MethodDelete, http.StatusUnauthorized, "error.json"))
 
-	err := client.DeleteRecord(context.Background(), "47c0ecf6c91243308c649ad1d2d618dd", "653464211b7447a1bee6b8fcb9fb86df")
+	err := client.DeleteRecord(t.Context(), "47c0ecf6c91243308c649ad1d2d618dd", "653464211b7447a1bee6b8fcb9fb86df")
 	require.Error(t, err)
 }
 
@@ -274,7 +273,7 @@ func TestGetZones(t *testing.T) {
 
 	mux.HandleFunc("/", testHandler(http.MethodGet, http.StatusOK, "service-cdn-zones.json"))
 
-	zones, err := client.GetZones(context.Background())
+	zones, err := client.GetZones(t.Context())
 	require.NoError(t, err)
 
 	excepted := []Zone{{
@@ -307,6 +306,6 @@ func TestGetZones_error(t *testing.T) {
 
 	mux.HandleFunc("/", testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetZones(context.Background())
+	_, err := client.GetZones(t.Context())
 	require.Error(t, err)
 }

--- a/providers/dns/digitalocean/internal/client_test.go
+++ b/providers/dns/digitalocean/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -98,7 +97,7 @@ func TestClient_AddTxtRecord(t *testing.T) {
 		TTL:  30,
 	}
 
-	newRecord, err := client.AddTxtRecord(context.Background(), "example.com", record)
+	newRecord, err := client.AddTxtRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &TxtRecordResponse{DomainRecord: Record{
@@ -134,6 +133,6 @@ func TestClient_RemoveTxtRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.RemoveTxtRecord(context.Background(), "example.com", 1234567)
+	err := client.RemoveTxtRecord(t.Context(), "example.com", 1234567)
 	require.NoError(t, err)
 }

--- a/providers/dns/directadmin/internal/client_test.go
+++ b/providers/dns/directadmin/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -92,7 +91,7 @@ func TestClient_SetRecord(t *testing.T) {
 		TTL:   123,
 	}
 
-	err := client.SetRecord(context.Background(), "example.com", record)
+	err := client.SetRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -110,7 +109,7 @@ func TestClient_SetRecord_error(t *testing.T) {
 		TTL:   123,
 	}
 
-	err := client.SetRecord(context.Background(), "example.com", record)
+	err := client.SetRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "[status code 500] Cannot View Dns Record: OOPS")
 }
 
@@ -133,7 +132,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		Value: "txtTXTtxt",
 	}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -150,6 +149,6 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		Value: "txtTXTtxt",
 	}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "[status code 500] Cannot View Dns Record: OOPS")
 }

--- a/providers/dns/dnshomede/dnshomede.go
+++ b/providers/dns/dnshomede/dnshomede.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -62,9 +61,9 @@ func NewDNSProvider() (*DNSProvider, error) {
 		return nil, fmt.Errorf("dnshomede: %w", err)
 	}
 
-	credentials, err := parseCredentials(values[EnvCredentials])
+	credentials, err := env.ParsePairs(values[EnvCredentials])
 	if err != nil {
-		return nil, fmt.Errorf("dnshomede: %w", err)
+		return nil, fmt.Errorf("dnshomede: credentials: %w", err)
 	}
 
 	config.Credentials = credentials
@@ -130,19 +129,4 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 // Returns the interval between each iteration.
 func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
-}
-
-func parseCredentials(raw string) (map[string]string, error) {
-	credentials := make(map[string]string)
-
-	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
-		data := strings.Split(credPair, ":")
-		if len(data) != 2 {
-			return nil, fmt.Errorf("invalid credential pair: %q", credPair)
-		}
-
-		credentials[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
-	}
-
-	return credentials, nil
 }

--- a/providers/dns/dnshomede/dnshomede.go
+++ b/providers/dns/dnshomede/dnshomede.go
@@ -135,8 +135,7 @@ func (d *DNSProvider) Sequential() time.Duration {
 func parseCredentials(raw string) (map[string]string, error) {
 	credentials := make(map[string]string)
 
-	credStrings := strings.Split(strings.TrimSuffix(raw, ","), ",")
-	for _, credPair := range credStrings {
+	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
 		data := strings.Split(credPair, ":")
 		if len(data) != 2 {
 			return nil, fmt.Errorf("invalid credential pair: %q", credPair)

--- a/providers/dns/dnshomede/dnshomede_test.go
+++ b/providers/dns/dnshomede/dnshomede_test.go
@@ -34,7 +34,7 @@ func TestNewDNSProvider(t *testing.T) {
 			envVars: map[string]string{
 				EnvCredentials: ",",
 			},
-			expected: `dnshomede: invalid credential pair: ""`,
+			expected: `dnshomede: credentials: incorrect pair: `,
 		},
 		{
 			desc: "missing password",
@@ -55,7 +55,7 @@ func TestNewDNSProvider(t *testing.T) {
 			envVars: map[string]string{
 				EnvCredentials: "example.org:123,example.net",
 			},
-			expected: `dnshomede: invalid credential pair: "example.net"`,
+			expected: "dnshomede: credentials: incorrect pair: example.net",
 		},
 		{
 			desc: "missing credentials",

--- a/providers/dns/dnshomede/internal/client_test.go
+++ b/providers/dns/dnshomede/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +30,7 @@ func TestClient_Add(t *testing.T) {
 
 	client := setupTest(t, map[string]string{"example.org": "secret"}, handlerMock(addAction, txtValue))
 
-	err := client.Add(context.Background(), "example.org", txtValue)
+	err := client.Add(t.Context(), "example.org", txtValue)
 	require.NoError(t, err)
 }
 
@@ -40,7 +39,7 @@ func TestClient_Add_error(t *testing.T) {
 
 	client := setupTest(t, map[string]string{"example.com": "secret"}, handlerMock(addAction, txtValue))
 
-	err := client.Add(context.Background(), "example.org", txtValue)
+	err := client.Add(t.Context(), "example.org", txtValue)
 	require.Error(t, err)
 }
 
@@ -49,7 +48,7 @@ func TestClient_Remove(t *testing.T) {
 
 	client := setupTest(t, map[string]string{"example.org": "secret"}, handlerMock(removeAction, txtValue))
 
-	err := client.Remove(context.Background(), "example.org", txtValue)
+	err := client.Remove(t.Context(), "example.org", txtValue)
 	require.NoError(t, err)
 }
 
@@ -58,7 +57,7 @@ func TestClient_Remove_error(t *testing.T) {
 
 	client := setupTest(t, map[string]string{"example.com": "secret"}, handlerMock(removeAction, txtValue))
 
-	err := client.Remove(context.Background(), "example.org", txtValue)
+	err := client.Remove(t.Context(), "example.org", txtValue)
 	require.Error(t, err)
 }
 

--- a/providers/dns/dode/internal/client_test.go
+++ b/providers/dns/dode/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,13 +80,13 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestClient_UpdateTxtRecord(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/letsencrypt", http.StatusOK, "success.json")
 
-	err := client.UpdateTxtRecord(context.Background(), "example.com.", "value", false)
+	err := client.UpdateTxtRecord(t.Context(), "example.com.", "value", false)
 	require.NoError(t, err)
 }
 
 func TestClient_UpdateTxtRecord_clear(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/letsencrypt", http.StatusOK, "success.json")
 
-	err := client.UpdateTxtRecord(context.Background(), "example.com.", "value", true)
+	err := client.UpdateTxtRecord(t.Context(), "example.com.", "value", true)
 	require.NoError(t, err)
 }

--- a/providers/dns/domeneshop/internal/client.go
+++ b/providers/dns/domeneshop/internal/client.go
@@ -72,7 +72,7 @@ func (c *Client) GetDomainByName(ctx context.Context, domain string) (*Domain, e
 
 // CreateTXTRecord creates a TXT record with the provided host (subdomain) and data.
 // https://api.domeneshop.no/docs/#tag/dns/paths/~1domains~1{domainId}~1dns/post
-func (c *Client) CreateTXTRecord(ctx context.Context, domain *Domain, host string, data string) error {
+func (c *Client) CreateTXTRecord(ctx context.Context, domain *Domain, host, data string) error {
 	endpoint := c.baseURL.JoinPath("domains", strconv.Itoa(domain.ID), "dns")
 
 	record := DNSRecord{
@@ -92,7 +92,7 @@ func (c *Client) CreateTXTRecord(ctx context.Context, domain *Domain, host strin
 
 // DeleteTXTRecord deletes the DNS record matching the provided host and data.
 // https://api.domeneshop.no/docs/#tag/dns/paths/~1domains~1{domainId}~1dns~1{recordId}/delete
-func (c *Client) DeleteTXTRecord(ctx context.Context, domain *Domain, host string, data string) error {
+func (c *Client) DeleteTXTRecord(ctx context.Context, domain *Domain, host, data string) error {
 	record, err := c.getDNSRecordByHostData(ctx, *domain, host, data)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (c *Client) DeleteTXTRecord(ctx context.Context, domain *Domain, host strin
 
 // getDNSRecordByHostData finds the first matching DNS record with the provided host and data.
 // https://api.domeneshop.no/docs/#operation/getDnsRecords
-func (c *Client) getDNSRecordByHostData(ctx context.Context, domain Domain, host string, data string) (*DNSRecord, error) {
+func (c *Client) getDNSRecordByHostData(ctx context.Context, domain Domain, host, data string) (*DNSRecord, error) {
 	endpoint := c.baseURL.JoinPath("domains", strconv.Itoa(domain.ID), "dns")
 
 	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)

--- a/providers/dns/domeneshop/internal/client_test.go
+++ b/providers/dns/domeneshop/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -45,7 +44,7 @@ func TestClient_CreateTXTRecord(t *testing.T) {
 		_, _ = rw.Write([]byte(`{"id": 1}`))
 	})
 
-	err := client.CreateTXTRecord(context.Background(), &Domain{ID: 1}, "example", "txtTXTtxt")
+	err := client.CreateTXTRecord(t.Context(), &Domain{ID: 1}, "example", "txtTXTtxt")
 	require.NoError(t, err)
 }
 
@@ -88,7 +87,7 @@ func TestClient_DeleteTXTRecord(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteTXTRecord(context.Background(), &Domain{ID: 1}, "example.com", "txtTXTtxt")
+	err := client.DeleteTXTRecord(t.Context(), &Domain{ID: 1}, "example.com", "txtTXTtxt")
 	require.NoError(t, err)
 }
 
@@ -118,7 +117,7 @@ func TestClient_getDNSRecordByHostData(t *testing.T) {
 ]`))
 	})
 
-	record, err := client.getDNSRecordByHostData(context.Background(), Domain{ID: 1}, "example.com", "txtTXTtxt")
+	record, err := client.getDNSRecordByHostData(t.Context(), Domain{ID: 1}, "example.com", "txtTXTtxt")
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
@@ -171,7 +170,7 @@ func TestClient_GetDomainByName(t *testing.T) {
 ]`))
 	})
 
-	domain, err := client.GetDomainByName(context.Background(), "example.com")
+	domain, err := client.GetDomainByName(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := &Domain{

--- a/providers/dns/dyn/internal/client.go
+++ b/providers/dns/dyn/internal/client.go
@@ -28,7 +28,7 @@ type Client struct {
 }
 
 // NewClient Creates a new Client.
-func NewClient(customerName string, username string, password string) *Client {
+func NewClient(customerName, username, password string) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{

--- a/providers/dns/dyn/internal/client_test.go
+++ b/providers/dns/dyn/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,20 +102,20 @@ func unauthenticatedHandler(method string, status int, file string) http.Handler
 func TestClient_Publish(t *testing.T) {
 	client := setupTest(t, "/Zone/example.com", unauthenticatedHandler(http.MethodPut, http.StatusOK, "publish.json"))
 
-	err := client.Publish(context.Background(), "example.com", "my message")
+	err := client.Publish(t.Context(), "example.com", "my message")
 	require.NoError(t, err)
 }
 
 func TestClient_AddTXTRecord(t *testing.T) {
 	client := setupTest(t, "/TXTRecord/example.com/example.com.", unauthenticatedHandler(http.MethodPost, http.StatusCreated, "create-txt-record.json"))
 
-	err := client.AddTXTRecord(context.Background(), "example.com", "example.com.", "txt", 120)
+	err := client.AddTXTRecord(t.Context(), "example.com", "example.com.", "txt", 120)
 	require.NoError(t, err)
 }
 
 func TestClient_RemoveTXTRecord(t *testing.T) {
 	client := setupTest(t, "/TXTRecord/example.com/example.com.", unauthenticatedHandler(http.MethodDelete, http.StatusOK, ""))
 
-	err := client.RemoveTXTRecord(context.Background(), "example.com", "example.com.")
+	err := client.RemoveTXTRecord(t.Context(), "example.com", "example.com.")
 	require.NoError(t, err)
 }

--- a/providers/dns/dyn/internal/session_test.go
+++ b/providers/dns/dyn/internal/session_test.go
@@ -9,14 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext() context.Context {
-	return context.WithValue(context.Background(), tokenKey, "tok")
+func mockContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return context.WithValue(t.Context(), tokenKey, "tok")
 }
 
 func TestClient_login(t *testing.T) {
 	client := setupTest(t, "/Session", unauthenticatedHandler(http.MethodPost, http.StatusOK, "login.json"))
 
-	sess, err := client.login(context.Background())
+	sess, err := client.login(t.Context())
 	require.NoError(t, err)
 
 	expected := session{Token: "tok", Version: "456"}
@@ -27,14 +29,14 @@ func TestClient_login(t *testing.T) {
 func TestClient_Logout(t *testing.T) {
 	client := setupTest(t, "/Session", authenticatedHandler(http.MethodDelete, http.StatusOK, ""))
 
-	err := client.Logout(mockContext())
+	err := client.Logout(mockContext(t))
 	require.NoError(t, err)
 }
 
 func TestClient_CreateAuthenticatedContext(t *testing.T) {
 	client := setupTest(t, "/Session", unauthenticatedHandler(http.MethodPost, http.StatusOK, "login.json"))
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	at := getToken(ctx)

--- a/providers/dns/dyndnsfree/internal/client_test.go
+++ b/providers/dns/dyndnsfree/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,13 +45,13 @@ func setupTest(t *testing.T, message string) *Client {
 func TestAddTXTRecord(t *testing.T) {
 	client := setupTest(t, "success")
 
-	err := client.AddTXTRecord(context.Background(), "example.com", "sub.example.com", "value")
+	err := client.AddTXTRecord(t.Context(), "example.com", "sub.example.com", "value")
 	require.NoError(t, err)
 }
 
 func TestAddTXTRecord_error(t *testing.T) {
 	client := setupTest(t, "error: authentification failed")
 
-	err := client.AddTXTRecord(context.Background(), "example.com", "sub.example.com", "value")
+	err := client.AddTXTRecord(t.Context(), "example.com", "sub.example.com", "value")
 	require.EqualError(t, err, "error: authentification failed")
 }

--- a/providers/dns/dynu/internal/client_test.go
+++ b/providers/dns/dynu/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -97,7 +96,7 @@ func TestGetRootDomain(t *testing.T) {
 
 			client := setupTest(t, http.MethodGet, test.pattern, test.status, test.file)
 
-			domain, err := client.GetRootDomain(context.Background(), "test.lego.freeddns.org")
+			domain, err := client.GetRootDomain(t.Context(), "test.lego.freeddns.org")
 
 			if test.expected.error != "" {
 				assert.EqualError(t, err, test.expected.error)
@@ -185,7 +184,7 @@ func TestGetRecords(t *testing.T) {
 
 			client := setupTest(t, http.MethodGet, test.pattern, test.status, test.file)
 
-			records, err := client.GetRecords(context.Background(), "_acme-challenge.lego.freeddns.org", "TXT")
+			records, err := client.GetRecords(t.Context(), "_acme-challenge.lego.freeddns.org", "TXT")
 
 			if test.expected.error != "" {
 				assert.EqualError(t, err, test.expected.error)
@@ -245,7 +244,7 @@ func TestAddNewRecord(t *testing.T) {
 				TTL:        300,
 			}
 
-			err := client.AddNewRecord(context.Background(), 9007481, record)
+			err := client.AddNewRecord(t.Context(), 9007481, record)
 
 			if test.expected.error != "" {
 				assert.EqualError(t, err, test.expected.error)
@@ -292,7 +291,7 @@ func TestDeleteRecord(t *testing.T) {
 
 			client := setupTest(t, http.MethodDelete, test.pattern, test.status, test.file)
 
-			err := client.DeleteRecord(context.Background(), 9007481, 6041418)
+			err := client.DeleteRecord(t.Context(), 9007481, 6041418)
 
 			if test.expected.error != "" {
 				assert.EqualError(t, err, test.expected.error)

--- a/providers/dns/easydns/internal/client.go
+++ b/providers/dns/easydns/internal/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // NewClient Creates a new Client.
-func NewClient(token string, key string) *Client {
+func NewClient(token, key string) *Client {
 	baseURL, _ := url.Parse(DefaultBaseURL)
 
 	return &Client{

--- a/providers/dns/easydns/internal/client_test.go
+++ b/providers/dns/easydns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,7 +69,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestClient_ListZones(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/zones/records/all/example.com", http.StatusOK, "list-zone.json")
 
-	zones, err := client.ListZones(context.Background(), "example.com")
+	zones, err := client.ListZones(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []ZoneRecord{{
@@ -90,7 +89,7 @@ func TestClient_ListZones(t *testing.T) {
 func TestClient_ListZones_error(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/zones/records/all/example.com", http.StatusOK, "error1.json")
 
-	_, err := client.ListZones(context.Background(), "example.com")
+	_, err := client.ListZones(t.Context(), "example.com")
 	require.EqualError(t, err, "code 420: Enhance Your Calm. Rate limit exceeded (too many requests) OR you did NOT provide any credentials with your request!")
 }
 
@@ -106,7 +105,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Priority: "0",
 	}
 
-	recordID, err := client.AddRecord(context.Background(), "example.com", record)
+	recordID, err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	assert.Equal(t, "xxx", recordID)
@@ -124,13 +123,13 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Priority: "0",
 	}
 
-	_, err := client.AddRecord(context.Background(), "example.com", record)
+	_, err := client.AddRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "code 420: Enhance Your Calm. Rate limit exceeded (too many requests) OR you did NOT provide any credentials with your request!")
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/zones/records/example.com/xxx", http.StatusOK, "")
 
-	err := client.DeleteRecord(context.Background(), "example.com", "xxx")
+	err := client.DeleteRecord(t.Context(), "example.com", "xxx")
 	require.NoError(t, err)
 }

--- a/providers/dns/efficientip/internal/client.go
+++ b/providers/dns/efficientip/internal/client.go
@@ -22,7 +22,7 @@ type Client struct {
 	password string
 }
 
-func NewClient(hostname string, username string, password string) *Client {
+func NewClient(hostname, username, password string) *Client {
 	baseURL, _ := url.Parse(fmt.Sprintf("https://%s/rest/", hostname))
 
 	return &Client{

--- a/providers/dns/efficientip/internal/client_test.go
+++ b/providers/dns/efficientip/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,7 +71,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestListRecords(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns_rr_list", http.StatusOK, "dns_rr_list.json")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	records, err := client.ListRecords(ctx)
 	require.NoError(t, err)
@@ -339,7 +338,7 @@ func TestListRecords(t *testing.T) {
 func TestGetRecord(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns_rr_info", http.StatusOK, "dns_rr_info.json")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	record, err := client.GetRecord(ctx, "239")
 	require.NoError(t, err)
@@ -386,7 +385,7 @@ func TestGetRecord(t *testing.T) {
 func TestAddRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns_rr_add", http.StatusCreated, "dns_rr_add.json")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	r := ResourceRecord{
 		RRName:      "test.example.com",
@@ -407,7 +406,7 @@ func TestAddRecord(t *testing.T) {
 func TestDeleteRecord(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns_rr_delete", http.StatusOK, "dns_rr_delete.json")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resp, err := client.DeleteRecord(ctx, DeleteInputParameters{RRID: "251"})
 	require.NoError(t, err)
@@ -420,7 +419,7 @@ func TestDeleteRecord(t *testing.T) {
 func TestDeleteRecord_error(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns_rr_delete", http.StatusBadRequest, "dns_rr_delete-error.json")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := client.DeleteRecord(ctx, DeleteInputParameters{RRID: "251"})
 	require.ErrorAs(t, err, &APIError{})

--- a/providers/dns/epik/internal/client.go
+++ b/providers/dns/epik/internal/client.go
@@ -77,7 +77,7 @@ func (c Client) CreateHostRecord(ctx context.Context, domain string, record Reco
 
 // RemoveHostRecord removes a record for a domain.
 // https://docs.userapi.epik.com/v2/#/DNS%20Host%20Records/removeHostRecord
-func (c Client) RemoveHostRecord(ctx context.Context, domain string, recordID string) (*Data, error) {
+func (c Client) RemoveHostRecord(ctx context.Context, domain, recordID string) (*Data, error) {
 	params := url.Values{}
 	params.Set("ID", recordID)
 

--- a/providers/dns/epik/internal/client_test.go
+++ b/providers/dns/epik/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,7 +33,7 @@ func TestClient_GetDNSRecords(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/records", testHandler(http.MethodGet, http.StatusOK, "getDnsRecord.json"))
 
-	records, err := client.GetDNSRecords(context.Background(), "example.com")
+	records, err := client.GetDNSRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -93,7 +92,7 @@ func TestClient_GetDNSRecords_error(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/records", testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetDNSRecords(context.Background(), "example.com")
+	_, err := client.GetDNSRecords(t.Context(), "example.com")
 	require.Error(t, err)
 }
 
@@ -110,7 +109,7 @@ func TestClient_CreateHostRecord(t *testing.T) {
 		TTL:  300,
 	}
 
-	data, err := client.CreateHostRecord(context.Background(), "example.com", record)
+	data, err := client.CreateHostRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &Data{
@@ -134,7 +133,7 @@ func TestClient_CreateHostRecord_error(t *testing.T) {
 		TTL:  300,
 	}
 
-	_, err := client.CreateHostRecord(context.Background(), "example.com", record)
+	_, err := client.CreateHostRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 }
 
@@ -143,7 +142,7 @@ func TestClient_RemoveHostRecord(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/records", testHandler(http.MethodDelete, http.StatusOK, "removeHostRecord.json"))
 
-	data, err := client.RemoveHostRecord(context.Background(), "example.com", "abc123")
+	data, err := client.RemoveHostRecord(t.Context(), "example.com", "abc123")
 	require.NoError(t, err)
 
 	expected := &Data{
@@ -159,7 +158,7 @@ func TestClient_RemoveHostRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/records", testHandler(http.MethodDelete, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.RemoveHostRecord(context.Background(), "example.com", "abc123")
+	_, err := client.RemoveHostRecord(t.Context(), "example.com", "abc123")
 	require.Error(t, err)
 }
 

--- a/providers/dns/exec/log_mock_test.go
+++ b/providers/dns/exec/log_mock_test.go
@@ -6,26 +6,26 @@ type LogRecorder struct {
 	mock.Mock
 }
 
-func (*LogRecorder) Fatal(args ...interface{}) {
+func (*LogRecorder) Fatal(args ...any) {
 	panic("implement me")
 }
 
-func (*LogRecorder) Fatalln(args ...interface{}) {
+func (*LogRecorder) Fatalln(args ...any) {
 	panic("implement me")
 }
 
-func (*LogRecorder) Fatalf(format string, args ...interface{}) {
+func (*LogRecorder) Fatalf(format string, args ...any) {
 	panic("implement me")
 }
 
-func (*LogRecorder) Print(args ...interface{}) {
+func (*LogRecorder) Print(args ...any) {
 	panic("implement me")
 }
 
-func (l *LogRecorder) Println(args ...interface{}) {
+func (l *LogRecorder) Println(args ...any) {
 	l.Called(args...)
 }
 
-func (*LogRecorder) Printf(format string, args ...interface{}) {
+func (*LogRecorder) Printf(format string, args ...any) {
 	panic("implement me")
 }

--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -207,7 +207,7 @@ func (d *DNSProvider) findExistingZone(zoneName string) (*egoscale.DNSDomain, er
 
 // findExistingRecordID Query Exoscale to find an existing record for this name.
 // Returns empty result if no record could be found.
-func (d *DNSProvider) findExistingRecordID(zoneID egoscale.UUID, recordName string, value string) (egoscale.UUID, error) {
+func (d *DNSProvider) findExistingRecordID(zoneID egoscale.UUID, recordName, value string) (egoscale.UUID, error) {
 	ctx := context.Background()
 
 	records, err := d.client.ListDNSDomainRecords(ctx, zoneID)

--- a/providers/dns/f5xc/internal/client.go
+++ b/providers/dns/f5xc/internal/client.go
@@ -27,7 +27,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(apiToken string, tenantName string) (*Client, error) {
+func NewClient(apiToken, tenantName string) (*Client, error) {
 	if apiToken == "" {
 		return nil, errors.New("credentials missing")
 	}

--- a/providers/dns/f5xc/internal/client_test.go
+++ b/providers/dns/f5xc/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -64,7 +63,7 @@ func TestClient_Create(t *testing.T) {
 		},
 	}
 
-	result, err := client.CreateRRSet(context.Background(), "example.com", "groupA", rrSet)
+	result, err := client.CreateRRSet(t.Context(), "example.com", "groupA", rrSet)
 	require.NoError(t, err)
 
 	expected := &APIRRSet{
@@ -94,14 +93,14 @@ func TestClient_Create_error(t *testing.T) {
 		},
 	}
 
-	_, err := client.CreateRRSet(context.Background(), "example.com", "groupA", rrSet)
+	_, err := client.CreateRRSet(t.Context(), "example.com", "groupA", rrSet)
 	require.Error(t, err)
 }
 
 func TestClient_Get(t *testing.T) {
 	client := setupTest(t, "GET /api/config/dns/namespaces/system/dns_zones/example.com/rrsets/groupA/www/TXT", http.StatusOK, "get.json")
 
-	result, err := client.GetRRSet(context.Background(), "example.com", "groupA", "www", "TXT")
+	result, err := client.GetRRSet(t.Context(), "example.com", "groupA", "www", "TXT")
 	require.NoError(t, err)
 
 	expected := &APIRRSet{
@@ -125,7 +124,7 @@ func TestClient_Get(t *testing.T) {
 func TestClient_Get_not_found(t *testing.T) {
 	client := setupTest(t, "GET /api/config/dns/namespaces/system/dns_zones/example.com/rrsets/groupA/www/TXT", http.StatusNotFound, "error_404.json")
 
-	result, err := client.GetRRSet(context.Background(), "example.com", "groupA", "www", "TXT")
+	result, err := client.GetRRSet(t.Context(), "example.com", "groupA", "www", "TXT")
 	require.NoError(t, err)
 
 	assert.Nil(t, result)
@@ -134,14 +133,14 @@ func TestClient_Get_not_found(t *testing.T) {
 func TestClient_Get_error(t *testing.T) {
 	client := setupTest(t, "GET /api/config/dns/namespaces/system/dns_zones/example.com/rrsets/groupA/www/TXT", http.StatusBadRequest, "")
 
-	_, err := client.GetRRSet(context.Background(), "example.com", "groupA", "www", "TXT")
+	_, err := client.GetRRSet(t.Context(), "example.com", "groupA", "www", "TXT")
 	require.Error(t, err)
 }
 
 func TestClient_Delete(t *testing.T) {
 	client := setupTest(t, "DELETE /api/config/dns/namespaces/system/dns_zones/example.com/rrsets/groupA/www/TXT", http.StatusOK, "get.json")
 
-	result, err := client.DeleteRRSet(context.Background(), "example.com", "groupA", "www", "TXT")
+	result, err := client.DeleteRRSet(t.Context(), "example.com", "groupA", "www", "TXT")
 	require.NoError(t, err)
 
 	expected := &APIRRSet{
@@ -165,7 +164,7 @@ func TestClient_Delete(t *testing.T) {
 func TestClient_Delete_error(t *testing.T) {
 	client := setupTest(t, "DELETE /api/config/dns/namespaces/system/dns_zones/example.com/rrsets/groupA/www/TXT", http.StatusBadRequest, "")
 
-	_, err := client.DeleteRRSet(context.Background(), "example.com", "groupA", "www", "TXT")
+	_, err := client.DeleteRRSet(t.Context(), "example.com", "groupA", "www", "TXT")
 	require.Error(t, err)
 }
 
@@ -181,7 +180,7 @@ func TestClient_Replace(t *testing.T) {
 		},
 	}
 
-	result, err := client.ReplaceRRSet(context.Background(), "example.com", "groupA", "www", "TXT", rrSet)
+	result, err := client.ReplaceRRSet(t.Context(), "example.com", "groupA", "www", "TXT", rrSet)
 	require.NoError(t, err)
 
 	expected := &APIRRSet{
@@ -214,6 +213,6 @@ func TestClient_Replace_error(t *testing.T) {
 		},
 	}
 
-	_, err := client.ReplaceRRSet(context.Background(), "example.com", "groupA", "www", "TXT", rrSet)
+	_, err := client.ReplaceRRSet(t.Context(), "example.com", "groupA", "www", "TXT", rrSet)
 	require.Error(t, err)
 }

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -1,6 +1,7 @@
 package gcloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/go-acme/lego/v4/platform/tester"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
 )

--- a/providers/dns/gcore/internal/client.go
+++ b/providers/dns/gcore/internal/client.go
@@ -116,7 +116,7 @@ func (c *Client) updateRRSet(ctx context.Context, zone, name string, record RRSe
 	return c.doRequest(ctx, http.MethodPut, endpoint, record, nil)
 }
 
-func (c *Client) doRequest(ctx context.Context, method string, endpoint *url.URL, bodyParams any, result any) error {
+func (c *Client) doRequest(ctx context.Context, method string, endpoint *url.URL, bodyParams, result any) error {
 	req, err := newJSONRequest(ctx, method, endpoint, bodyParams)
 	if err != nil {
 		return fmt.Errorf("new request: %w", err)

--- a/providers/dns/gcore/internal/client_test.go
+++ b/providers/dns/gcore/internal/client_test.go
@@ -223,7 +223,7 @@ func handleAPIError() http.HandlerFunc {
 	}
 }
 
-func handleJSONResponse(data interface{}) http.HandlerFunc {
+func handleJSONResponse(data any) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		err := json.NewEncoder(rw).Encode(data)
 		if err != nil {

--- a/providers/dns/gcore/internal/client_test.go
+++ b/providers/dns/gcore/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -44,7 +43,7 @@ func TestClient_GetZone(t *testing.T) {
 		next:   handleJSONResponse(expected),
 	})
 
-	zone, err := client.GetZone(context.Background(), "example.com")
+	zone, err := client.GetZone(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, zone)
@@ -58,7 +57,7 @@ func TestClient_GetZone_error(t *testing.T) {
 		next:   handleAPIError(),
 	})
 
-	_, err := client.GetZone(context.Background(), "example.com")
+	_, err := client.GetZone(t.Context(), "example.com")
 	require.Error(t, err)
 }
 
@@ -77,7 +76,7 @@ func TestClient_GetRRSet(t *testing.T) {
 		next:   handleJSONResponse(expected),
 	})
 
-	rrSet, err := client.GetRRSet(context.Background(), "example.com", "foo.example.com")
+	rrSet, err := client.GetRRSet(t.Context(), "example.com", "foo.example.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, rrSet)
@@ -91,7 +90,7 @@ func TestClient_GetRRSet_error(t *testing.T) {
 		next:   handleAPIError(),
 	})
 
-	_, err := client.GetRRSet(context.Background(), "example.com", "foo.example.com")
+	_, err := client.GetRRSet(t.Context(), "example.com", "foo.example.com")
 	require.Error(t, err)
 }
 
@@ -101,7 +100,7 @@ func TestClient_DeleteRRSet(t *testing.T) {
 	mux.Handle("/v2/zones/test.example.com/my.test.example.com/"+txtRecordType,
 		validationHandler{method: http.MethodDelete})
 
-	err := client.DeleteRRSet(context.Background(), "test.example.com", "my.test.example.com.")
+	err := client.DeleteRRSet(t.Context(), "test.example.com", "my.test.example.com.")
 	require.NoError(t, err)
 }
 
@@ -113,7 +112,7 @@ func TestClient_DeleteRRSet_error(t *testing.T) {
 		next:   handleAPIError(),
 	})
 
-	err := client.DeleteRRSet(context.Background(), "test.example.com", "my.test.example.com.")
+	err := client.DeleteRRSet(t.Context(), "test.example.com", "my.test.example.com.")
 	require.NoError(t, err)
 }
 
@@ -183,7 +182,7 @@ func TestClient_AddRRSet(t *testing.T) {
 				mux.Handle(pattern, handler)
 			}
 
-			err := cl.AddRRSet(context.Background(), test.zone, test.recordName, test.value, testTTL)
+			err := cl.AddRRSet(t.Context(), test.zone, test.recordName, test.value, testTTL)
 			if test.wantErr {
 				require.Error(t, err)
 				return

--- a/providers/dns/glesys/internal/client.go
+++ b/providers/dns/glesys/internal/client.go
@@ -24,7 +24,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(apiUser string, apiKey string) *Client {
+func NewClient(apiUser, apiKey string) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{

--- a/providers/dns/glesys/internal/client_test.go
+++ b/providers/dns/glesys/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +64,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestClient_AddTXTRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/domain/addrecord", http.StatusOK, "add-record.json")
 
-	recordID, err := client.AddTXTRecord(context.Background(), "example.com", "foo", "txt", 120)
+	recordID, err := client.AddTXTRecord(t.Context(), "example.com", "foo", "txt", 120)
 	require.NoError(t, err)
 
 	assert.Equal(t, 123, recordID)
@@ -74,6 +73,6 @@ func TestClient_AddTXTRecord(t *testing.T) {
 func TestClient_DeleteTXTRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/domain/deleterecord", http.StatusOK, "delete-record.json")
 
-	err := client.DeleteTXTRecord(context.Background(), 123)
+	err := client.DeleteTXTRecord(t.Context(), 123)
 	require.NoError(t, err)
 }

--- a/providers/dns/godaddy/internal/client.go
+++ b/providers/dns/godaddy/internal/client.go
@@ -26,7 +26,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(apiKey string, apiSecret string) *Client {
+func NewClient(apiKey, apiSecret string) *Client {
 	baseURL, _ := url.Parse(DefaultBaseURL)
 
 	return &Client{

--- a/providers/dns/godaddy/internal/client_test.go
+++ b/providers/dns/godaddy/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,7 +33,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/v1/domains/example.com/records/TXT/", testHandler(http.MethodGet, http.StatusOK, "getrecords.json"))
 
-	records, err := client.GetRecords(context.Background(), "example.com", "TXT", "")
+	records, err := client.GetRecords(t.Context(), "example.com", "TXT", "")
 	require.NoError(t, err)
 
 	expected := []DNSRecord{
@@ -54,7 +53,7 @@ func TestClient_GetRecords_errors(t *testing.T) {
 
 	mux.HandleFunc("/v1/domains/example.com/records/TXT/", testHandler(http.MethodGet, http.StatusUnprocessableEntity, "errors.json"))
 
-	records, err := client.GetRecords(context.Background(), "example.com", "TXT", "")
+	records, err := client.GetRecords(t.Context(), "example.com", "TXT", "")
 	require.EqualError(t, err, "[status code: 422] INVALID_BODY: Request body doesn't fulfill schema, see details in `fields`")
 	assert.Nil(t, records)
 }
@@ -84,7 +83,7 @@ func TestClient_UpdateTxtRecords(t *testing.T) {
 		{Name: "_acme-challenge.lego", Type: "TXT", Data: "acme", TTL: 600},
 	}
 
-	err := client.UpdateTxtRecords(context.Background(), records, "example.com", "lego")
+	err := client.UpdateTxtRecords(t.Context(), records, "example.com", "lego")
 	require.NoError(t, err)
 }
 
@@ -103,7 +102,7 @@ func TestClient_UpdateTxtRecords_errors(t *testing.T) {
 		{Name: "_acme-challenge.lego", Type: "TXT", Data: "acme", TTL: 600},
 	}
 
-	err := client.UpdateTxtRecords(context.Background(), records, "example.com", "lego")
+	err := client.UpdateTxtRecords(t.Context(), records, "example.com", "lego")
 	require.EqualError(t, err, "[status code: 422] INVALID_BODY: Request body doesn't fulfill schema, see details in `fields`")
 }
 
@@ -112,7 +111,7 @@ func TestClient_DeleteTxtRecords(t *testing.T) {
 
 	mux.HandleFunc("/v1/domains/example.com/records/TXT/foo", testHandler(http.MethodDelete, http.StatusNoContent, ""))
 
-	err := client.DeleteTxtRecords(context.Background(), "example.com", "foo")
+	err := client.DeleteTxtRecords(t.Context(), "example.com", "foo")
 	require.NoError(t, err)
 }
 
@@ -121,7 +120,7 @@ func TestClient_DeleteTxtRecords_errors(t *testing.T) {
 
 	mux.HandleFunc("/v1/domains/example.com/records/TXT/foo", testHandler(http.MethodDelete, http.StatusConflict, "error-extended.json"))
 
-	err := client.DeleteTxtRecords(context.Background(), "example.com", "foo")
+	err := client.DeleteTxtRecords(t.Context(), "example.com", "foo")
 	require.EqualError(t, err, "[status code: 409] ACCESS_DENIED: Authenticated user is not allowed access [test: content (path=/foo) (pathRelated=/bar)]")
 }
 

--- a/providers/dns/hetzner/internal/client_test.go
+++ b/providers/dns/hetzner/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,7 +65,7 @@ func TestClient_GetTxtRecord(t *testing.T) {
 		}
 	})
 
-	record, err := client.GetTxtRecord(context.Background(), "test1", "txttxttxt", zoneID)
+	record, err := client.GetTxtRecord(t.Context(), "test1", "txttxttxt", zoneID)
 	require.NoError(t, err)
 
 	fmt.Println(record)
@@ -112,7 +111,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		ZoneID: zoneID,
 	}
 
-	err := client.CreateRecord(context.Background(), record)
+	err := client.CreateRecord(t.Context(), record)
 	require.NoError(t, err)
 }
 
@@ -134,7 +133,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteRecord(context.Background(), "recordID")
+	err := client.DeleteRecord(t.Context(), "recordID")
 	require.NoError(t, err)
 }
 
@@ -169,7 +168,7 @@ func TestClient_GetZoneID(t *testing.T) {
 		}
 	})
 
-	zoneID, err := client.GetZoneID(context.Background(), "example.com")
+	zoneID, err := client.GetZoneID(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, "zoneA", zoneID)

--- a/providers/dns/hosttech/internal/client_test.go
+++ b/providers/dns/hosttech/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,7 +19,7 @@ const testAPIKey = "secret"
 func TestClient_GetZones(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones", testHandler(http.MethodGet, http.StatusOK, "zones.json"))
 
-	zones, err := client.GetZones(context.Background(), "", 100, 0)
+	zones, err := client.GetZones(t.Context(), "", 100, 0)
 	require.NoError(t, err)
 
 	expected := []Zone{
@@ -41,14 +40,14 @@ func TestClient_GetZones(t *testing.T) {
 func TestClient_GetZones_error(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones", testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetZones(context.Background(), "", 100, 0)
+	_, err := client.GetZones(t.Context(), "", 100, 0)
 	require.Error(t, err)
 }
 
 func TestClient_GetZone(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123", testHandler(http.MethodGet, http.StatusOK, "zone.json"))
 
-	zone, err := client.GetZone(context.Background(), "123")
+	zone, err := client.GetZone(t.Context(), "123")
 	require.NoError(t, err)
 
 	expected := &Zone{
@@ -67,14 +66,14 @@ func TestClient_GetZone(t *testing.T) {
 func TestClient_GetZone_error(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123", testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetZone(context.Background(), "123")
+	_, err := client.GetZone(t.Context(), "123")
 	require.Error(t, err)
 }
 
 func TestClient_GetRecords(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123/records", testHandler(http.MethodGet, http.StatusOK, "records.json"))
 
-	records, err := client.GetRecords(context.Background(), "123", "TXT")
+	records, err := client.GetRecords(t.Context(), "123", "TXT")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -154,7 +153,7 @@ func TestClient_GetRecords(t *testing.T) {
 func TestClient_GetRecords_error(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123/records", testHandler(http.MethodGet, http.StatusUnauthorized, "error.json"))
 
-	_, err := client.GetRecords(context.Background(), "123", "TXT")
+	_, err := client.GetRecords(t.Context(), "123", "TXT")
 	require.Error(t, err)
 }
 
@@ -169,7 +168,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Comment: "example",
 	}
 
-	newRecord, err := client.AddRecord(context.Background(), "123", record)
+	newRecord, err := client.AddRecord(t.Context(), "123", record)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -195,21 +194,21 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Comment: "example",
 	}
 
-	_, err := client.AddRecord(context.Background(), "123", record)
+	_, err := client.AddRecord(t.Context(), "123", record)
 	require.Error(t, err)
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123/records/6", testHandler(http.MethodDelete, http.StatusUnauthorized, "error.json"))
 
-	err := client.DeleteRecord(context.Background(), "123", "6")
+	err := client.DeleteRecord(t.Context(), "123", "6")
 	require.Error(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/user/v1/zones/123/records/6", testHandler(http.MethodDelete, http.StatusNoContent, ""))
 
-	err := client.DeleteRecord(context.Background(), "123", "6")
+	err := client.DeleteRecord(t.Context(), "123", "6")
 	require.NoError(t, err)
 }
 

--- a/providers/dns/hurricane/hurricane.go
+++ b/providers/dns/hurricane/hurricane.go
@@ -126,8 +126,7 @@ func (d *DNSProvider) Sequential() time.Duration {
 func parseCredentials(raw string) (map[string]string, error) {
 	credentials := make(map[string]string)
 
-	credStrings := strings.Split(strings.TrimSuffix(raw, ","), ",")
-	for _, credPair := range credStrings {
+	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
 		data := strings.Split(credPair, ":")
 		if len(data) != 2 {
 			return nil, fmt.Errorf("incorrect credential pair: %s", credPair)

--- a/providers/dns/hurricane/hurricane.go
+++ b/providers/dns/hurricane/hurricane.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge"
@@ -63,9 +62,9 @@ func NewDNSProvider() (*DNSProvider, error) {
 		return nil, fmt.Errorf("hurricane: %w", err)
 	}
 
-	credentials, err := parseCredentials(values[EnvTokens])
+	credentials, err := env.ParsePairs(values[EnvTokens])
 	if err != nil {
-		return nil, fmt.Errorf("hurricane: %w", err)
+		return nil, fmt.Errorf("hurricane: credentials: %w", err)
 	}
 
 	config.Credentials = credentials
@@ -121,19 +120,4 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 // Returns the interval between each iteration.
 func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
-}
-
-func parseCredentials(raw string) (map[string]string, error) {
-	credentials := make(map[string]string)
-
-	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
-		data := strings.Split(credPair, ":")
-		if len(data) != 2 {
-			return nil, fmt.Errorf("incorrect credential pair: %s", credPair)
-		}
-
-		credentials[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
-	}
-
-	return credentials, nil
 }

--- a/providers/dns/hurricane/hurricane_test.go
+++ b/providers/dns/hurricane/hurricane_test.go
@@ -34,14 +34,14 @@ func TestNewDNSProvider(t *testing.T) {
 			envVars: map[string]string{
 				EnvTokens: ",",
 			},
-			expected: "hurricane: incorrect credential pair: ",
+			expected: "hurricane: credentials: incorrect pair: ",
 		},
 		{
 			desc: "invalid credentials, partial",
 			envVars: map[string]string{
 				EnvTokens: "example.org:123,example.net",
 			},
-			expected: "hurricane: incorrect credential pair: example.net",
+			expected: "hurricane: credentials: incorrect pair: example.net",
 		},
 		{
 			desc: "missing credentials",

--- a/providers/dns/hurricane/internal/client.go
+++ b/providers/dns/hurricane/internal/client.go
@@ -52,7 +52,7 @@ func NewClient(credentials map[string]string) *Client {
 }
 
 // UpdateTxtRecord updates a TXT record.
-func (c *Client) UpdateTxtRecord(ctx context.Context, hostname string, txt string) error {
+func (c *Client) UpdateTxtRecord(ctx context.Context, hostname, txt string) error {
 	domain := strings.TrimPrefix(hostname, "_acme-challenge.")
 
 	c.credMu.Lock()
@@ -101,7 +101,7 @@ func (c *Client) UpdateTxtRecord(ctx context.Context, hostname string, txt strin
 	return evaluateBody(string(bytes.TrimSpace(raw)), hostname)
 }
 
-func evaluateBody(body string, hostname string) error {
+func evaluateBody(body, hostname string) error {
 	code, _, _ := strings.Cut(body, " ")
 
 	switch code {

--- a/providers/dns/hurricane/internal/client_test.go
+++ b/providers/dns/hurricane/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -75,7 +74,7 @@ func TestClient_UpdateTxtRecord(t *testing.T) {
 			client.baseURL = server.URL
 			client.HTTPClient = server.Client()
 
-			err := client.UpdateTxtRecord(context.Background(), "_acme-challenge.example.com", "foo")
+			err := client.UpdateTxtRecord(t.Context(), "_acme-challenge.example.com", "foo")
 			test.expected(t, err)
 		})
 	}

--- a/providers/dns/hyperone/internal/client.go
+++ b/providers/dns/hyperone/internal/client.go
@@ -132,7 +132,7 @@ func (c *Client) CreateRecordset(ctx context.Context, zoneID, recordType, name, 
 
 // DeleteRecordset deletes a recordset.
 // https://api.hyperone.com/v2/docs#operation/dns_project_zone_recordset_delete
-func (c *Client) DeleteRecordset(ctx context.Context, zoneID string, recordsetID string) error {
+func (c *Client) DeleteRecordset(ctx context.Context, zoneID, recordsetID string) error {
 	// https://api.hyperone.com/v2/dns/{locationId}/project/{projectId}/zone/{zoneId}/recordset/{recordsetId}
 	endpoint := c.baseURL.JoinPath("zone", zoneID, "recordset", recordsetID)
 
@@ -146,7 +146,7 @@ func (c *Client) DeleteRecordset(ctx context.Context, zoneID string, recordsetID
 
 // GetRecords gets all records within specified recordset.
 // https://api.hyperone.com/v2/docs#operation/dns_project_zone_recordset_record_list
-func (c *Client) GetRecords(ctx context.Context, zoneID string, recordsetID string) ([]Record, error) {
+func (c *Client) GetRecords(ctx context.Context, zoneID, recordsetID string) ([]Record, error) {
 	// https://api.hyperone.com/v2/dns/{locationId}/project/{projectId}/zone/{zoneId}/recordset/{recordsetId}/record
 	endpoint := c.baseURL.JoinPath("zone", zoneID, "recordset", recordsetID, "record")
 

--- a/providers/dns/hyperone/internal/client_test.go
+++ b/providers/dns/hyperone/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +24,7 @@ func (s signerMock) GetJWT() (string, error) {
 func TestClient_FindRecordset(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns/loc123/project/proj123/zone/zone321/recordset", respFromFile("recordset.json"))
 
-	recordset, err := client.FindRecordset(context.Background(), "zone321", "SOA", "example.com.")
+	recordset, err := client.FindRecordset(t.Context(), "zone321", "SOA", "example.com.")
 	require.NoError(t, err)
 
 	expected := &Recordset{
@@ -49,7 +48,7 @@ func TestClient_CreateRecordset(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns/loc123/project/proj123/zone/zone123/recordset",
 		hasReqBody(expectedReqBody), respFromFile("createRecordset.json"))
 
-	rs, err := client.CreateRecordset(context.Background(), "zone123", "TXT", "test.example.com.", "value", 3600)
+	rs, err := client.CreateRecordset(t.Context(), "zone123", "TXT", "test.example.com.", "value", 3600)
 	require.NoError(t, err)
 
 	expected := &Recordset{RecordType: "TXT", Name: "test.example.com.", TTL: 3600, ID: "1234567890qwertyuiop"}
@@ -59,14 +58,14 @@ func TestClient_CreateRecordset(t *testing.T) {
 func TestClient_DeleteRecordset(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns/loc123/project/proj123/zone/zone321/recordset/rs322")
 
-	err := client.DeleteRecordset(context.Background(), "zone321", "rs322")
+	err := client.DeleteRecordset(t.Context(), "zone321", "rs322")
 	require.NoError(t, err)
 }
 
 func TestClient_GetRecords(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns/loc123/project/proj123/zone/321/recordset/322/record", respFromFile("record.json"))
 
-	records, err := client.GetRecords(context.Background(), "321", "322")
+	records, err := client.GetRecords(t.Context(), "321", "322")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -88,7 +87,7 @@ func TestClient_CreateRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns/loc123/project/proj123/zone/z123/recordset/rs325/record",
 		hasReqBody(expectedReqBody), respFromFile("createRecord.json"))
 
-	rs, err := client.CreateRecord(context.Background(), "z123", "rs325", "value")
+	rs, err := client.CreateRecord(t.Context(), "z123", "rs325", "value")
 	require.NoError(t, err)
 
 	expected := &Record{ID: "123321qwerqwewqerq", Content: "value", Enabled: true}
@@ -98,14 +97,14 @@ func TestClient_CreateRecord(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns/loc123/project/proj123/zone/321/recordset/322/record/323")
 
-	err := client.DeleteRecord(context.Background(), "321", "322", "323")
+	err := client.DeleteRecord(t.Context(), "321", "322", "323")
 	require.NoError(t, err)
 }
 
 func TestClient_FindZone(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns/loc123/project/proj123/zone", respFromFile("zones.json"))
 
-	zone, err := client.FindZone(context.Background(), "example.com")
+	zone, err := client.FindZone(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := &Zone{
@@ -122,7 +121,7 @@ func TestClient_FindZone(t *testing.T) {
 func TestClient_GetZones(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns/loc123/project/proj123/zone", respFromFile("zones.json"))
 
-	zones, err := client.GetZones(context.Background())
+	zones, err := client.GetZones(t.Context())
 	require.NoError(t, err)
 
 	expected := []Zone{

--- a/providers/dns/hyperone/internal/client_test.go
+++ b/providers/dns/hyperone/internal/client_test.go
@@ -183,7 +183,7 @@ func setupTest(t *testing.T, method, path string, handlers ...assertHandler) *Cl
 
 type assertHandler func(http.ResponseWriter, *http.Request) (int, error)
 
-func hasReqBody(v interface{}) assertHandler {
+func hasReqBody(v any) assertHandler {
 	return func(rw http.ResponseWriter, req *http.Request) (int, error) {
 		reqBody, err := io.ReadAll(req.Body)
 		if err != nil {

--- a/providers/dns/iij/iij_test.go
+++ b/providers/dns/iij/iij_test.go
@@ -161,31 +161,31 @@ func TestSplitDomain(t *testing.T) {
 	}{
 		{
 			desc:          "domain equals zone",
-			domain:        "domain.com",
-			zones:         []string{"domain.com"},
+			domain:        "example.com",
+			zones:         []string{"example.com"},
 			expectedOwner: "_acme-challenge",
-			expectedZone:  "domain.com",
+			expectedZone:  "example.com",
 		},
 		{
 			desc:          "with a subdomain",
-			domain:        "my.domain.com",
-			zones:         []string{"domain.com"},
+			domain:        "my.example.com",
+			zones:         []string{"example.com"},
 			expectedOwner: "_acme-challenge.my",
-			expectedZone:  "domain.com",
+			expectedZone:  "example.com",
 		},
 		{
 			desc:          "with a subdomain in a zone",
-			domain:        "my.sub.domain.com",
-			zones:         []string{"sub.domain.com", "domain.com"},
+			domain:        "my.sub.example.com",
+			zones:         []string{"sub.example.com", "example.com"},
 			expectedOwner: "_acme-challenge.my",
-			expectedZone:  "sub.domain.com",
+			expectedZone:  "sub.example.com",
 		},
 		{
 			desc:          "with a sub-subdomain",
-			domain:        "my.sub.domain.com",
-			zones:         []string{"domain1.com", "domain.com"},
+			domain:        "my.sub.example.com",
+			zones:         []string{"domain1.com", "example.com"},
 			expectedOwner: "_acme-challenge.my.sub",
-			expectedZone:  "domain.com",
+			expectedZone:  "example.com",
 		},
 	}
 
@@ -198,6 +198,36 @@ func TestSplitDomain(t *testing.T) {
 
 			assert.Equal(t, test.expectedOwner, owner)
 			assert.Equal(t, test.expectedZone, zone)
+		})
+	}
+}
+
+func TestSplitDomain_error(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		domain        string
+		zones         []string
+		expectedOwner string
+		expectedZone  string
+	}{
+		{
+			desc:   "no zone",
+			domain: "example.com",
+			zones:  nil,
+		},
+		{
+			desc:   "domain does not contain zone",
+			domain: "example.com",
+			zones:  []string{"example.org"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := splitDomain(test.domain, test.zones)
+			require.Error(t, err)
 		})
 	}
 }

--- a/providers/dns/infomaniak/internal/client_test.go
+++ b/providers/dns/infomaniak/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -73,7 +72,7 @@ func TestClient_CreateDNSRecord(t *testing.T) {
 		TTL:    60,
 	}
 
-	recordID, err := client.CreateDNSRecord(context.Background(), domain, record)
+	recordID, err := client.CreateDNSRecord(t.Context(), domain, record)
 	require.NoError(t, err)
 
 	assert.Equal(t, "123", recordID)
@@ -128,7 +127,7 @@ func TestClient_GetDomainByName(t *testing.T) {
 		}
 	})
 
-	domain, err := client.GetDomainByName(context.Background(), "one.two.three.example.com.")
+	domain, err := client.GetDomainByName(t.Context(), "one.two.three.example.com.")
 	require.NoError(t, err)
 
 	expected := &DNSDomain{ID: 123, CustomerName: "two.three.example.com"}
@@ -156,6 +155,6 @@ func TestClient_DeleteDNSRecord(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteDNSRecord(context.Background(), 123, "456")
+	err := client.DeleteDNSRecord(t.Context(), 123, "456")
 	require.NoError(t, err)
 }

--- a/providers/dns/internal/active24/client_test.go
+++ b/providers/dns/internal/active24/client_test.go
@@ -1,7 +1,6 @@
 package active24
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +55,7 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 func TestClient_GetServices(t *testing.T) {
 	client := setupTest(t, "GET /v1/user/self/service", http.StatusOK, "services.json")
 
-	services, err := client.GetServices(context.Background())
+	services, err := client.GetServices(t.Context())
 	require.NoError(t, err)
 
 	expected := []Service{
@@ -86,7 +85,7 @@ func TestClient_GetServices(t *testing.T) {
 func TestClient_GetServices_errors(t *testing.T) {
 	client := setupTest(t, "GET /v1/user/self/service", http.StatusUnauthorized, "error_v1.json")
 
-	_, err := client.GetServices(context.Background())
+	_, err := client.GetServices(t.Context())
 	require.EqualError(t, err, "401: No username or password.")
 }
 
@@ -99,7 +98,7 @@ func TestClient_GetRecords(t *testing.T) {
 		Content: "txt",
 	}
 
-	records, err := client.GetRecords(context.Background(), "aaa", filter)
+	records, err := client.GetRecords(t.Context(), "aaa", filter)
 	require.NoError(t, err)
 
 	expected := []Record{{
@@ -124,35 +123,35 @@ func TestClient_GetRecords_errors(t *testing.T) {
 		Content: "txt",
 	}
 
-	_, err := client.GetRecords(context.Background(), "aaa", filter)
+	_, err := client.GetRecords(t.Context(), "aaa", filter)
 	require.EqualError(t, err, "403: /errors/httpException: This action is unauthorized.")
 }
 
 func TestClient_CreateRecord(t *testing.T) {
 	client := setupTest(t, "POST /v2/service/aaa/dns/record", http.StatusNoContent, "")
 
-	err := client.CreateRecord(context.Background(), "aaa", Record{})
+	err := client.CreateRecord(t.Context(), "aaa", Record{})
 	require.NoError(t, err)
 }
 
 func TestClient_CreateRecord_errors(t *testing.T) {
 	client := setupTest(t, "POST /v2/service/aaa/dns/record", http.StatusForbidden, "error_403.json")
 
-	err := client.CreateRecord(context.Background(), "aaa", Record{})
+	err := client.CreateRecord(t.Context(), "aaa", Record{})
 	require.EqualError(t, err, "403: /errors/httpException: This action is unauthorized.")
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "DELETE /v2/service/aaa/dns/record/123", http.StatusNoContent, "")
 
-	err := client.DeleteRecord(context.Background(), "aaa", "123")
+	err := client.DeleteRecord(t.Context(), "aaa", "123")
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "DELETE /v2/service/aaa/dns/record/123", http.StatusForbidden, "error_403.json")
 
-	err := client.DeleteRecord(context.Background(), "aaa", "123")
+	err := client.DeleteRecord(t.Context(), "aaa", "123")
 	require.EqualError(t, err, "403: /errors/httpException: This action is unauthorized.")
 }
 

--- a/providers/dns/internal/hostingde/client_test.go
+++ b/providers/dns/internal/hostingde/client_test.go
@@ -2,7 +2,6 @@ package hostingde
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -72,7 +71,7 @@ func TestClient_ListZoneConfigs(t *testing.T) {
 		Page:   1,
 	}
 
-	zoneResponse, err := client.ListZoneConfigs(context.Background(), zonesFind)
+	zoneResponse, err := client.ListZoneConfigs(t.Context(), zonesFind)
 	require.NoError(t, err)
 
 	expected := &ZoneResponse{
@@ -124,7 +123,7 @@ func TestClient_ListZoneConfigs_error(t *testing.T) {
 		Page:   1,
 	}
 
-	_, err := client.ListZoneConfigs(context.Background(), zonesFind)
+	_, err := client.ListZoneConfigs(t.Context(), zonesFind)
 	require.Error(t, err)
 }
 
@@ -179,7 +178,7 @@ func TestClient_UpdateZone(t *testing.T) {
 		}},
 	}
 
-	response, err := client.UpdateZone(context.Background(), request)
+	response, err := client.UpdateZone(t.Context(), request)
 	require.NoError(t, err)
 
 	expected := &Zone{
@@ -259,6 +258,6 @@ func TestClient_UpdateZone_error(t *testing.T) {
 		}},
 	}
 
-	_, err := client.UpdateZone(context.Background(), request)
+	_, err := client.UpdateZone(t.Context(), request)
 	require.Error(t, err)
 }

--- a/providers/dns/internal/rimuhosting/client_test.go
+++ b/providers/dns/internal/rimuhosting/client_test.go
@@ -1,7 +1,6 @@
 package rimuhosting
 
 import (
-	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -99,7 +98,7 @@ func TestClient_FindTXTRecords(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			records, err := client.FindTXTRecords(context.Background(), test.domain)
+			records, err := client.FindTXTRecords(t.Context(), test.domain)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected, records)
@@ -291,7 +290,7 @@ func TestClient_DoActions(t *testing.T) {
 				}
 			})
 
-			resp, err := client.DoActions(context.Background(), test.actions...)
+			resp, err := client.DoActions(t.Context(), test.actions...)
 			if test.expected.Error != "" {
 				require.EqualError(t, err, test.expected.Error)
 				return

--- a/providers/dns/internal/selectel/client_test.go
+++ b/providers/dns/internal/selectel/client_test.go
@@ -1,7 +1,6 @@
 package selectel
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,7 +46,7 @@ func TestClient_ListRecords(t *testing.T) {
 		}
 	})
 
-	records, err := client.ListRecords(context.Background(), 123)
+	records, err := client.ListRecords(t.Context(), 123)
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -76,7 +75,7 @@ func TestClient_ListRecords_error(t *testing.T) {
 		}
 	})
 
-	records, err := client.ListRecords(context.Background(), 123)
+	records, err := client.ListRecords(t.Context(), 123)
 
 	require.EqualError(t, err, "request failed with status code 401: API error: 400 - error description - field that the error occurred in")
 	assert.Nil(t, records)
@@ -118,7 +117,7 @@ func TestClient_GetDomainByName(t *testing.T) {
 		}
 	})
 
-	domain, err := client.GetDomainByName(context.Background(), "sub.sub.example.org")
+	domain, err := client.GetDomainByName(t.Context(), "sub.sub.example.org")
 	require.NoError(t, err)
 
 	expected := &Domain{
@@ -155,7 +154,7 @@ func TestClient_AddRecord(t *testing.T) {
 		}
 	})
 
-	record, err := client.AddRecord(context.Background(), 123, Record{
+	record, err := client.AddRecord(t.Context(), 123, Record{
 		Name:    "example.org",
 		Type:    "TXT",
 		TTL:     60,
@@ -187,7 +186,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.NoError(t, err)
 }
 

--- a/providers/dns/internetbs/internal/client.go
+++ b/providers/dns/internetbs/internal/client.go
@@ -34,7 +34,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(apiKey string, password string) *Client {
+func NewClient(apiKey, password string) *Client {
 	baseURL, _ := url.Parse(baseURL)
 
 	return &Client{
@@ -90,7 +90,7 @@ func (c Client) ListRecords(ctx context.Context, query ListRecordQuery) ([]Recor
 	return l.Records, nil
 }
 
-func (c Client) doRequest(ctx context.Context, action string, params any, result any) error {
+func (c Client) doRequest(ctx context.Context, action string, params, result any) error {
 	endpoint := c.baseURL.JoinPath("Domain", "DnsRecord", action)
 
 	values, err := querystring.Values(params)

--- a/providers/dns/internetbs/internal/client_test.go
+++ b/providers/dns/internetbs/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,7 +31,7 @@ func TestClient_AddRecord(t *testing.T) {
 		TTL:            36000,
 	}
 
-	err := client.AddRecord(context.Background(), query)
+	err := client.AddRecord(t.Context(), query)
 	require.NoError(t, err)
 }
 
@@ -46,7 +45,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		TTL:            36000,
 	}
 
-	err := client.AddRecord(context.Background(), query)
+	err := client.AddRecord(t.Context(), query)
 	require.Error(t, err)
 }
 
@@ -67,7 +66,7 @@ func TestClient_AddRecord_integration(t *testing.T) {
 		TTL:            36000,
 	}
 
-	err := client.AddRecord(context.Background(), query)
+	err := client.AddRecord(t.Context(), query)
 	require.NoError(t, err)
 
 	query = RecordQuery{
@@ -77,7 +76,7 @@ func TestClient_AddRecord_integration(t *testing.T) {
 		TTL:            36000,
 	}
 
-	err = client.AddRecord(context.Background(), query)
+	err = client.AddRecord(t.Context(), query)
 	require.NoError(t, err)
 }
 
@@ -89,7 +88,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 		Type:           "TXT",
 		Value:          "",
 	}
-	err := client.RemoveRecord(context.Background(), query)
+	err := client.RemoveRecord(t.Context(), query)
 	require.NoError(t, err)
 }
 
@@ -101,7 +100,7 @@ func TestClient_RemoveRecord_error(t *testing.T) {
 		Type:           "TXT",
 		Value:          "",
 	}
-	err := client.RemoveRecord(context.Background(), query)
+	err := client.RemoveRecord(t.Context(), query)
 	require.Error(t, err)
 }
 
@@ -121,7 +120,7 @@ func TestClient_RemoveRecord_integration(t *testing.T) {
 		Value:          "",
 	}
 
-	err := client.RemoveRecord(context.Background(), query)
+	err := client.RemoveRecord(t.Context(), query)
 	require.NoError(t, err)
 }
 
@@ -132,7 +131,7 @@ func TestClient_ListRecords(t *testing.T) {
 		Domain: "example.com",
 	}
 
-	records, err := client.ListRecords(context.Background(), query)
+	records, err := client.ListRecords(t.Context(), query)
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -184,7 +183,7 @@ func TestClient_ListRecords_error(t *testing.T) {
 		Domain: "www.example.com",
 	}
 
-	_, err := client.ListRecords(context.Background(), query)
+	_, err := client.ListRecords(t.Context(), query)
 	require.Error(t, err)
 }
 
@@ -202,7 +201,7 @@ func TestClient_ListRecords_integration(t *testing.T) {
 		Domain: "example.com",
 	}
 
-	records, err := client.ListRecords(context.Background(), query)
+	records, err := client.ListRecords(t.Context(), query)
 	require.NoError(t, err)
 
 	for _, record := range records {

--- a/providers/dns/ionos/internal/client_test.go
+++ b/providers/dns/ionos/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +20,7 @@ func TestClient_ListZones(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones", mockHandler(http.MethodGet, http.StatusOK, "list_zones.json"))
 
-	zones, err := client.ListZones(context.Background())
+	zones, err := client.ListZones(t.Context())
 	require.NoError(t, err)
 
 	expected := []Zone{{
@@ -38,7 +37,7 @@ func TestClient_ListZones_error(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones", mockHandler(http.MethodGet, http.StatusUnauthorized, "list_zones_error.json"))
 
-	zones, err := client.ListZones(context.Background())
+	zones, err := client.ListZones(t.Context())
 	require.Error(t, err)
 
 	assert.Nil(t, zones)
@@ -53,7 +52,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones/azone01", mockHandler(http.MethodGet, http.StatusOK, "get_records.json"))
 
-	records, err := client.GetRecords(context.Background(), "azone01", nil)
+	records, err := client.GetRecords(t.Context(), "azone01", nil)
 	require.NoError(t, err)
 
 	expected := []Record{{
@@ -71,7 +70,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones/azone01", mockHandler(http.MethodGet, http.StatusUnauthorized, "get_records_error.json"))
 
-	records, err := client.GetRecords(context.Background(), "azone01", nil)
+	records, err := client.GetRecords(t.Context(), "azone01", nil)
 	require.Error(t, err)
 
 	assert.Nil(t, records)
@@ -86,7 +85,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones/azone01/records/arecord01", mockHandler(http.MethodDelete, http.StatusOK, ""))
 
-	err := client.RemoveRecord(context.Background(), "azone01", "arecord01")
+	err := client.RemoveRecord(t.Context(), "azone01", "arecord01")
 	require.NoError(t, err)
 }
 
@@ -95,7 +94,7 @@ func TestClient_RemoveRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/v1/zones/azone01/records/arecord01", mockHandler(http.MethodDelete, http.StatusInternalServerError, "remove_record_error.json"))
 
-	err := client.RemoveRecord(context.Background(), "azone01", "arecord01")
+	err := client.RemoveRecord(t.Context(), "azone01", "arecord01")
 	require.Error(t, err)
 
 	var cErr *ClientError
@@ -115,7 +114,7 @@ func TestClient_ReplaceRecords(t *testing.T) {
 		Type:    "A",
 	}}
 
-	err := client.ReplaceRecords(context.Background(), "azone01", records)
+	err := client.ReplaceRecords(t.Context(), "azone01", records)
 	require.NoError(t, err)
 }
 
@@ -131,7 +130,7 @@ func TestClient_ReplaceRecords_error(t *testing.T) {
 		Type:    "A",
 	}}
 
-	err := client.ReplaceRecords(context.Background(), "azone01", records)
+	err := client.ReplaceRecords(t.Context(), "azone01", records)
 	require.Error(t, err)
 
 	var cErr *ClientError

--- a/providers/dns/ipv64/internal/client_test.go
+++ b/providers/dns/ipv64/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +62,7 @@ func testHandler(method, filename string, statusCode int) http.HandlerFunc {
 func TestClient_GetDomains(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodGet, "get_domains.json", http.StatusOK))
 
-	domains, err := client.GetDomains(context.Background())
+	domains, err := client.GetDomains(t.Context())
 	require.NoError(t, err)
 
 	expected := &Domains{
@@ -114,7 +113,7 @@ func TestClient_GetDomains(t *testing.T) {
 func TestClient_GetDomains_error(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodGet, "error.json", http.StatusUnauthorized))
 
-	domains, err := client.GetDomains(context.Background())
+	domains, err := client.GetDomains(t.Context())
 	require.Error(t, err)
 
 	require.Nil(t, domains)
@@ -123,27 +122,27 @@ func TestClient_GetDomains_error(t *testing.T) {
 func TestClient_AddRecord(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodPost, "add_record.json", http.StatusCreated))
 
-	err := client.AddRecord(context.Background(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
+	err := client.AddRecord(t.Context(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
 	require.NoError(t, err)
 }
 
 func TestClient_AddRecord_error(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodPost, "add_record-error.json", http.StatusBadRequest))
 
-	err := client.AddRecord(context.Background(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
+	err := client.AddRecord(t.Context(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
 	require.Error(t, err)
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodDelete, "del_record.json", http.StatusAccepted))
 
-	err := client.DeleteRecord(context.Background(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
+	err := client.DeleteRecord(t.Context(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, testHandler(http.MethodDelete, "del_record-error.json", http.StatusBadRequest))
 
-	err := client.DeleteRecord(context.Background(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
+	err := client.DeleteRecord(t.Context(), "lego.ipv64.net", "_acme-challenge", "TXT", "value")
 	require.Error(t, err)
 }

--- a/providers/dns/iwantmyname/internal/client.go
+++ b/providers/dns/iwantmyname/internal/client.go
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username string, password string) *Client {
+func NewClient(username, password string) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{

--- a/providers/dns/iwantmyname/internal/client_test.go
+++ b/providers/dns/iwantmyname/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -82,6 +81,6 @@ func TestClient_Do(t *testing.T) {
 		TTL:      120,
 	}
 
-	err := client.SendRequest(context.Background(), record)
+	err := client.SendRequest(t.Context(), record)
 	require.NoError(t, err)
 }

--- a/providers/dns/joker/internal/dmapi/client.go
+++ b/providers/dns/joker/internal/dmapi/client.go
@@ -126,7 +126,7 @@ func parseResponse(message string) *Response {
 
 	lines, body, _ := strings.Cut(message, "\n\n")
 
-	for _, line := range strings.Split(lines, "\n") {
+	for line := range strings.Lines(lines) {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -177,7 +177,7 @@ func RemoveTxtEntryFromZone(zone, relative string) (string, bool) {
 
 	modified := false
 	var zoneEntries []string
-	for _, line := range strings.Split(zone, "\n") {
+	for line := range strings.Lines(zone) {
 		if strings.HasPrefix(line, prefix) {
 			modified = true
 			continue
@@ -192,7 +192,7 @@ func RemoveTxtEntryFromZone(zone, relative string) (string, bool) {
 func AddTxtEntryToZone(zone, relative, value string, ttl int) string {
 	var zoneEntries []string
 
-	for _, line := range strings.Split(zone, "\n") {
+	for line := range strings.Lines(zone) {
 		zoneEntries = append(zoneEntries, fixTxtLines(line))
 	}
 

--- a/providers/dns/joker/internal/dmapi/client_test.go
+++ b/providers/dns/joker/internal/dmapi/client_test.go
@@ -93,7 +93,7 @@ func TestClient_GetZone(t *testing.T) {
 			client := NewClient(AuthInfo{APIKey: "12345"})
 			client.BaseURL = serverURL
 
-			response, err := client.GetZone(mockContext(test.authSid), test.domain)
+			response, err := client.GetZone(mockContext(t, test.authSid), test.domain)
 			if test.expectedError {
 				require.Error(t, err)
 			} else {

--- a/providers/dns/joker/internal/dmapi/identity_test.go
+++ b/providers/dns/joker/internal/dmapi/identity_test.go
@@ -14,12 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext(sessionID string) context.Context {
+func mockContext(t *testing.T, sessionID string) context.Context {
+	t.Helper()
+
 	if sessionID == "" {
 		sessionID = "xxx"
 	}
 
-	return context.WithValue(context.Background(), sessionIDKey, sessionID)
+	return context.WithValue(t.Context(), sessionIDKey, sessionID)
 }
 
 func TestClient_login_apikey(t *testing.T) {
@@ -78,7 +80,7 @@ func TestClient_login_apikey(t *testing.T) {
 			client := NewClient(AuthInfo{APIKey: test.apiKey})
 			client.BaseURL = serverURL
 
-			response, err := client.login(context.Background())
+			response, err := client.login(t.Context())
 			if test.expectedError {
 				require.Error(t, err)
 			} else {
@@ -153,7 +155,7 @@ func TestClient_login_username(t *testing.T) {
 			client := NewClient(AuthInfo{Username: test.username, Password: test.password})
 			client.BaseURL = serverURL
 
-			response, err := client.login(context.Background())
+			response, err := client.login(t.Context())
 			if test.expectedError {
 				require.Error(t, err)
 			} else {
@@ -216,7 +218,7 @@ func TestClient_logout(t *testing.T) {
 			client.BaseURL = serverURL
 			client.token = &Token{SessionID: test.authSid}
 
-			response, err := client.Logout(mockContext(test.authSid))
+			response, err := client.Logout(mockContext(t, test.authSid))
 			if test.expectedError {
 				require.Error(t, err)
 			} else {
@@ -253,7 +255,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 	client.HTTPClient = server.Client()
 	client.BaseURL = server.URL
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, "100", getSessionID(ctx))
@@ -263,7 +265,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 	client.token.SessionID = "cache"
 	client.muToken.Unlock()
 
-	ctx, err = client.CreateAuthenticatedContext(context.Background())
+	ctx, err = client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, "cache", getSessionID(ctx))
@@ -273,7 +275,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 	client.token.ExpireAt = time.Now().UTC().Add(-1 * time.Hour)
 	client.muToken.Unlock()
 
-	ctx, err = client.CreateAuthenticatedContext(context.Background())
+	ctx, err = client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, "200", getSessionID(ctx))

--- a/providers/dns/joker/internal/svc/client_test.go
+++ b/providers/dns/joker/internal/svc/client_test.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,7 +51,7 @@ func TestClient_Send(t *testing.T) {
 	label := "_acme-challenge"
 	value := "123"
 
-	err := client.SendRequest(context.Background(), zone, label, value)
+	err := client.SendRequest(t.Context(), zone, label, value)
 	require.NoError(t, err)
 }
 
@@ -83,6 +82,6 @@ func TestClient_Send_empty(t *testing.T) {
 	label := "_acme-challenge"
 	value := ""
 
-	err := client.SendRequest(context.Background(), zone, label, value)
+	err := client.SendRequest(t.Context(), zone, label, value)
 	require.NoError(t, err)
 }

--- a/providers/dns/joker/joker_test.go
+++ b/providers/dns/joker/joker_test.go
@@ -20,7 +20,7 @@ func TestNewDNSProvider(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		envVars  map[string]string
-		expected interface{}
+		expected any
 	}{
 		{
 			desc: "mode DMAPI (default)",
@@ -72,7 +72,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		mode     string
-		expected interface{}
+		expected any
 	}{
 		{
 			desc:     "mode DMAPI (default)",

--- a/providers/dns/liara/internal/client_test.go
+++ b/providers/dns/liara/internal/client_test.go
@@ -128,7 +128,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 	require.Error(t, err)
 }
 
-func testHandler(filename string, method string, statusCode int) http.HandlerFunc {
+func testHandler(filename, method string, statusCode int) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != method {
 			http.Error(rw, fmt.Sprintf("unsupported method: %s", req.Method), http.StatusMethodNotAllowed)

--- a/providers/dns/liara/internal/client_test.go
+++ b/providers/dns/liara/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +21,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/zones/example.com/dns-records", testHandler("./RecordsResponse.json", http.MethodGet, http.StatusOK))
 
-	records, err := client.GetRecords(context.Background(), "example.com")
+	records, err := client.GetRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -46,7 +45,7 @@ func TestClient_GetRecord(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/zones/example.com/dns-records/123", testHandler("./RecordResponse.json", http.MethodGet, http.StatusOK))
 
-	record, err := client.GetRecord(context.Background(), "example.com", "123")
+	record, err := client.GetRecord(t.Context(), "example.com", "123")
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -79,7 +78,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		TTL: 3600,
 	}
 
-	record, err := client.CreateRecord(context.Background(), "example.com", data)
+	record, err := client.CreateRecord(t.Context(), "example.com", data)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -104,7 +103,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteRecord(context.Background(), "example.com", "123")
+	err := client.DeleteRecord(t.Context(), "example.com", "123")
 	require.NoError(t, err)
 }
 
@@ -115,7 +114,7 @@ func TestClient_DeleteRecord_NotFound_Response(t *testing.T) {
 		rw.WriteHeader(http.StatusNotFound)
 	})
 
-	err := client.DeleteRecord(context.Background(), "example.com", "123")
+	err := client.DeleteRecord(t.Context(), "example.com", "123")
 	require.NoError(t, err)
 }
 
@@ -124,7 +123,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/zones/example.com/dns-records/123", testHandler("./error.json", http.MethodDelete, http.StatusUnauthorized))
 
-	err := client.DeleteRecord(context.Background(), "example.com", "123")
+	err := client.DeleteRecord(t.Context(), "example.com", "123")
 	require.Error(t, err)
 }
 

--- a/providers/dns/lightsail/lightsail.go
+++ b/providers/dns/lightsail/lightsail.go
@@ -96,10 +96,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 				// causing a high number of consecutive throttling errors.
 				// For reference: Route 53 enforces an account-wide(!) 5req/s query limit.
 				options.Backoff = retry.BackoffDelayerFunc(func(attempt int, err error) (time.Duration, error) {
-					retryCount := attempt
-					if retryCount > 7 {
-						retryCount = 7
-					}
+					retryCount := min(attempt, 7)
 
 					delay := (1 << uint(retryCount)) * (rand.Intn(50) + 200)
 					return time.Duration(delay) * time.Millisecond, nil

--- a/providers/dns/lightsail/lightsail_integration_test.go
+++ b/providers/dns/lightsail/lightsail_integration_test.go
@@ -1,7 +1,6 @@
 package lightsail
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,7 +28,7 @@ func TestLiveTTL(t *testing.T) {
 	// we need a separate Lightsail client here as the one in the DNS provider is unexported.
 	fqdn := "_acme-challenge." + domain
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)

--- a/providers/dns/lightsail/lightsail_test.go
+++ b/providers/dns/lightsail/lightsail_test.go
@@ -1,7 +1,6 @@
 package lightsail
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestCredentialsFromEnv(t *testing.T) {
 	_ = os.Setenv(envAwsSecretAccessKey, "123")
 	_ = os.Setenv(envAwsRegion, "us-east-1")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
 

--- a/providers/dns/limacity/internal/client_test.go
+++ b/providers/dns/limacity/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,7 +65,7 @@ func TestClient_GetDomains(t *testing.T) {
 
 	mux.HandleFunc("/domains.json", testHandler("get-domains.json", http.MethodGet, http.StatusOK))
 
-	domains, err := client.GetDomains(context.Background())
+	domains, err := client.GetDomains(t.Context())
 	require.NoError(t, err)
 
 	expected := []Domain{{
@@ -84,7 +83,7 @@ func TestClient_GetDomains_error(t *testing.T) {
 
 	mux.HandleFunc("/domains.json", testHandler("error.json", http.MethodGet, http.StatusBadRequest))
 
-	_, err := client.GetDomains(context.Background())
+	_, err := client.GetDomains(t.Context())
 	require.EqualError(t, err, "[status code: 400] status: invalid_resource, details: name: [muss ausgefüllt werden]")
 }
 
@@ -93,7 +92,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records.json", testHandler("get-records.json", http.MethodGet, http.StatusOK))
 
-	records, err := client.GetRecords(context.Background(), 123)
+	records, err := client.GetRecords(t.Context(), 123)
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -120,7 +119,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records.json", testHandler("error.json", http.MethodGet, http.StatusBadRequest))
 
-	_, err := client.GetRecords(context.Background(), 123)
+	_, err := client.GetRecords(t.Context(), 123)
 	require.EqualError(t, err, "[status code: 400] status: invalid_resource, details: name: [muss ausgefüllt werden]")
 }
 
@@ -136,7 +135,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Type:    "TXT",
 	}
 
-	err := client.AddRecord(context.Background(), 123, record)
+	err := client.AddRecord(t.Context(), 123, record)
 	require.NoError(t, err)
 }
 
@@ -152,7 +151,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Type:    "TXT",
 	}
 
-	err := client.AddRecord(context.Background(), 123, record)
+	err := client.AddRecord(t.Context(), 123, record)
 	require.EqualError(t, err, "[status code: 400] status: invalid_resource, details: name: [muss ausgefüllt werden]")
 }
 
@@ -161,7 +160,7 @@ func TestClient_UpdateRecord(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records/456", testHandler("ok.json", http.MethodPut, http.StatusOK))
 
-	err := client.UpdateRecord(context.Background(), 123, 456, Record{})
+	err := client.UpdateRecord(t.Context(), 123, 456, Record{})
 	require.NoError(t, err)
 }
 
@@ -170,7 +169,7 @@ func TestClient_UpdateRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records/456", testHandler("error.json", http.MethodPut, http.StatusBadRequest))
 
-	err := client.UpdateRecord(context.Background(), 123, 456, Record{})
+	err := client.UpdateRecord(t.Context(), 123, 456, Record{})
 	require.EqualError(t, err, "[status code: 400] status: invalid_resource, details: name: [muss ausgefüllt werden]")
 }
 
@@ -179,7 +178,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records/456", testHandler("ok.json", http.MethodDelete, http.StatusOK))
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.NoError(t, err)
 }
 
@@ -188,6 +187,6 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/domains/123/records/456", testHandler("error.json", http.MethodDelete, http.StatusBadRequest))
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.EqualError(t, err, "[status code: 400] status: invalid_resource, details: name: [muss ausgefüllt werden]")
 }

--- a/providers/dns/limacity/internal/client_test.go
+++ b/providers/dns/limacity/internal/client_test.go
@@ -30,7 +30,7 @@ func setupTest(t *testing.T) (*Client, *http.ServeMux) {
 	return client, mux
 }
 
-func testHandler(filename string, method string, statusCode int) http.HandlerFunc {
+func testHandler(filename, method string, statusCode int) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != method {
 			http.Error(rw, fmt.Sprintf("unsupported method: %s", req.Method), http.StatusMethodNotAllowed)

--- a/providers/dns/limacity/limacity.go
+++ b/providers/dns/limacity/limacity.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/providers/dns/limacity/internal"
-	"github.com/miekg/dns"
 )
 
 // Environment variables names.
@@ -185,8 +184,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	for _, index := range dns.Split(fqdn) {
-		f := fqdn[index:]
+	for f := range dns01.DomainsSeq(fqdn) {
 		domain := dns01.UnFqdn(f)
 
 		for _, dom := range domains {

--- a/providers/dns/limacity/limacity.go
+++ b/providers/dns/limacity/limacity.go
@@ -185,9 +185,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	labelIndexes := dns.Split(fqdn)
-
-	for _, index := range labelIndexes {
+	for _, index := range dns.Split(fqdn) {
 		f := fqdn[index:]
 		domain := dns01.UnFqdn(f)
 

--- a/providers/dns/linode/linode_test.go
+++ b/providers/dns/linode/linode_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockResponseMap map[string]interface{}
+type MockResponseMap map[string]any
 
 var envTest = tester.NewEnvTest(EnvToken)
 

--- a/providers/dns/loopia/internal/client.go
+++ b/providers/dns/loopia/internal/client.go
@@ -37,7 +37,7 @@ func NewClient(apiUser, apiPassword string) *Client {
 }
 
 // AddTXTRecord adds a TXT record.
-func (c *Client) AddTXTRecord(ctx context.Context, domain string, subdomain string, ttl int, value string) error {
+func (c *Client) AddTXTRecord(ctx context.Context, domain, subdomain string, ttl int, value string) error {
 	call := &methodCall{
 		MethodName: "addZoneRecord",
 		Params: []param{
@@ -67,7 +67,7 @@ func (c *Client) AddTXTRecord(ctx context.Context, domain string, subdomain stri
 }
 
 // RemoveTXTRecord removes a TXT record.
-func (c *Client) RemoveTXTRecord(ctx context.Context, domain string, subdomain string, recordID int) error {
+func (c *Client) RemoveTXTRecord(ctx context.Context, domain, subdomain string, recordID int) error {
 	call := &methodCall{
 		MethodName: "removeZoneRecord",
 		Params: []param{
@@ -89,7 +89,7 @@ func (c *Client) RemoveTXTRecord(ctx context.Context, domain string, subdomain s
 }
 
 // GetTXTRecords gets TXT records.
-func (c *Client) GetTXTRecords(ctx context.Context, domain string, subdomain string) ([]RecordObj, error) {
+func (c *Client) GetTXTRecords(ctx context.Context, domain, subdomain string) ([]RecordObj, error) {
 	call := &methodCall{
 		MethodName: "getZoneRecords",
 		Params: []param{

--- a/providers/dns/loopia/internal/client_test.go
+++ b/providers/dns/loopia/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -59,7 +58,7 @@ func TestClient_AddZoneRecord(t *testing.T) {
 			client := NewClient("apiuser", test.password)
 			client.BaseURL = serverURL + "/"
 
-			err := client.AddTXTRecord(context.Background(), test.domain, exampleSubDomain, 123, "TXTrecord")
+			err := client.AddTXTRecord(t.Context(), test.domain, exampleSubDomain, 123, "TXTrecord")
 			if test.err == "" {
 				require.NoError(t, err)
 			} else {
@@ -116,7 +115,7 @@ func TestClient_RemoveSubdomain(t *testing.T) {
 			client := NewClient("apiuser", test.password)
 			client.BaseURL = serverURL + "/"
 
-			err := client.RemoveSubdomain(context.Background(), test.domain, exampleSubDomain)
+			err := client.RemoveSubdomain(t.Context(), test.domain, exampleSubDomain)
 			if test.err == "" {
 				require.NoError(t, err)
 			} else {
@@ -173,7 +172,7 @@ func TestClient_RemoveZoneRecord(t *testing.T) {
 			client := NewClient("apiuser", test.password)
 			client.BaseURL = serverURL + "/"
 
-			err := client.RemoveTXTRecord(context.Background(), test.domain, exampleSubDomain, 12345678)
+			err := client.RemoveTXTRecord(t.Context(), test.domain, exampleSubDomain, 12345678)
 			if test.err == "" {
 				require.NoError(t, err)
 			} else {
@@ -194,7 +193,7 @@ func TestClient_GetZoneRecord(t *testing.T) {
 	client := NewClient("apiuser", "goodpassword")
 	client.BaseURL = serverURL + "/"
 
-	recordObjs, err := client.GetTXTRecords(context.Background(), exampleDomain, exampleSubDomain)
+	recordObjs, err := client.GetTXTRecords(t.Context(), exampleDomain, exampleSubDomain)
 	require.NoError(t, err)
 
 	expected := []RecordObj{
@@ -238,7 +237,7 @@ func TestClient_rpcCall_404(t *testing.T) {
 	client := NewClient("apiuser", "apipassword")
 	client.BaseURL = server.URL + "/"
 
-	err := client.rpcCall(context.Background(), call, &responseString{})
+	err := client.rpcCall(t.Context(), call, &responseString{})
 	require.EqualError(t, err, "unexpected status code: [status code: 404] body: <?xml version='1.0' encoding='UTF-8'?>")
 }
 
@@ -269,7 +268,7 @@ func TestClient_rpcCall_RPCError(t *testing.T) {
 	client := NewClient("apiuser", "apipassword")
 	client.BaseURL = server.URL + "/"
 
-	err := client.rpcCall(context.Background(), call, &responseString{})
+	err := client.rpcCall(t.Context(), call, &responseString{})
 	require.EqualError(t, err, "RPC Error: (201) Method signature error: 42")
 }
 

--- a/providers/dns/loopia/loopia.go
+++ b/providers/dns/loopia/loopia.go
@@ -34,9 +34,9 @@ const minTTL = 300
 var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
 
 type dnsClient interface {
-	AddTXTRecord(ctx context.Context, domain string, subdomain string, ttl int, value string) error
-	RemoveTXTRecord(ctx context.Context, domain string, subdomain string, recordID int) error
-	GetTXTRecords(ctx context.Context, domain string, subdomain string) ([]internal.RecordObj, error)
+	AddTXTRecord(ctx context.Context, domain, subdomain string, ttl int, value string) error
+	RemoveTXTRecord(ctx context.Context, domain, subdomain string, recordID int) error
+	GetTXTRecords(ctx context.Context, domain, subdomain string) ([]internal.RecordObj, error)
 	RemoveSubdomain(ctx context.Context, domain, subdomain string) error
 }
 

--- a/providers/dns/loopia/loopia_mock_test.go
+++ b/providers/dns/loopia/loopia_mock_test.go
@@ -215,17 +215,17 @@ type mockedClient struct {
 	mock.Mock
 }
 
-func (c *mockedClient) RemoveTXTRecord(ctx context.Context, domain string, subdomain string, recordID int) error {
+func (c *mockedClient) RemoveTXTRecord(ctx context.Context, domain, subdomain string, recordID int) error {
 	args := c.Called(domain, subdomain, recordID)
 	return args.Error(0)
 }
 
-func (c *mockedClient) AddTXTRecord(ctx context.Context, domain string, subdomain string, ttl int, value string) error {
+func (c *mockedClient) AddTXTRecord(ctx context.Context, domain, subdomain string, ttl int, value string) error {
 	args := c.Called(domain, subdomain, ttl, value)
 	return args.Error(0)
 }
 
-func (c *mockedClient) GetTXTRecords(ctx context.Context, domain string, subdomain string) ([]internal.RecordObj, error) {
+func (c *mockedClient) GetTXTRecords(ctx context.Context, domain, subdomain string) ([]internal.RecordObj, error) {
 	args := c.Called(domain, subdomain)
 	return args.Get(0).([]internal.RecordObj), args.Error(1)
 }

--- a/providers/dns/luadns/internal/client_test.go
+++ b/providers/dns/luadns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -57,7 +56,7 @@ func TestClient_ListZones(t *testing.T) {
 		}
 	})
 
-	zones, err := client.ListZones(context.Background())
+	zones, err := client.ListZones(t.Context())
 	require.NoError(t, err)
 
 	expected := []DNSZone{
@@ -126,7 +125,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		TTL:     300,
 	}
 
-	newRecord, err := client.CreateRecord(context.Background(), zone, record)
+	newRecord, err := client.CreateRecord(t.Context(), zone, record)
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
@@ -179,6 +178,6 @@ func TestClient_DeleteRecord(t *testing.T) {
 		ZoneID:  1,
 	}
 
-	err := client.DeleteRecord(context.Background(), record)
+	err := client.DeleteRecord(t.Context(), record)
 	require.NoError(t, err)
 }

--- a/providers/dns/manageengine/internal/client.go
+++ b/providers/dns/manageengine/internal/client.go
@@ -75,7 +75,7 @@ func (c *Client) GetAllZoneRecords(ctx context.Context, zoneID int) ([]ZoneRecor
 
 // DeleteZoneRecord deletes a "zone record".
 // https://pitstop.manageengine.com/portal/en/kb/articles/manageengine-clouddns-rest-api-documentation#DEL_Delete_10
-func (c *Client) DeleteZoneRecord(ctx context.Context, zoneID int, domainID int) error {
+func (c *Client) DeleteZoneRecord(ctx context.Context, zoneID, domainID int) error {
 	endpoint := c.baseURL.JoinPath("dns", "domain", strconv.Itoa(zoneID), "records", "SPF_TXT", strconv.Itoa(domainID))
 
 	req, err := newRequest(ctx, http.MethodDelete, endpoint, nil)

--- a/providers/dns/manageengine/internal/client_test.go
+++ b/providers/dns/manageengine/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +42,7 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 		}
 	})
 
-	client := NewClient(context.Background(), "abc", "secret")
+	client := NewClient(t.Context(), "abc", "secret")
 
 	client.httpClient = server.Client()
 	client.baseURL, _ = url.Parse(server.URL)
@@ -54,7 +53,7 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 func TestClient_GetAllZones(t *testing.T) {
 	client := setupTest(t, "GET /dns/domain", http.StatusOK, "zone_domains_all.json")
 
-	groups, err := client.GetAllZones(context.Background())
+	groups, err := client.GetAllZones(t.Context())
 	require.NoError(t, err)
 
 	expected := []Zone{
@@ -135,7 +134,7 @@ func TestClient_GetAllZones(t *testing.T) {
 func TestClient_GetAllZones_error(t *testing.T) {
 	client := setupTest(t, "GET /dns/domain", http.StatusUnauthorized, "error.json")
 
-	_, err := client.GetAllZones(context.Background())
+	_, err := client.GetAllZones(t.Context())
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 401] Authentication credentials were not provided.")
@@ -144,7 +143,7 @@ func TestClient_GetAllZones_error(t *testing.T) {
 func TestClient_GetAllZoneRecords(t *testing.T) {
 	client := setupTest(t, "GET /dns/domain/4/records/SPF_TXT", http.StatusOK, "zone_records_all.json")
 
-	groups, err := client.GetAllZoneRecords(context.Background(), 4)
+	groups, err := client.GetAllZoneRecords(t.Context(), 4)
 	require.NoError(t, err)
 
 	expected := []ZoneRecord{
@@ -182,7 +181,7 @@ func TestClient_GetAllZoneRecords(t *testing.T) {
 func TestClient_GetAllZoneRecords_error(t *testing.T) {
 	client := setupTest(t, "GET /dns/domain/4/records/SPF_TXT", http.StatusUnauthorized, "error.json")
 
-	_, err := client.GetAllZoneRecords(context.Background(), 4)
+	_, err := client.GetAllZoneRecords(t.Context(), 4)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 401] Authentication credentials were not provided.")
@@ -191,14 +190,14 @@ func TestClient_GetAllZoneRecords_error(t *testing.T) {
 func TestClient_DeleteZoneRecord(t *testing.T) {
 	client := setupTest(t, "DELETE /dns/domain/4/records/SPF_TXT/6", http.StatusOK, "zone_record_delete.json")
 
-	err := client.DeleteZoneRecord(context.Background(), 4, 6)
+	err := client.DeleteZoneRecord(t.Context(), 4, 6)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteZoneRecord_error(t *testing.T) {
 	client := setupTest(t, "DELETE /dns/domain/4/records/SPF_TXT/6", http.StatusUnauthorized, "error.json")
 
-	err := client.DeleteZoneRecord(context.Background(), 4, 6)
+	err := client.DeleteZoneRecord(t.Context(), 4, 6)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 401] Authentication credentials were not provided.")
@@ -209,7 +208,7 @@ func TestClient_CreateZoneRecord(t *testing.T) {
 
 	record := ZoneRecord{}
 
-	err := client.CreateZoneRecord(context.Background(), 4, record)
+	err := client.CreateZoneRecord(t.Context(), 4, record)
 	require.NoError(t, err)
 }
 
@@ -218,7 +217,7 @@ func TestClient_CreateZoneRecord_error(t *testing.T) {
 
 	record := ZoneRecord{}
 
-	err := client.CreateZoneRecord(context.Background(), 4, record)
+	err := client.CreateZoneRecord(t.Context(), 4, record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 401] Authentication credentials were not provided.")
@@ -229,7 +228,7 @@ func TestClient_CreateZoneRecord_error_bad_request(t *testing.T) {
 
 	record := ZoneRecord{}
 
-	err := client.CreateZoneRecord(context.Background(), 4, record)
+	err := client.CreateZoneRecord(t.Context(), 4, record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 400] Invalid record format, Record should be in list.")
@@ -243,7 +242,7 @@ func TestClient_UpdateZoneRecord(t *testing.T) {
 		ZoneID:         4,
 	}
 
-	err := client.UpdateZoneRecord(context.Background(), record)
+	err := client.UpdateZoneRecord(t.Context(), record)
 	require.NoError(t, err)
 }
 
@@ -255,7 +254,7 @@ func TestClient_UpdateZoneRecord_error(t *testing.T) {
 		ZoneID:         4,
 	}
 
-	err := client.UpdateZoneRecord(context.Background(), record)
+	err := client.UpdateZoneRecord(t.Context(), record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "[status code: 401] Authentication credentials were not provided.")

--- a/providers/dns/metaregistrar/internal/client_test.go
+++ b/providers/dns/metaregistrar/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -64,7 +63,7 @@ func TestClient_UpdateDNSZone(t *testing.T) {
 		}},
 	}
 
-	response, err := client.UpdateDNSZone(context.Background(), "example.com", updateRequest)
+	response, err := client.UpdateDNSZone(t.Context(), "example.com", updateRequest)
 	require.NoError(t, err)
 
 	expected := &DNSZoneUpdateResponse{
@@ -107,7 +106,7 @@ func TestClient_UpdateDNSZone_error(t *testing.T) {
 				}},
 			}
 
-			_, err := client.UpdateDNSZone(context.Background(), "example.com", updateRequest)
+			_, err := client.UpdateDNSZone(t.Context(), "example.com", updateRequest)
 			require.EqualError(t, err, test.expected)
 		})
 	}

--- a/providers/dns/mijnhost/internal/client_test.go
+++ b/providers/dns/mijnhost/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,7 +65,7 @@ func TestClient_ListDomains(t *testing.T) {
 
 	mux.HandleFunc("/domains", testHandler("./list-domains.json", http.MethodGet, http.StatusOK))
 
-	domains, err := client.ListDomains(context.Background())
+	domains, err := client.ListDomains(t.Context())
 	require.NoError(t, err)
 
 	expected := []Domain{{
@@ -86,7 +85,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/dns", testHandler("./get-dns-records.json", http.MethodGet, http.StatusOK))
 
-	records, err := client.GetRecords(context.Background(), "example.com")
+	records, err := client.GetRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -124,6 +123,6 @@ func TestClient_UpdateRecords(t *testing.T) {
 
 	mux.HandleFunc("/domains/example.com/dns", testHandler("./update-dns-records.json", http.MethodPut, http.StatusOK))
 
-	err := client.UpdateRecords(context.Background(), "example.com", nil)
+	err := client.UpdateRecords(t.Context(), "example.com", nil)
 	require.NoError(t, err)
 }

--- a/providers/dns/mijnhost/internal/client_test.go
+++ b/providers/dns/mijnhost/internal/client_test.go
@@ -30,7 +30,7 @@ func setupTest(t *testing.T) (*Client, *http.ServeMux) {
 	return client, mux
 }
 
-func testHandler(filename string, method string, statusCode int) http.HandlerFunc {
+func testHandler(filename, method string, statusCode int) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != method {
 			http.Error(rw, fmt.Sprintf("unsupported method: %s", req.Method), http.StatusMethodNotAllowed)

--- a/providers/dns/mijnhost/mijnhost.go
+++ b/providers/dns/mijnhost/mijnhost.go
@@ -184,9 +184,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	labelIndexes := dns.Split(fqdn)
-
-	for _, index := range labelIndexes {
+	for _, index := range dns.Split(fqdn) {
 		domain := dns01.UnFqdn(fqdn[index:])
 
 		for _, dom := range domains {

--- a/providers/dns/mijnhost/mijnhost.go
+++ b/providers/dns/mijnhost/mijnhost.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/providers/dns/mijnhost/internal"
-	"github.com/miekg/dns"
 )
 
 // Environment variables names.
@@ -184,9 +183,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	for _, index := range dns.Split(fqdn) {
-		domain := dns01.UnFqdn(fqdn[index:])
-
+	for domain := range dns01.UnFqdnDomainsSeq(fqdn) {
 		for _, dom := range domains {
 			if dom.Domain == domain {
 				return dom, nil

--- a/providers/dns/mittwald/internal/client_test.go
+++ b/providers/dns/mittwald/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -69,7 +68,7 @@ func testHandler(method string, statusCode int, filename string) http.HandlerFun
 func TestClient_ListDomains(t *testing.T) {
 	client := setupTest(t, "/domains", testHandler(http.MethodGet, http.StatusOK, "domain-list-domains.json"))
 
-	domains, err := client.ListDomains(context.Background())
+	domains, err := client.ListDomains(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, domains, 1)
@@ -86,14 +85,14 @@ func TestClient_ListDomains(t *testing.T) {
 func TestClient_ListDomains_error(t *testing.T) {
 	client := setupTest(t, "/domains", testHandler(http.MethodGet, http.StatusBadRequest, "error-client.json"))
 
-	_, err := client.ListDomains(context.Background())
+	_, err := client.ListDomains(t.Context())
 	require.EqualError(t, err, "[status code 400] ValidationError: Validation failed [format: should be string (.address.street, email)]")
 }
 
 func TestClient_ListDNSZones(t *testing.T) {
 	client := setupTest(t, "/projects/my-project-id/dns-zones", testHandler(http.MethodGet, http.StatusOK, "dns-list-dns-zones.json"))
 
-	zones, err := client.ListDNSZones(context.Background(), "my-project-id")
+	zones, err := client.ListDNSZones(t.Context(), "my-project-id")
 	require.NoError(t, err)
 
 	require.Len(t, zones, 1)
@@ -112,7 +111,7 @@ func TestClient_ListDNSZones(t *testing.T) {
 func TestClient_GetDNSZone(t *testing.T) {
 	client := setupTest(t, "/dns-zones/my-zone-id", testHandler(http.MethodGet, http.StatusOK, "dns-get-dns-zone.json"))
 
-	zone, err := client.GetDNSZone(context.Background(), "my-zone-id")
+	zone, err := client.GetDNSZone(t.Context(), "my-zone-id")
 	require.NoError(t, err)
 
 	expected := &DNSZone{
@@ -134,7 +133,7 @@ func TestClient_CreateDNSZone(t *testing.T) {
 		ParentZoneID: "my-parent-zone-id",
 	}
 
-	zone, err := client.CreateDNSZone(context.Background(), request)
+	zone, err := client.CreateDNSZone(t.Context(), request)
 	require.NoError(t, err)
 
 	expected := &DNSZone{
@@ -154,20 +153,20 @@ func TestClient_UpdateTXTRecord(t *testing.T) {
 		Entries: []string{"txt"},
 	}
 
-	err := client.UpdateTXTRecord(context.Background(), "my-zone-id", record)
+	err := client.UpdateTXTRecord(t.Context(), "my-zone-id", record)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteDNSZone(t *testing.T) {
 	client := setupTest(t, "/dns-zones/my-zone-id", testHandler(http.MethodDelete, http.StatusOK, ""))
 
-	err := client.DeleteDNSZone(context.Background(), "my-zone-id")
+	err := client.DeleteDNSZone(t.Context(), "my-zone-id")
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteDNSZone_error(t *testing.T) {
 	client := setupTest(t, "/dns-zones/my-zone-id", testHandler(http.MethodDelete, http.StatusInternalServerError, "error.json"))
 
-	err := client.DeleteDNSZone(context.Background(), "my-zone-id")
+	err := client.DeleteDNSZone(t.Context(), "my-zone-id")
 	assert.EqualError(t, err, "[status code 500] InternalServerError: Something went wrong")
 }

--- a/providers/dns/mittwald/mittwald.go
+++ b/providers/dns/mittwald/mittwald.go
@@ -212,9 +212,7 @@ func (d *DNSProvider) getOrCreateZone(ctx context.Context, fqdn string) (*intern
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	labelIndexes := dns.Split(fqdn)
-
-	for _, index := range labelIndexes {
+	for _, index := range dns.Split(fqdn) {
 		domain := dns01.UnFqdn(fqdn[index:])
 
 		for _, dom := range domains {
@@ -228,9 +226,7 @@ func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error)
 }
 
 func findZone(zones []internal.DNSZone, fqdn string) (internal.DNSZone, error) {
-	labelIndexes := dns.Split(fqdn)
-
-	for _, index := range labelIndexes {
+	for _, index := range dns.Split(fqdn) {
 		domain := dns01.UnFqdn(fqdn[index:])
 
 		for _, zon := range zones {

--- a/providers/dns/mittwald/mittwald.go
+++ b/providers/dns/mittwald/mittwald.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/providers/dns/mittwald/internal"
-	"github.com/miekg/dns"
 )
 
 // Environment variables names.
@@ -212,9 +211,7 @@ func (d *DNSProvider) getOrCreateZone(ctx context.Context, fqdn string) (*intern
 }
 
 func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error) {
-	for _, index := range dns.Split(fqdn) {
-		domain := dns01.UnFqdn(fqdn[index:])
-
+	for domain := range dns01.UnFqdnDomainsSeq(fqdn) {
 		for _, dom := range domains {
 			if dom.Domain == domain {
 				return dom, nil
@@ -226,9 +223,7 @@ func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error)
 }
 
 func findZone(zones []internal.DNSZone, fqdn string) (internal.DNSZone, error) {
-	for _, index := range dns.Split(fqdn) {
-		domain := dns01.UnFqdn(fqdn[index:])
-
+	for domain := range dns01.UnFqdnDomainsSeq(fqdn) {
 		for _, zon := range zones {
 			if zon.Domain == domain {
 				return zon, nil

--- a/providers/dns/myaddr/internal/client_test.go
+++ b/providers/dns/myaddr/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -58,20 +57,20 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 func TestClient_AddTXTRecord(t *testing.T) {
 	client := setupTest(t, "POST /update", http.StatusOK, "")
 
-	err := client.AddTXTRecord(context.Background(), "example", "txt")
+	err := client.AddTXTRecord(t.Context(), "example", "txt")
 	require.NoError(t, err)
 }
 
 func TestClient_AddTXTRecord_error(t *testing.T) {
 	client := setupTest(t, "POST /update", http.StatusBadRequest, "error.txt")
 
-	err := client.AddTXTRecord(context.Background(), "example", "txt")
+	err := client.AddTXTRecord(t.Context(), "example", "txt")
 	require.EqualError(t, err, `unexpected status code: [status code: 400] body: invalid value for "key"`)
 }
 
 func TestClient_AddTXTRecord_error_credentials(t *testing.T) {
 	client := setupTest(t, "POST /update", http.StatusOK, "")
 
-	err := client.AddTXTRecord(context.Background(), "nx", "txt")
+	err := client.AddTXTRecord(t.Context(), "nx", "txt")
 	require.EqualError(t, err, "subdomain nx not found in credentials, check your credentials map")
 }

--- a/providers/dns/myaddr/myaddr.go
+++ b/providers/dns/myaddr/myaddr.go
@@ -146,8 +146,7 @@ func (d *DNSProvider) Sequential() time.Duration {
 func parseCredentials(raw string) (map[string]string, error) {
 	credentials := make(map[string]string)
 
-	credStrings := strings.Split(strings.TrimSuffix(raw, ","), ",")
-	for _, credPair := range credStrings {
+	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
 		data := strings.Split(credPair, ":")
 		if len(data) != 2 {
 			return nil, fmt.Errorf("incorrect credential pair: %s", credPair)

--- a/providers/dns/myaddr/myaddr.go
+++ b/providers/dns/myaddr/myaddr.go
@@ -66,7 +66,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 
 	config := NewDefaultConfig()
 
-	credentials, err := parseCredentials(values[EnvPrivateKeysMapping])
+	credentials, err := env.ParsePairs(values[EnvPrivateKeysMapping])
 	if err != nil {
 		return nil, fmt.Errorf("myaddr: %w", err)
 	}
@@ -141,19 +141,4 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 // Returns the interval between each iteration.
 func (d *DNSProvider) Sequential() time.Duration {
 	return d.config.SequenceInterval
-}
-
-func parseCredentials(raw string) (map[string]string, error) {
-	credentials := make(map[string]string)
-
-	for credPair := range strings.SplitSeq(strings.TrimSuffix(raw, ","), ",") {
-		data := strings.Split(credPair, ":")
-		if len(data) != 2 {
-			return nil, fmt.Errorf("incorrect credential pair: %s", credPair)
-		}
-
-		credentials[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
-	}
-
-	return credentials, nil
 }

--- a/providers/dns/mydnsjp/internal/client.go
+++ b/providers/dns/mydnsjp/internal/client.go
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // NewClient Creates a new Client.
-func NewClient(masterID string, password string) *Client {
+func NewClient(masterID, password string) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{

--- a/providers/dns/mydnsjp/internal/client_test.go
+++ b/providers/dns/mydnsjp/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -80,13 +79,13 @@ func setupTest(t *testing.T, cmdName string) *Client {
 func TestClient_AddTXTRecord(t *testing.T) {
 	client := setupTest(t, "REGIST")
 
-	err := client.AddTXTRecord(context.Background(), "example.com", "txt")
+	err := client.AddTXTRecord(t.Context(), "example.com", "txt")
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteTXTRecord(t *testing.T) {
 	client := setupTest(t, "DELETE")
 
-	err := client.DeleteTXTRecord(context.Background(), "example.com", "txt")
+	err := client.DeleteTXTRecord(t.Context(), "example.com", "txt")
 	require.NoError(t, err)
 }

--- a/providers/dns/mythicbeasts/internal/client.go
+++ b/providers/dns/mythicbeasts/internal/client.go
@@ -35,7 +35,7 @@ type Client struct {
 }
 
 // NewClient Creates a new Client.
-func NewClient(username string, password string) *Client {
+func NewClient(username, password string) *Client {
 	apiEndpoint, _ := url.Parse(APIBaseURL)
 	authEndpoint, _ := url.Parse(AuthBaseURL)
 

--- a/providers/dns/mythicbeasts/internal/client_test.go
+++ b/providers/dns/mythicbeasts/internal/client_test.go
@@ -57,13 +57,13 @@ func writeFixtureHandler(method, filename string) http.HandlerFunc {
 func TestClient_CreateTXTRecord(t *testing.T) {
 	client := setupTest(t, "/zones/example.com/records/foo/TXT", writeFixtureHandler(http.MethodPost, "post-zoneszonerecords.json"))
 
-	err := client.CreateTXTRecord(mockContext(), "example.com", "foo", "txt", 120)
+	err := client.CreateTXTRecord(mockContext(t), "example.com", "foo", "txt", 120)
 	require.NoError(t, err)
 }
 
 func TestClient_RemoveTXTRecord(t *testing.T) {
 	client := setupTest(t, "/zones/example.com/records/foo/TXT", writeFixtureHandler(http.MethodDelete, "delete-zoneszonerecords.json"))
 
-	err := client.RemoveTXTRecord(mockContext(), "example.com", "foo", "txt")
+	err := client.RemoveTXTRecord(mockContext(t), "example.com", "foo", "txt")
 	require.NoError(t, err)
 }

--- a/providers/dns/mythicbeasts/internal/identity_test.go
+++ b/providers/dns/mythicbeasts/internal/identity_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext() context.Context {
-	return context.WithValue(context.Background(), tokenKey, &Token{Token: "xxx"})
+func mockContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return context.WithValue(t.Context(), tokenKey, &Token{Token: "xxx"})
 }
 
 func tokenHandler(rw http.ResponseWriter, req *http.Request) {
@@ -49,7 +51,7 @@ func TestClient_obtainToken(t *testing.T) {
 
 	assert.Nil(t, client.token)
 
-	tok, err := client.obtainToken(context.Background())
+	tok, err := client.obtainToken(t.Context())
 	require.NoError(t, err)
 
 	assert.NotNil(t, tok)
@@ -70,7 +72,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 
 	assert.Nil(t, client.token)
 
-	ctx, err := client.CreateAuthenticatedContext(context.Background())
+	ctx, err := client.CreateAuthenticatedContext(t.Context())
 	require.NoError(t, err)
 
 	tok := getToken(ctx)

--- a/providers/dns/namecheap/internal/client.go
+++ b/providers/dns/namecheap/internal/client.go
@@ -32,7 +32,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(apiUser string, apiKey string, clientIP string) *Client {
+func NewClient(apiUser, apiKey, clientIP string) *Client {
 	return &Client{
 		apiUser:    apiUser,
 		apiKey:     apiKey,

--- a/providers/dns/namecheap/internal/client_test.go
+++ b/providers/dns/namecheap/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -69,7 +68,7 @@ func TestClient_GetHosts(t *testing.T) {
 		writeFixture(rw, "getHosts.xml")
 	})
 
-	hosts, err := client.GetHosts(context.Background(), "foo", "example.com")
+	hosts, err := client.GetHosts(t.Context(), "foo", "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -90,7 +89,7 @@ func TestClient_GetHosts_error(t *testing.T) {
 		writeFixture(rw, "getHosts_errorBadAPIKey1.xml")
 	})
 
-	_, err := client.GetHosts(context.Background(), "foo", "example.com")
+	_, err := client.GetHosts(t.Context(), "foo", "example.com")
 	require.ErrorAs(t, err, &apiError{})
 }
 
@@ -149,7 +148,7 @@ func TestClient_SetHosts(t *testing.T) {
 		{Name: "_acme-challenge.test.example.org", Type: "TXT", Address: "txtTXTtxt", MXPref: "10", TTL: "120"},
 	}
 
-	err := client.SetHosts(context.Background(), "foo", "example.com", records)
+	err := client.SetHosts(t.Context(), "foo", "example.com", records)
 	require.NoError(t, err)
 }
 
@@ -168,6 +167,6 @@ func TestClient_SetHosts_error(t *testing.T) {
 		{Name: "_acme-challenge.test.example.org", Type: "TXT", Address: "txtTXTtxt", MXPref: "10", TTL: "120"},
 	}
 
-	err := client.SetHosts(context.Background(), "foo", "example.com", records)
+	err := client.SetHosts(t.Context(), "foo", "example.com", records)
 	require.ErrorAs(t, err, &apiError{})
 }

--- a/providers/dns/nearlyfreespeech/internal/client.go
+++ b/providers/dns/nearlyfreespeech/internal/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(login string, apiKey string) *Client {
+func NewClient(login, apiKey string) *Client {
 	baseURL, _ := url.Parse(apiURL)
 
 	return &Client{
@@ -114,7 +114,7 @@ func NewSigner() *Signer {
 	return &Signer{saltShaker: getRandomSalt, clock: time.Now}
 }
 
-func (c Signer) Sign(uri string, body, login, apiKey string) string {
+func (c Signer) Sign(uri, body, login, apiKey string) string {
 	// Header is "login;timestamp;salt;hash".
 	// hash is SHA1("login;timestamp;salt;api-key;request-uri;body-hash")
 	// and body-hash is SHA1(body).

--- a/providers/dns/nearlyfreespeech/internal/client_test.go
+++ b/providers/dns/nearlyfreespeech/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -97,7 +96,7 @@ func TestClient_AddRecord(t *testing.T) {
 		TTL:  30,
 	}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -113,7 +112,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		TTL:  30,
 	}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 }
 
@@ -134,7 +133,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 		Data: "txtTXTtxt",
 	}
 
-	err := client.RemoveRecord(context.Background(), "example.com", record)
+	err := client.RemoveRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -149,7 +148,7 @@ func TestClient_RemoveRecord_error(t *testing.T) {
 		Data: "txtTXTtxt",
 	}
 
-	err := client.RemoveRecord(context.Background(), "example.com", record)
+	err := client.RemoveRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 }
 

--- a/providers/dns/netcup/internal/client.go
+++ b/providers/dns/netcup/internal/client.go
@@ -142,7 +142,7 @@ func GetDNSRecordIdx(records []DNSRecord, record DNSRecord) (int, error) {
 	return -1, errors.New("no DNS Record found")
 }
 
-func newJSONRequest(ctx context.Context, method string, endpoint string, payload any) (*http.Request, error) {
+func newJSONRequest(ctx context.Context, method, endpoint string, payload any) (*http.Request, error) {
 	buf := new(bytes.Buffer)
 
 	if payload != nil {

--- a/providers/dns/netcup/internal/client_test.go
+++ b/providers/dns/netcup/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -212,7 +211,7 @@ func TestClient_GetDNSRecords(t *testing.T) {
 		State:        "yes",
 	}}
 
-	records, err := client.GetDNSRecords(context.Background(), "example.com")
+	records, err := client.GetDNSRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, records)
@@ -292,7 +291,7 @@ func TestClient_GetDNSRecords_errors(t *testing.T) {
 
 			mux.HandleFunc("/", test.handler)
 
-			records, err := client.GetDNSRecords(context.Background(), "example.com")
+			records, err := client.GetDNSRecords(t.Context(), "example.com")
 			require.Error(t, err)
 			assert.Empty(t, records)
 		})
@@ -313,7 +312,7 @@ func TestClient_GetDNSRecords_Live(t *testing.T) {
 		envTest.GetValue("NETCUP_API_PASSWORD"))
 	require.NoError(t, err)
 
-	ctx, err := client.CreateSessionContext(context.Background())
+	ctx, err := client.CreateSessionContext(t.Context())
 	require.NoError(t, err)
 
 	info := dns01.GetChallengeInfo(envTest.GetDomain(), "123d==")
@@ -346,7 +345,7 @@ func TestClient_UpdateDNSRecord_Live(t *testing.T) {
 		envTest.GetValue("NETCUP_API_PASSWORD"))
 	require.NoError(t, err)
 
-	ctx, err := client.CreateSessionContext(context.Background())
+	ctx, err := client.CreateSessionContext(t.Context())
 	require.NoError(t, err)
 
 	info := dns01.GetChallengeInfo(envTest.GetDomain(), "123d==")

--- a/providers/dns/netcup/internal/session_test.go
+++ b/providers/dns/netcup/internal/session_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockContext() context.Context {
-	return context.WithValue(context.Background(), sessionIDKey, "session-id")
+func mockContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return context.WithValue(t.Context(), sessionIDKey, "session-id")
 }
 
 func TestClient_Login(t *testing.T) {
@@ -53,7 +55,7 @@ func TestClient_Login(t *testing.T) {
 		}
 	})
 
-	sessionID, err := client.login(context.Background())
+	sessionID, err := client.login(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, "api-session-id", sessionID)
@@ -122,7 +124,7 @@ func TestClient_Login_errors(t *testing.T) {
 
 			mux.HandleFunc("/", test.handler)
 
-			sessionID, err := client.login(context.Background())
+			sessionID, err := client.login(t.Context())
 			assert.Error(t, err)
 			assert.Empty(t, sessionID)
 		})
@@ -162,7 +164,7 @@ func TestClient_Logout(t *testing.T) {
 		}
 	})
 
-	err := client.Logout(mockContext())
+	err := client.Logout(mockContext(t))
 	require.NoError(t, err)
 }
 
@@ -208,7 +210,7 @@ func TestClient_Logout_errors(t *testing.T) {
 
 			mux.HandleFunc("/", test.handler)
 
-			err := client.Logout(context.Background())
+			err := client.Logout(t.Context())
 			require.Error(t, err)
 		})
 	}
@@ -232,7 +234,7 @@ func TestLiveClientAuth(t *testing.T) {
 		t.Run("Test_"+strconv.Itoa(i+1), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, err := client.CreateSessionContext(context.Background())
+			ctx, err := client.CreateSessionContext(t.Context())
 			require.NoError(t, err)
 
 			err = client.Logout(ctx)

--- a/providers/dns/netlify/internal/client.go
+++ b/providers/dns/netlify/internal/client.go
@@ -124,7 +124,7 @@ func (c *Client) RemoveRecord(ctx context.Context, zoneID, recordID string) erro
 	return nil
 }
 
-func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, payload interface{}) (*http.Request, error) {
+func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, payload any) (*http.Request, error) {
 	buf := new(bytes.Buffer)
 
 	if payload != nil {

--- a/providers/dns/netlify/internal/client_test.go
+++ b/providers/dns/netlify/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -58,7 +57,7 @@ func TestClient_GetRecords(t *testing.T) {
 		}
 	})
 
-	records, err := client.GetRecords(context.Background(), "zoneID")
+	records, err := client.GetRecords(t.Context(), "zoneID")
 	require.NoError(t, err)
 
 	expected := []DNSRecord{
@@ -108,7 +107,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		Value:    "txtxtxtxtxtxt",
 	}
 
-	result, err := client.CreateRecord(context.Background(), "zoneID", record)
+	result, err := client.CreateRecord(t.Context(), "zoneID", record)
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
@@ -140,6 +139,6 @@ func TestClient_RemoveRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.RemoveRecord(context.Background(), "zoneID", "recordID")
+	err := client.RemoveRecord(t.Context(), "zoneID", "recordID")
 	require.NoError(t, err)
 }

--- a/providers/dns/nicmanager/internal/client_test.go
+++ b/providers/dns/nicmanager/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +17,7 @@ import (
 func TestClient_GetZone(t *testing.T) {
 	client := setupTest(t, "/anycast/nicmanager-anycastdns4.net", testHandler(http.MethodGet, http.StatusOK, "zone.json"))
 
-	zone, err := client.GetZone(context.Background(), "nicmanager-anycastdns4.net")
+	zone, err := client.GetZone(t.Context(), "nicmanager-anycastdns4.net")
 	require.NoError(t, err)
 
 	expected := &Zone{
@@ -41,7 +40,7 @@ func TestClient_GetZone(t *testing.T) {
 func TestClient_GetZone_error(t *testing.T) {
 	client := setupTest(t, "/anycast/foo", testHandler(http.MethodGet, http.StatusNotFound, "error.json"))
 
-	_, err := client.GetZone(context.Background(), "foo")
+	_, err := client.GetZone(t.Context(), "foo")
 	require.Error(t, err)
 }
 
@@ -55,7 +54,7 @@ func TestClient_AddRecord(t *testing.T) {
 		TTL:   3600,
 	}
 
-	err := client.AddRecord(context.Background(), "zonedomain.tld", record)
+	err := client.AddRecord(t.Context(), "zonedomain.tld", record)
 	require.NoError(t, err)
 }
 
@@ -69,21 +68,21 @@ func TestClient_AddRecord_error(t *testing.T) {
 		TTL:   3600,
 	}
 
-	err := client.AddRecord(context.Background(), "zonedomain.tld", record)
+	err := client.AddRecord(t.Context(), "zonedomain.tld", record)
 	require.Error(t, err)
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/anycast/zonedomain.tld/records/6", testHandler(http.MethodDelete, http.StatusAccepted, "error.json"))
 
-	err := client.DeleteRecord(context.Background(), "zonedomain.tld", 6)
+	err := client.DeleteRecord(t.Context(), "zonedomain.tld", 6)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/anycast/zonedomain.tld/records/6", testHandler(http.MethodDelete, http.StatusNoContent, ""))
 
-	err := client.DeleteRecord(context.Background(), "zonedomain.tld", 7)
+	err := client.DeleteRecord(t.Context(), "zonedomain.tld", 7)
 	require.Error(t, err)
 }
 

--- a/providers/dns/nicru/internal/client.go
+++ b/providers/dns/nicru/internal/client.go
@@ -136,7 +136,7 @@ func (c *Client) GetRecords(ctx context.Context, serviceName, zoneName string) (
 	return records, nil
 }
 
-func (c *Client) DeleteRecord(ctx context.Context, serviceName, zoneName string, id string) error {
+func (c *Client) DeleteRecord(ctx context.Context, serviceName, zoneName, id string) error {
 	endpoint := c.baseURL.JoinPath("services", serviceName, "zones", zoneName, "records", id)
 
 	req, err := newXMLRequest(ctx, http.MethodDelete, endpoint, nil)

--- a/providers/dns/nicru/internal/client_test.go
+++ b/providers/dns/nicru/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,7 +59,7 @@ func TestClient_GetServices(t *testing.T) {
 	client := setupTest(t, "/services",
 		writeFixtures(http.MethodGet, "services_GET.xml", http.StatusOK))
 
-	zones, err := client.GetServices(context.Background())
+	zones, err := client.GetServices(t.Context())
 	require.NoError(t, err)
 
 	expected := []Service{
@@ -95,7 +94,7 @@ func TestClient_ListZones(t *testing.T) {
 	client := setupTest(t, "/zones",
 		writeFixtures(http.MethodGet, "zones_all_GET.xml", http.StatusOK))
 
-	zones, err := client.ListZones(context.Background())
+	zones, err := client.ListZones(t.Context())
 	require.NoError(t, err)
 
 	expected := []Zone{
@@ -141,7 +140,7 @@ func TestClient_ListZones_error(t *testing.T) {
 	client := setupTest(t, "/zones",
 		writeFixtures(http.MethodGet, "errors.xml", http.StatusOK))
 
-	_, err := client.ListZones(context.Background())
+	_, err := client.ListZones(t.Context())
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",
@@ -152,7 +151,7 @@ func TestClient_GetZonesByService(t *testing.T) {
 	client := setupTest(t, "/services/test/zones",
 		writeFixtures(http.MethodGet, "zones_GET.xml", http.StatusOK))
 
-	zones, err := client.GetZonesByService(context.Background(), "test")
+	zones, err := client.GetZonesByService(t.Context(), "test")
 	require.NoError(t, err)
 
 	expected := []Zone{
@@ -198,7 +197,7 @@ func TestClient_GetZonesByService_error(t *testing.T) {
 	client := setupTest(t, "/services/test/zones",
 		writeFixtures(http.MethodGet, "errors.xml", http.StatusOK))
 
-	_, err := client.GetZonesByService(context.Background(), "test")
+	_, err := client.GetZonesByService(t.Context(), "test")
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",
@@ -209,7 +208,7 @@ func TestClient_GetRecords(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./records",
 		writeFixtures(http.MethodGet, "records_GET.xml", http.StatusOK))
 
-	records, err := client.GetRecords(context.Background(), "test", "example.com.")
+	records, err := client.GetRecords(t.Context(), "test", "example.com.")
 	require.NoError(t, err)
 
 	expected := []RR{
@@ -274,7 +273,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./records",
 		writeFixtures(http.MethodGet, "errors.xml", http.StatusOK))
 
-	_, err := client.GetRecords(context.Background(), "test", "example.com.")
+	_, err := client.GetRecords(t.Context(), "test", "example.com.")
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",
@@ -298,7 +297,7 @@ func TestClient_AddRecord(t *testing.T) {
 		},
 	}
 
-	response, err := client.AddRecords(context.Background(), "test", "example.com.", rrs)
+	response, err := client.AddRecords(t.Context(), "test", "example.com.", rrs)
 	require.NoError(t, err)
 
 	expected := []Zone{
@@ -354,7 +353,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		},
 	}
 
-	_, err := client.AddRecords(context.Background(), "test", "example.com.", rrs)
+	_, err := client.AddRecords(t.Context(), "test", "example.com.", rrs)
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",
@@ -365,7 +364,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./records/123",
 		writeFixtures(http.MethodDelete, "record_DELETE.xml", http.StatusUnauthorized))
 
-	err := client.DeleteRecord(context.Background(), "test", "example.com.", "123")
+	err := client.DeleteRecord(t.Context(), "test", "example.com.", "123")
 	require.NoError(t, err)
 }
 
@@ -373,7 +372,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./records/123",
 		writeFixtures(http.MethodDelete, "errors.xml", http.StatusUnauthorized))
 
-	err := client.DeleteRecord(context.Background(), "test", "example.com.", "123")
+	err := client.DeleteRecord(t.Context(), "test", "example.com.", "123")
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",
@@ -383,14 +382,14 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 func TestClient_CommitZone(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./commit", writeFixtures(http.MethodPost, "commit_POST.xml", http.StatusOK))
 
-	err := client.CommitZone(context.Background(), "test", "example.com.")
+	err := client.CommitZone(t.Context(), "test", "example.com.")
 	require.NoError(t, err)
 }
 
 func TestClient_CommitZone_error(t *testing.T) {
 	client := setupTest(t, "/services/test/zones/example.com./commit", writeFixtures(http.MethodPost, "errors.xml", http.StatusOK))
 
-	err := client.CommitZone(context.Background(), "test", "example.com.")
+	err := client.CommitZone(t.Context(), "test", "example.com.")
 	require.ErrorIs(t, err, Error{
 		Text: "Access token expired or not found",
 		Code: "4097",

--- a/providers/dns/nicru/internal/client_test.go
+++ b/providers/dns/nicru/internal/client_test.go
@@ -32,7 +32,7 @@ func setupTest(t *testing.T, pattern string, handler http.HandlerFunc) *Client {
 	return client
 }
 
-func writeFixtures(method string, filename string, status int) http.HandlerFunc {
+func writeFixtures(method, filename string, status int) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != method {
 			http.Error(rw, fmt.Sprintf("unsupported method: %s", req.Method), http.StatusMethodNotAllowed)

--- a/providers/dns/nifcloud/internal/client_test.go
+++ b/providers/dns/nifcloud/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +44,7 @@ func TestChangeResourceRecordSets(t *testing.T) {
 
 	client := setupTest(t, responseBody, http.StatusOK)
 
-	res, err := client.ChangeResourceRecordSets(context.Background(), "example.com", ChangeResourceRecordSetsRequest{})
+	res, err := client.ChangeResourceRecordSets(t.Context(), "example.com", ChangeResourceRecordSetsRequest{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "xxxxx", res.ChangeInfo.ID)
@@ -92,7 +91,7 @@ func TestChangeResourceRecordSetsErrors(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			client := setupTest(t, test.responseBody, test.statusCode)
 
-			res, err := client.ChangeResourceRecordSets(context.Background(), "example.com", ChangeResourceRecordSetsRequest{})
+			res, err := client.ChangeResourceRecordSets(t.Context(), "example.com", ChangeResourceRecordSetsRequest{})
 			assert.Nil(t, res)
 			assert.EqualError(t, err, test.expected)
 		})
@@ -112,7 +111,7 @@ func TestGetChange(t *testing.T) {
 
 	client := setupTest(t, responseBody, http.StatusOK)
 
-	res, err := client.GetChange(context.Background(), "12345")
+	res, err := client.GetChange(t.Context(), "12345")
 	require.NoError(t, err)
 
 	assert.Equal(t, "xxxxx", res.ChangeInfo.ID)
@@ -159,7 +158,7 @@ func TestGetChangeErrors(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			client := setupTest(t, test.responseBody, test.statusCode)
 
-			res, err := client.GetChange(context.Background(), "12345")
+			res, err := client.GetChange(t.Context(), "12345")
 			assert.Nil(t, res)
 			assert.EqualError(t, err, test.expected)
 		})

--- a/providers/dns/njalla/internal/client.go
+++ b/providers/dns/njalla/internal/client.go
@@ -55,7 +55,7 @@ func (c *Client) AddRecord(ctx context.Context, record Record) (*Record, error) 
 }
 
 // RemoveRecord removes a record.
-func (c *Client) RemoveRecord(ctx context.Context, id string, domain string) error {
+func (c *Client) RemoveRecord(ctx context.Context, id, domain string) error {
 	data := APIRequest{
 		Method: "remove-record",
 		Params: Record{
@@ -127,7 +127,7 @@ func (c *Client) do(req *http.Request, result Response) error {
 	return result.GetError()
 }
 
-func newJSONRequest(ctx context.Context, method string, endpoint string, payload any) (*http.Request, error) {
+func newJSONRequest(ctx context.Context, method, endpoint string, payload any) (*http.Request, error) {
 	buf := new(bytes.Buffer)
 
 	if payload != nil {

--- a/providers/dns/njalla/internal/client_test.go
+++ b/providers/dns/njalla/internal/client_test.go
@@ -59,7 +59,7 @@ func TestClient_AddRecord(t *testing.T) {
 
 		apiReq.Params.ID = "123"
 
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      "897",
 			"result":  apiReq.Params,
@@ -125,7 +125,7 @@ func TestClient_ListRecords(t *testing.T) {
 			return
 		}
 
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      "897",
 			"result": Records{

--- a/providers/dns/njalla/internal/client_test.go
+++ b/providers/dns/njalla/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,7 +79,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Type:    "TXT",
 	}
 
-	result, err := client.AddRecord(context.Background(), record)
+	result, err := client.AddRecord(t.Context(), record)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -106,7 +105,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Type:    "TXT",
 	}
 
-	result, err := client.AddRecord(context.Background(), record)
+	result, err := client.AddRecord(t.Context(), record)
 	require.Error(t, err)
 
 	assert.Nil(t, result)
@@ -157,7 +156,7 @@ func TestClient_ListRecords(t *testing.T) {
 		}
 	})
 
-	records, err := client.ListRecords(context.Background(), "example.com")
+	records, err := client.ListRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -186,7 +185,7 @@ func TestClient_ListRecords_error(t *testing.T) {
 	client := setupTest(t, nil)
 	client.token = "invalid"
 
-	records, err := client.ListRecords(context.Background(), "example.com")
+	records, err := client.ListRecords(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Empty(t, records)
@@ -218,7 +217,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 		_, _ = rw.Write([]byte(`{"jsonrpc":"2.0"}`))
 	})
 
-	err := client.RemoveRecord(context.Background(), "123", "example.com")
+	err := client.RemoveRecord(t.Context(), "123", "example.com")
 	require.NoError(t, err)
 }
 
@@ -226,6 +225,6 @@ func TestClient_RemoveRecord_error(t *testing.T) {
 	client := setupTest(t, nil)
 	client.token = "invalid"
 
-	err := client.RemoveRecord(context.Background(), "123", "example.com")
+	err := client.RemoveRecord(t.Context(), "123", "example.com")
 	require.Error(t, err)
 }

--- a/providers/dns/otc/internal/client.go
+++ b/providers/dns/otc/internal/client.go
@@ -196,7 +196,7 @@ func (c *Client) do(req *http.Request, result any) error {
 	return nil
 }
 
-func newJSONRequest[T string | *url.URL](ctx context.Context, method string, endpoint T, payload interface{}) (*http.Request, error) {
+func newJSONRequest[T string | *url.URL](ctx context.Context, method string, endpoint T, payload any) (*http.Request, error) {
 	buf := new(bytes.Buffer)
 
 	if payload != nil {

--- a/providers/dns/otc/internal/client.go
+++ b/providers/dns/otc/internal/client.go
@@ -31,7 +31,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(username string, password string, domainName string, projectName string) *Client {
+func NewClient(username, password, domainName, projectName string) *Client {
 	return &Client{
 		username:         username,
 		password:         password,

--- a/providers/dns/otc/internal/identity_test.go
+++ b/providers/dns/otc/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/url"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestClient_Login(t *testing.T) {
 	client := NewClient("user", "secret", "example.com", "test")
 	client.IdentityEndpoint, _ = url.JoinPath(mock.GetServerURL(), "/v3/auth/token")
 
-	err := client.Login(context.Background())
+	err := client.Login(t.Context())
 	require.NoError(t, err)
 
 	serverURL, _ := url.Parse(mock.GetServerURL())

--- a/providers/dns/pdns/internal/client_test.go
+++ b/providers/dns/pdns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -163,7 +162,7 @@ func TestClient_GetHostedZone(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/api/v1/servers/server/zones/example.org.", http.StatusOK, "zone.json")
 	client.apiVersion = 1
 
-	zone, err := client.GetHostedZone(context.Background(), "example.org.")
+	zone, err := client.GetHostedZone(t.Context(), "example.org.")
 	require.NoError(t, err)
 
 	expected := &HostedZone{
@@ -206,7 +205,7 @@ func TestClient_GetHostedZone_error(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/api/v1/servers/server/zones/example.org.", http.StatusUnprocessableEntity, "error.json")
 	client.apiVersion = 1
 
-	_, err := client.GetHostedZone(context.Background(), "example.org.")
+	_, err := client.GetHostedZone(t.Context(), "example.org.")
 	require.ErrorAs(t, err, &apiError{})
 }
 
@@ -214,7 +213,7 @@ func TestClient_GetHostedZone_v0(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/servers/server/zones/example.org.", http.StatusOK, "zone.json")
 	client.apiVersion = 0
 
-	zone, err := client.GetHostedZone(context.Background(), "example.org.")
+	zone, err := client.GetHostedZone(t.Context(), "example.org.")
 	require.NoError(t, err)
 
 	expected := &HostedZone{
@@ -279,7 +278,7 @@ func TestClient_UpdateRecords(t *testing.T) {
 		}},
 	}
 
-	err := client.UpdateRecords(context.Background(), zone, rrSets)
+	err := client.UpdateRecords(t.Context(), zone, rrSets)
 	require.NoError(t, err)
 }
 
@@ -310,7 +309,7 @@ func TestClient_UpdateRecords_NonRootApi(t *testing.T) {
 		}},
 	}
 
-	err := client.UpdateRecords(context.Background(), zone, rrSets)
+	err := client.UpdateRecords(t.Context(), zone, rrSets)
 	require.NoError(t, err)
 }
 
@@ -340,7 +339,7 @@ func TestClient_UpdateRecords_v0(t *testing.T) {
 		}},
 	}
 
-	err := client.UpdateRecords(context.Background(), zone, rrSets)
+	err := client.UpdateRecords(t.Context(), zone, rrSets)
 	require.NoError(t, err)
 }
 
@@ -356,7 +355,7 @@ func TestClient_Notify(t *testing.T) {
 		Kind: "Master",
 	}
 
-	err := client.Notify(context.Background(), zone)
+	err := client.Notify(t.Context(), zone)
 	require.NoError(t, err)
 }
 
@@ -373,7 +372,7 @@ func TestClient_Notify_NonRootApi(t *testing.T) {
 		Kind: "Master",
 	}
 
-	err := client.Notify(context.Background(), zone)
+	err := client.Notify(t.Context(), zone)
 	require.NoError(t, err)
 }
 
@@ -388,14 +387,14 @@ func TestClient_Notify_v0(t *testing.T) {
 		Kind: "Master",
 	}
 
-	err := client.Notify(context.Background(), zone)
+	err := client.Notify(t.Context(), zone)
 	require.NoError(t, err)
 }
 
 func TestClient_getAPIVersion(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/api", http.StatusOK, "versions.json")
 
-	version, err := client.getAPIVersion(context.Background())
+	version, err := client.getAPIVersion(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, 4, version)

--- a/providers/dns/plesk/internal/client.go
+++ b/providers/dns/plesk/internal/client.go
@@ -24,7 +24,7 @@ type Client struct {
 }
 
 // NewClient created a new Client.
-func NewClient(baseURL *url.URL, login string, password string) *Client {
+func NewClient(baseURL *url.URL, login, password string) *Client {
 	return &Client{
 		login:      login,
 		password:   password,

--- a/providers/dns/plesk/internal/client_test.go
+++ b/providers/dns/plesk/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,7 +65,7 @@ func setupTest(t *testing.T, filename string) *Client {
 func TestClient_GetSite(t *testing.T) {
 	client := setupTest(t, "get-site.xml")
 
-	siteID, err := client.GetSite(context.Background(), "example.com")
+	siteID, err := client.GetSite(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	assert.Equal(t, 82, siteID)
@@ -75,7 +74,7 @@ func TestClient_GetSite(t *testing.T) {
 func TestClient_GetSite_error(t *testing.T) {
 	client := setupTest(t, "get-site-error.xml")
 
-	siteID, err := client.GetSite(context.Background(), "example.com")
+	siteID, err := client.GetSite(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Equal(t, 0, siteID)
@@ -84,7 +83,7 @@ func TestClient_GetSite_error(t *testing.T) {
 func TestClient_GetSite_system_error(t *testing.T) {
 	client := setupTest(t, "global-error.xml")
 
-	siteID, err := client.GetSite(context.Background(), "example.com")
+	siteID, err := client.GetSite(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Equal(t, 0, siteID)
@@ -93,7 +92,7 @@ func TestClient_GetSite_system_error(t *testing.T) {
 func TestClient_AddRecord(t *testing.T) {
 	client := setupTest(t, "add-record.xml")
 
-	recordID, err := client.AddRecord(context.Background(), 123, "_acme-challenge.example.com", "txtTXTtxt")
+	recordID, err := client.AddRecord(t.Context(), 123, "_acme-challenge.example.com", "txtTXTtxt")
 	require.NoError(t, err)
 
 	assert.Equal(t, 4537, recordID)
@@ -102,7 +101,7 @@ func TestClient_AddRecord(t *testing.T) {
 func TestClient_AddRecord_error(t *testing.T) {
 	client := setupTest(t, "add-record-error.xml")
 
-	recordID, err := client.AddRecord(context.Background(), 123, "_acme-challenge.example.com", "txtTXTtxt")
+	recordID, err := client.AddRecord(t.Context(), 123, "_acme-challenge.example.com", "txtTXTtxt")
 	require.ErrorAs(t, err, new(RecResult))
 
 	assert.Equal(t, 0, recordID)
@@ -111,7 +110,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 func TestClient_AddRecord_system_error(t *testing.T) {
 	client := setupTest(t, "global-error.xml")
 
-	recordID, err := client.AddRecord(context.Background(), 123, "_acme-challenge.example.com", "txtTXTtxt")
+	recordID, err := client.AddRecord(t.Context(), 123, "_acme-challenge.example.com", "txtTXTtxt")
 	require.ErrorAs(t, err, new(*System))
 
 	assert.Equal(t, 0, recordID)
@@ -120,7 +119,7 @@ func TestClient_AddRecord_system_error(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "delete-record.xml")
 
-	recordID, err := client.DeleteRecord(context.Background(), 4537)
+	recordID, err := client.DeleteRecord(t.Context(), 4537)
 	require.NoError(t, err)
 
 	assert.Equal(t, 4537, recordID)
@@ -129,7 +128,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "delete-record-error.xml")
 
-	recordID, err := client.DeleteRecord(context.Background(), 4537)
+	recordID, err := client.DeleteRecord(t.Context(), 4537)
 	require.ErrorAs(t, err, new(RecResult))
 
 	assert.Equal(t, 0, recordID)
@@ -138,7 +137,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 func TestClient_DeleteRecord_system_error(t *testing.T) {
 	client := setupTest(t, "global-error.xml")
 
-	recordID, err := client.DeleteRecord(context.Background(), 4537)
+	recordID, err := client.DeleteRecord(t.Context(), 4537)
 	require.ErrorAs(t, err, new(*System))
 
 	assert.Equal(t, 0, recordID)

--- a/providers/dns/rackspace/internal/client.go
+++ b/providers/dns/rackspace/internal/client.go
@@ -21,7 +21,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(endpoint string, token string) (*Client, error) {
+func NewClient(endpoint, token string) (*Client, error) {
 	baseURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (c *Client) listDomainsByName(ctx context.Context, domain string) (*ZoneSea
 }
 
 // FindTxtRecord searches a DNS zone for a TXT record with a specific name.
-func (c *Client) FindTxtRecord(ctx context.Context, fqdn string, zoneID string) (*Record, error) {
+func (c *Client) FindTxtRecord(ctx context.Context, fqdn, zoneID string) (*Record, error) {
 	records, err := c.searchRecords(ctx, zoneID, dns01.UnFqdn(fqdn), "TXT")
 	if err != nil {
 		return nil, err

--- a/providers/dns/rackspace/internal/client.go
+++ b/providers/dns/rackspace/internal/client.go
@@ -191,7 +191,7 @@ func (c *Client) do(req *http.Request, result any) error {
 	return nil
 }
 
-func newJSONRequest[T string | *url.URL](ctx context.Context, method string, endpoint T, payload interface{}) (*http.Request, error) {
+func newJSONRequest[T string | *url.URL](ctx context.Context, method string, endpoint T, payload any) (*http.Request, error) {
 	buf := new(bytes.Buffer)
 
 	if payload != nil {

--- a/providers/dns/rackspace/internal/client_test.go
+++ b/providers/dns/rackspace/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,21 +60,21 @@ func writeFixtureHandler(method, filename string) http.HandlerFunc {
 func TestClient_AddRecord(t *testing.T) {
 	client := setupTest(t, "/domains/1234/records", writeFixtureHandler(http.MethodPost, "add-records.json"))
 
-	err := client.AddRecord(context.Background(), "1234", Record{})
+	err := client.AddRecord(t.Context(), "1234", Record{})
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/domains/1234/records", writeFixtureHandler(http.MethodDelete, ""))
 
-	err := client.DeleteRecord(context.Background(), "1234", "2725233")
+	err := client.DeleteRecord(t.Context(), "1234", "2725233")
 	require.NoError(t, err)
 }
 
 func TestClient_searchRecords(t *testing.T) {
 	client := setupTest(t, "/domains/1234/records", writeFixtureHandler(http.MethodGet, "search-records.json"))
 
-	records, err := client.searchRecords(context.Background(), "1234", "2725233", "A")
+	records, err := client.searchRecords(t.Context(), "1234", "2725233", "A")
 	require.NoError(t, err)
 
 	expected := &Records{
@@ -96,7 +95,7 @@ func TestClient_searchRecords(t *testing.T) {
 func TestClient_listDomainsByName(t *testing.T) {
 	client := setupTest(t, "/domains", writeFixtureHandler(http.MethodGet, "list-domains-by-name.json"))
 
-	domains, err := client.listDomainsByName(context.Background(), "1234")
+	domains, err := client.listDomainsByName(t.Context(), "1234")
 	require.NoError(t, err)
 
 	expected := &ZoneSearchResponse{

--- a/providers/dns/rackspace/internal/identity_test.go
+++ b/providers/dns/rackspace/internal/identity_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,7 +44,7 @@ func TestIdentifier_Login(t *testing.T) {
 
 	mux.HandleFunc("/", writeIdentityFixtureHandler(http.MethodPost, "tokens.json"))
 
-	identity, err := identifier.Login(context.Background(), "user", "secret")
+	identity, err := identifier.Login(t.Context(), "user", "secret")
 	require.NoError(t, err)
 
 	expected := &Identity{

--- a/providers/dns/rainyun/internal/client_test.go
+++ b/providers/dns/rainyun/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +54,7 @@ func setupTest(t *testing.T, pattern string, status int, filename string) *Clien
 func TestClient_ListDomains(t *testing.T) {
 	client := setupTest(t, "GET /domain", http.StatusOK, "domains.json")
 
-	domains, err := client.ListDomains(context.Background())
+	domains, err := client.ListDomains(t.Context())
 	require.NoError(t, err)
 
 	expected := []Domain{
@@ -69,7 +68,7 @@ func TestClient_ListDomains(t *testing.T) {
 func TestClient_ListDomains_error(t *testing.T) {
 	client := setupTest(t, "GET /domain", http.StatusForbidden, "error.json")
 
-	_, err := client.ListDomains(context.Background())
+	_, err := client.ListDomains(t.Context())
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "30039: 密钥认证错误或已失效")
@@ -78,7 +77,7 @@ func TestClient_ListDomains_error(t *testing.T) {
 func TestClient_ListRecords(t *testing.T) {
 	client := setupTest(t, "GET /domain/123/dns", http.StatusOK, "records.json")
 
-	records, err := client.ListRecords(context.Background(), 123)
+	records, err := client.ListRecords(t.Context(), 123)
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -106,7 +105,7 @@ func TestClient_ListRecords(t *testing.T) {
 func TestClient_ListRecords_error(t *testing.T) {
 	client := setupTest(t, "GET /domain/123/dns", http.StatusForbidden, "error.json")
 
-	_, err := client.ListRecords(context.Background(), 123)
+	_, err := client.ListRecords(t.Context(), 123)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "30039: 密钥认证错误或已失效")
@@ -123,7 +122,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Value: "foo",
 	}
 
-	err := client.AddRecord(context.Background(), 123, record)
+	err := client.AddRecord(t.Context(), 123, record)
 	require.NoError(t, err)
 }
 
@@ -138,7 +137,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Value: "foo",
 	}
 
-	err := client.AddRecord(context.Background(), 123, record)
+	err := client.AddRecord(t.Context(), 123, record)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "30039: 密钥认证错误或已失效")
@@ -147,14 +146,14 @@ func TestClient_AddRecord_error(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "DELETE /domain/123/dns", http.StatusOK, "")
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "DELETE /domain/123/dns", http.StatusForbidden, "error.json")
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "30039: 密钥认证错误或已失效")

--- a/providers/dns/rcodezero/internal/client_test.go
+++ b/providers/dns/rcodezero/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,7 +71,7 @@ func TestClient_UpdateRecords_error(t *testing.T) {
 		Records:    []Record{{Content: `"my-acme-challenge"`}},
 	}}
 
-	resp, err := client.UpdateRecords(context.Background(), "example.org", rrSet)
+	resp, err := client.UpdateRecords(t.Context(), "example.org", rrSet)
 	require.ErrorAs(t, err, new(*APIResponse))
 	assert.Nil(t, resp)
 }
@@ -87,7 +86,7 @@ func TestClient_UpdateRecords(t *testing.T) {
 		Records:    []Record{{Content: `"my-acme-challenge"`}},
 	}}
 
-	resp, err := client.UpdateRecords(context.Background(), "example.org", rrSet)
+	resp, err := client.UpdateRecords(t.Context(), "example.org", rrSet)
 	require.NoError(t, err)
 
 	expected := &APIResponse{Status: "ok", Message: "RRsets updated"}

--- a/providers/dns/regru/internal/client_test.go
+++ b/providers/dns/regru/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,7 +23,7 @@ func TestRemoveRecord(t *testing.T) {
 	client := NewClient(officialTestUser, officialTestPassword)
 	client.HTTPClient = &http.Client{Timeout: 30 * time.Second}
 
-	err := client.RemoveTxtRecord(context.Background(), "test.ru", "_acme-challenge", "txttxttxt")
+	err := client.RemoveTxtRecord(t.Context(), "test.ru", "_acme-challenge", "txttxttxt")
 	require.NoError(t, err)
 }
 
@@ -68,7 +67,7 @@ func TestRemoveRecord_errors(t *testing.T) {
 			client.HTTPClient = &http.Client{Timeout: 30 * time.Second}
 			client.baseURL, _ = url.Parse(test.baseURL)
 
-			err := client.RemoveTxtRecord(context.Background(), test.domain, "_acme-challenge", "txttxttxt")
+			err := client.RemoveTxtRecord(t.Context(), test.domain, "_acme-challenge", "txttxttxt")
 			require.EqualError(t, err, test.expected)
 		})
 	}
@@ -81,7 +80,7 @@ func TestAddTXTRecord(t *testing.T) {
 	client := NewClient(officialTestUser, officialTestPassword)
 	client.HTTPClient = &http.Client{Timeout: 30 * time.Second}
 
-	err := client.AddTXTRecord(context.Background(), "test.ru", "_acme-challenge", "txttxttxt")
+	err := client.AddTXTRecord(t.Context(), "test.ru", "_acme-challenge", "txttxttxt")
 	require.NoError(t, err)
 }
 
@@ -125,7 +124,7 @@ func TestAddTXTRecord_errors(t *testing.T) {
 			client.HTTPClient = &http.Client{Timeout: 30 * time.Second}
 			client.baseURL, _ = url.Parse(test.baseURL)
 
-			err := client.AddTXTRecord(context.Background(), test.domain, "_acme-challenge", "txttxttxt")
+			err := client.AddTXTRecord(t.Context(), test.domain, "_acme-challenge", "txttxttxt")
 			require.EqualError(t, err, test.expected)
 		})
 	}

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -345,10 +345,7 @@ func createAWSConfig(ctx context.Context, config *Config) (aws.Config, error) {
 				// causing a high number of consecutive throttling errors.
 				// For reference: Route 53 enforces an account-wide(!) 5req/s query limit.
 				options.Backoff = retry.BackoffDelayerFunc(func(attempt int, err error) (time.Duration, error) {
-					retryCount := attempt
-					if retryCount > 7 {
-						retryCount = 7
-					}
+					retryCount := min(attempt, 7)
 
 					delay := (1 << uint(retryCount)) * (rand.Intn(50) + 200)
 					return time.Duration(delay) * time.Millisecond, nil

--- a/providers/dns/route53/route53_integration_test.go
+++ b/providers/dns/route53/route53_integration_test.go
@@ -1,7 +1,6 @@
 package route53
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,7 +28,7 @@ func TestLiveTTL(t *testing.T) {
 	// we need a separate R53 client here as the one in the DNS provider is unexported.
 	fqdn := "_acme-challenge." + domain + "."
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
@@ -43,7 +42,7 @@ func TestLiveTTL(t *testing.T) {
 		}
 	}()
 
-	zoneID, err := provider.getHostedZoneID(context.Background(), fqdn)
+	zoneID, err := provider.getHostedZoneID(t.Context(), fqdn)
 	require.NoError(t, err)
 
 	params := &route53.ListResourceRecordSetsInput{

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -1,7 +1,6 @@
 package route53
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -55,7 +54,7 @@ func Test_loadCredentials_FromEnv(t *testing.T) {
 	_ = os.Setenv(EnvSecretAccessKey, "456")
 	_ = os.Setenv(EnvRegion, "us-east-1")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
@@ -79,7 +78,7 @@ func Test_loadRegion_FromEnv(t *testing.T) {
 
 	_ = os.Setenv(EnvRegion, "foo")
 
-	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
+	cfg, err := awsconfig.LoadDefaultConfig(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, "foo", cfg.Region, "Region")
@@ -96,7 +95,7 @@ func Test_getHostedZoneID_FromEnv(t *testing.T) {
 	provider, err := NewDNSProvider()
 	require.NoError(t, err)
 
-	hostedZoneID, err := provider.getHostedZoneID(context.Background(), "whatever")
+	hostedZoneID, err := provider.getHostedZoneID(t.Context(), "whatever")
 	require.NoError(t, err, "HostedZoneID")
 
 	assert.Equal(t, expectedZoneID, hostedZoneID)
@@ -268,7 +267,7 @@ func Test_createAWSConfig(t *testing.T) {
 
 			envTest.Apply(test.env)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			cfg, err := createAWSConfig(ctx, test.config)
 			requireErr(t, err, test.wantErr)

--- a/providers/dns/safedns/internal/client_test.go
+++ b/providers/dns/safedns/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,7 +77,7 @@ func TestClient_AddRecord(t *testing.T) {
 		TTL:     dns01.DefaultTTL,
 	}
 
-	response, err := client.AddRecord(context.Background(), "example.com", record)
+	response, err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &AddRecordResponse{
@@ -114,6 +113,6 @@ func TestClient_RemoveRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.RemoveRecord(context.Background(), "example.com", 1234567)
+	err := client.RemoveRecord(t.Context(), "example.com", 1234567)
 	require.NoError(t, err)
 }

--- a/providers/dns/sakuracloud/wrapper_test.go
+++ b/providers/dns/sakuracloud/wrapper_test.go
@@ -1,7 +1,6 @@
 package sakuracloud
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -33,7 +32,7 @@ func fakeCaller() iaas.APICaller {
 func createDummyZone(t *testing.T, caller iaas.APICaller) {
 	t.Helper()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	dnsOp := iaas.NewDNSOp(caller)
 
@@ -50,7 +49,7 @@ func createDummyZone(t *testing.T, caller iaas.APICaller) {
 	}
 
 	// create dummy zone
-	_, err = iaas.NewDNSOp(caller).Create(context.Background(), &iaas.DNSCreateRequest{Name: "example.com"})
+	_, err = iaas.NewDNSOp(caller).Create(t.Context(), &iaas.DNSCreateRequest{Name: "example.com"})
 	require.NoError(t, err)
 }
 

--- a/providers/dns/selfhostde/internal/client_test.go
+++ b/providers/dns/selfhostde/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +48,7 @@ func TestClient_UpdateTXTRecord(t *testing.T) {
 		}
 	})
 
-	err := client.UpdateTXTRecord(context.Background(), "123456", "txt")
+	err := client.UpdateTXTRecord(t.Context(), "123456", "txt")
 	require.NoError(t, err)
 }
 
@@ -60,6 +59,6 @@ func TestClient_UpdateTXTRecord_error(t *testing.T) {
 		http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 	})
 
-	err := client.UpdateTXTRecord(context.Background(), "123456", "txt")
+	err := client.UpdateTXTRecord(t.Context(), "123456", "txt")
 	require.Error(t, err)
 }

--- a/providers/dns/servercow/internal/client_test.go
+++ b/providers/dns/servercow/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -51,7 +50,7 @@ func TestClient_GetRecords(t *testing.T) {
 		}
 	})
 
-	records, err := client.GetRecords(context.Background(), "lego.wtf")
+	records, err := client.GetRecords(t.Context(), "lego.wtf")
 	require.NoError(t, err)
 
 	recordsJSON, err := json.Marshal(records)
@@ -79,7 +78,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 		}
 	})
 
-	records, err := client.GetRecords(context.Background(), "lego.wtf")
+	records, err := client.GetRecords(t.Context(), "lego.wtf")
 	require.Error(t, err)
 
 	assert.Nil(t, records)
@@ -121,7 +120,7 @@ func TestClient_CreateUpdateRecord(t *testing.T) {
 		Content: Value{"aaa", "bbb"},
 	}
 
-	msg, err := client.CreateUpdateRecord(context.Background(), "lego.wtf", record)
+	msg, err := client.CreateUpdateRecord(t.Context(), "lego.wtf", record)
 	require.NoError(t, err)
 
 	expected := &Message{Message: "ok"}
@@ -148,7 +147,7 @@ func TestClient_CreateUpdateRecord_error(t *testing.T) {
 		Name: "_acme-challenge.www",
 	}
 
-	msg, err := client.CreateUpdateRecord(context.Background(), "lego.wtf", record)
+	msg, err := client.CreateUpdateRecord(t.Context(), "lego.wtf", record)
 	require.Error(t, err)
 
 	assert.Nil(t, msg)
@@ -188,7 +187,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		Type: "TXT",
 	}
 
-	msg, err := client.DeleteRecord(context.Background(), "lego.wtf", record)
+	msg, err := client.DeleteRecord(t.Context(), "lego.wtf", record)
 	require.NoError(t, err)
 
 	expected := &Message{Message: "ok"}
@@ -215,7 +214,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		Name: "_acme-challenge.www",
 	}
 
-	msg, err := client.DeleteRecord(context.Background(), "lego.wtf", record)
+	msg, err := client.DeleteRecord(t.Context(), "lego.wtf", record)
 	require.Error(t, err)
 
 	assert.Nil(t, msg)

--- a/providers/dns/shellrent/internal/client.go
+++ b/providers/dns/shellrent/internal/client.go
@@ -29,7 +29,7 @@ type Client struct {
 }
 
 // NewClient Creates a new Client.
-func NewClient(username string, token string) *Client {
+func NewClient(username, token string) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{
@@ -142,7 +142,7 @@ func (c Client) CreateRecord(ctx context.Context, domainID int, record Record) (
 
 // DeleteRecord deletes a record.
 // https://api.shellrent.com/eliminazione-record-dns-di-un-dominio
-func (c Client) DeleteRecord(ctx context.Context, domainID int, recordID int) error {
+func (c Client) DeleteRecord(ctx context.Context, domainID, recordID int) error {
 	endpoint := c.baseURL.JoinPath("dns_record", "remove", strconv.Itoa(domainID), strconv.Itoa(recordID))
 
 	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)

--- a/providers/dns/shellrent/internal/client_test.go
+++ b/providers/dns/shellrent/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +64,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestClient_ListServices(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase", http.StatusOK, "purchase.json")
 
-	services, err := client.ListServices(context.Background())
+	services, err := client.ListServices(t.Context())
 	require.NoError(t, err)
 
 	expected := []int{2018, 10039, 10128}
@@ -76,21 +75,21 @@ func TestClient_ListServices(t *testing.T) {
 func TestClient_ListServices_error(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase", http.StatusOK, "error.json")
 
-	_, err := client.ListServices(context.Background())
+	_, err := client.ListServices(t.Context())
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_ListServices_error_status(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase", http.StatusUnauthorized, "error.json")
 
-	_, err := client.ListServices(context.Background())
+	_, err := client.ListServices(t.Context())
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_GetServiceDetails(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase/details/123", http.StatusOK, "purchase-details.json")
 
-	services, err := client.GetServiceDetails(context.Background(), 123)
+	services, err := client.GetServiceDetails(t.Context(), 123)
 	require.NoError(t, err)
 
 	expected := &ServiceDetails{ID: 123, Name: "example", DomainID: 456}
@@ -101,21 +100,21 @@ func TestClient_GetServiceDetails(t *testing.T) {
 func TestClient_GetServiceDetails_error(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase/details/123", http.StatusOK, "error.json")
 
-	_, err := client.GetServiceDetails(context.Background(), 123)
+	_, err := client.GetServiceDetails(t.Context(), 123)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_GetServiceDetails_error_status(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/purchase/details/123", http.StatusUnauthorized, "error.json")
 
-	_, err := client.GetServiceDetails(context.Background(), 123)
+	_, err := client.GetServiceDetails(t.Context(), 123)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_GetDomainDetails(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/domain/details/123", http.StatusOK, "domain-details.json")
 
-	services, err := client.GetDomainDetails(context.Background(), 123)
+	services, err := client.GetDomainDetails(t.Context(), 123)
 	require.NoError(t, err)
 
 	expected := &DomainDetails{ID: 123, DomainName: "example.com", DomainNameASCII: "example.com"}
@@ -126,21 +125,21 @@ func TestClient_GetDomainDetails(t *testing.T) {
 func TestClient_GetDomainDetails_error(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/domain/details/123", http.StatusOK, "error.json")
 
-	_, err := client.GetDomainDetails(context.Background(), 123)
+	_, err := client.GetDomainDetails(t.Context(), 123)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_GetDomainDetails_error_status(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/domain/details/123", http.StatusUnauthorized, "error.json")
 
-	_, err := client.GetDomainDetails(context.Background(), 123)
+	_, err := client.GetDomainDetails(t.Context(), 123)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_CreateRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns_record/store/123", http.StatusOK, "dns_record-store.json")
 
-	services, err := client.CreateRecord(context.Background(), 123, Record{})
+	services, err := client.CreateRecord(t.Context(), 123, Record{})
 	require.NoError(t, err)
 
 	expected := 2255674
@@ -151,35 +150,35 @@ func TestClient_CreateRecord(t *testing.T) {
 func TestClient_CreateRecord_error(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns_record/store/123", http.StatusOK, "error.json")
 
-	_, err := client.CreateRecord(context.Background(), 123, Record{})
+	_, err := client.CreateRecord(t.Context(), 123, Record{})
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_CreateRecord_error_status(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns_record/store/123", http.StatusUnauthorized, "error.json")
 
-	_, err := client.CreateRecord(context.Background(), 123, Record{})
+	_, err := client.CreateRecord(t.Context(), 123, Record{})
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns_record/remove/123/456", http.StatusOK, "dns_record-remove.json")
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns_record/remove/123/456", http.StatusOK, "error.json")
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 
 func TestClient_DeleteRecord_error_status(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns_record/remove/123/456", http.StatusUnauthorized, "error.json")
 
-	err := client.DeleteRecord(context.Background(), 123, 456)
+	err := client.DeleteRecord(t.Context(), 123, 456)
 	require.EqualError(t, err, "code 2: Token di autorizzazione non valido")
 }
 

--- a/providers/dns/simply/internal/client.go
+++ b/providers/dns/simply/internal/client.go
@@ -28,7 +28,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(accountName string, apiKey string) (*Client, error) {
+func NewClient(accountName, apiKey string) (*Client, error) {
 	if accountName == "" {
 		return nil, errors.New("credentials missing: accountName")
 	}
@@ -110,7 +110,7 @@ func (c *Client) DeleteRecord(ctx context.Context, zoneName string, id int64) er
 	return c.do(req, &apiResponse[json.RawMessage, json.RawMessage]{})
 }
 
-func (c *Client) createEndpoint(zoneName string, uri string) *url.URL {
+func (c *Client) createEndpoint(zoneName, uri string) *url.URL {
 	return c.baseURL.JoinPath(c.accountName, c.apiKey, "my", "products", zoneName, "dns", "records", strings.TrimSuffix(uri, "/"))
 }
 

--- a/providers/dns/simply/internal/client_test.go
+++ b/providers/dns/simply/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +20,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 	mux.HandleFunc("/accountname/apikey/my/products/azone01/dns/records", mockHandler(http.MethodGet, http.StatusOK, "get_records.json"))
 
-	records, err := client.GetRecords(context.Background(), "azone01")
+	records, err := client.GetRecords(t.Context(), "azone01")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -67,7 +66,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 
 	mux.HandleFunc("/accountname/apikey/my/products/azone01/dns/records", mockHandler(http.MethodGet, http.StatusBadRequest, "bad_auth_error.json"))
 
-	records, err := client.GetRecords(context.Background(), "azone01")
+	records, err := client.GetRecords(t.Context(), "azone01")
 	require.Error(t, err)
 
 	assert.Nil(t, records)
@@ -86,7 +85,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Priority: 0,
 	}
 
-	recordID, err := client.AddRecord(context.Background(), "azone01", record)
+	recordID, err := client.AddRecord(t.Context(), "azone01", record)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, 123456789, recordID)
@@ -105,7 +104,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Priority: 0,
 	}
 
-	recordID, err := client.AddRecord(context.Background(), "azone01", record)
+	recordID, err := client.AddRecord(t.Context(), "azone01", record)
 	require.Error(t, err)
 
 	assert.Zero(t, recordID)
@@ -124,7 +123,7 @@ func TestClient_EditRecord(t *testing.T) {
 		Priority: 0,
 	}
 
-	err := client.EditRecord(context.Background(), "azone01", 123456789, record)
+	err := client.EditRecord(t.Context(), "azone01", 123456789, record)
 	require.NoError(t, err)
 }
 
@@ -141,7 +140,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 		Priority: 0,
 	}
 
-	err := client.EditRecord(context.Background(), "azone01", 123456789, record)
+	err := client.EditRecord(t.Context(), "azone01", 123456789, record)
 	require.Error(t, err)
 }
 
@@ -150,7 +149,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 	mux.HandleFunc("/accountname/apikey/my/products/azone01/dns/records/123456789", mockHandler(http.MethodDelete, http.StatusOK, "success.json"))
 
-	err := client.DeleteRecord(context.Background(), "azone01", 123456789)
+	err := client.DeleteRecord(t.Context(), "azone01", 123456789)
 	require.NoError(t, err)
 }
 
@@ -159,7 +158,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 
 	mux.HandleFunc("/accountname/apikey/my/products/azone01/dns/records/123456789", mockHandler(http.MethodDelete, http.StatusNotFound, "invalid_record_id.json"))
 
-	err := client.DeleteRecord(context.Background(), "azone01", 123456789)
+	err := client.DeleteRecord(t.Context(), "azone01", 123456789)
 	require.Error(t, err)
 }
 

--- a/providers/dns/sonic/internal/client.go
+++ b/providers/dns/sonic/internal/client.go
@@ -42,7 +42,7 @@ func NewClient(userID, apiKey string) (*Client, error) {
 // SetRecord creates or updates a TXT records.
 // Sonic does not provide a delete record API endpoint.
 // https://public-api.sonic.net/dyndns#updating_or_adding_host_records
-func (c *Client) SetRecord(ctx context.Context, hostname string, value string, ttl int) error {
+func (c *Client) SetRecord(ctx context.Context, hostname, value string, ttl int) error {
 	payload := &Record{
 		UserID:   c.userID,
 		APIKey:   c.apiKey,

--- a/providers/dns/sonic/internal/client_test.go
+++ b/providers/dns/sonic/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +52,7 @@ func TestClient_SetRecord(t *testing.T) {
 
 			client := setupTest(t, test.response)
 
-			err := client.SetRecord(context.Background(), "example.com", "txttxttxt", 10)
+			err := client.SetRecord(t.Context(), "example.com", "txttxttxt", 10)
 			test.assert(t, err)
 		})
 	}

--- a/providers/dns/spaceship/internal/client_test.go
+++ b/providers/dns/spaceship/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +60,7 @@ func TestClient_AddRecord(t *testing.T) {
 		TTL:  60,
 	}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -74,7 +73,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		TTL:  60,
 	}
 
-	err := client.AddRecord(context.Background(), "example.com", record)
+	err := client.AddRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "^$, name: The domain name contains invalid characters")
 }
 
@@ -87,7 +86,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		TTL:  60,
 	}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 }
 
@@ -100,14 +99,14 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		TTL:  60,
 	}
 
-	err := client.DeleteRecord(context.Background(), "example.com", record)
+	err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.EqualError(t, err, "^$, name: The domain name contains invalid characters")
 }
 
 func TestClient_GetRecords(t *testing.T) {
 	client := setupTest(t, "GET /dns/records/example.com", http.StatusOK, "get-records.json")
 
-	records, err := client.GetRecords(context.Background(), "example.com")
+	records, err := client.GetRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -120,6 +119,6 @@ func TestClient_GetRecords(t *testing.T) {
 func TestClient_GetRecords_error(t *testing.T) {
 	client := setupTest(t, "GET /dns/records/example.com", http.StatusUnprocessableEntity, "error.json")
 
-	_, err := client.GetRecords(context.Background(), "example.com")
+	_, err := client.GetRecords(t.Context(), "example.com")
 	require.EqualError(t, err, "^$, name: The domain name contains invalid characters")
 }

--- a/providers/dns/stackpath/internal/client_test.go
+++ b/providers/dns/stackpath/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,7 +17,7 @@ func setupTest(t *testing.T) (*Client, *http.ServeMux) {
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	client := NewClient(context.Background(), "STACK_ID", "CLIENT_ID", "CLIENT_SECRET")
+	client := NewClient(t.Context(), "STACK_ID", "CLIENT_ID", "CLIENT_SECRET")
 	client.httpClient = server.Client()
 	client.baseURL, _ = url.Parse(server.URL + "/")
 
@@ -44,7 +43,7 @@ func TestClient_GetZoneRecords(t *testing.T) {
 		}
 	})
 
-	records, err := client.GetZoneRecords(context.Background(), "foo1", &Zone{ID: "A", Domain: "test"})
+	records, err := client.GetZoneRecords(t.Context(), "foo1", &Zone{ID: "A", Domain: "test"})
 	require.NoError(t, err)
 
 	expected := []Record{
@@ -73,7 +72,7 @@ func TestClient_GetZoneRecords_apiError(t *testing.T) {
 		}
 	})
 
-	_, err := client.GetZoneRecords(context.Background(), "foo1", &Zone{ID: "A", Domain: "test"})
+	_, err := client.GetZoneRecords(t.Context(), "foo1", &Zone{ID: "A", Domain: "test"})
 
 	expected := &ErrorResponse{Code: 401, Message: "an unauthorized request is attempted."}
 	assert.Equal(t, expected, err)
@@ -122,7 +121,7 @@ func TestClient_GetZones(t *testing.T) {
 		}
 	})
 
-	zone, err := client.GetZones(context.Background(), "sub.foo.com")
+	zone, err := client.GetZones(t.Context(), "sub.foo.com")
 	require.NoError(t, err)
 
 	expected := &Zone{ID: "A", Domain: "foo.com"}

--- a/providers/dns/technitium/internal/client_test.go
+++ b/providers/dns/technitium/internal/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTest(t *testing.T, pattern string, filename string) *Client {
+func setupTest(t *testing.T, pattern, filename string) *Client {
 	t.Helper()
 
 	mux := http.NewServeMux()

--- a/providers/dns/technitium/internal/client_test.go
+++ b/providers/dns/technitium/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +52,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Text:   "txtTXTtxt",
 	}
 
-	newRecord, err := client.AddRecord(context.Background(), record)
+	newRecord, err := client.AddRecord(t.Context(), record)
 	require.NoError(t, err)
 
 	expected := &Record{Name: "example.com", Type: "A"}
@@ -70,7 +69,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Text:   "txtTXTtxt",
 	}
 
-	_, err := client.AddRecord(context.Background(), record)
+	_, err := client.AddRecord(t.Context(), record)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "Status: error, ErrorMessage: error message, StackTrace: application stack trace, InnerErrorMessage: inner exception message")
@@ -85,7 +84,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		Text:   "txtTXTtxt",
 	}
 
-	err := client.DeleteRecord(context.Background(), record)
+	err := client.DeleteRecord(t.Context(), record)
 	require.NoError(t, err)
 }
 
@@ -98,7 +97,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		Text:   "txtTXTtxt",
 	}
 
-	err := client.DeleteRecord(context.Background(), record)
+	err := client.DeleteRecord(t.Context(), record)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "Status: error, ErrorMessage: error message, StackTrace: application stack trace, InnerErrorMessage: inner exception message")

--- a/providers/dns/timewebcloud/internal/client_test.go
+++ b/providers/dns/timewebcloud/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -89,7 +88,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		SubDomain: "_acme-challenge",
 	}
 
-	response, err := client.CreateRecord(context.Background(), "example.com.", payload)
+	response, err := client.CreateRecord(t.Context(), "example.com.", payload)
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
@@ -111,7 +110,7 @@ func TestClient_CreateRecord_error(t *testing.T) {
 		}
 	})
 
-	_, err := client.CreateRecord(context.Background(), "example.com.", DNSRecord{})
+	_, err := client.CreateRecord(t.Context(), "example.com.", DNSRecord{})
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "400: Value must be a number conforming to the specified constraints (bad_request) [15095f25-aac3-4d60-a788-96cb5136f186]")
@@ -130,7 +129,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteRecord(context.Background(), "example.com.", 123)
+	err := client.DeleteRecord(t.Context(), "example.com.", 123)
 	require.NoError(t, err)
 }
 
@@ -145,7 +144,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		}
 	})
 
-	err := client.DeleteRecord(context.Background(), "example.com.", 123)
+	err := client.DeleteRecord(t.Context(), "example.com.", 123)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "401: Unauthorized (unauthorized) [15095f25-aac3-4d60-a788-96cb5136f186]")

--- a/providers/dns/variomedia/internal/client_test.go
+++ b/providers/dns/variomedia/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,7 +71,7 @@ func TestClient_CreateDNSRecord(t *testing.T) {
 		TTL:        300,
 	}
 
-	resp, err := client.CreateDNSRecord(context.Background(), record)
+	resp, err := client.CreateDNSRecord(t.Context(), record)
 	require.NoError(t, err)
 
 	expected := &CreateDNSRecordResponse{
@@ -112,7 +111,7 @@ func TestClient_DeleteDNSRecord(t *testing.T) {
 
 	mux.HandleFunc("/dns-records/test", mockHandler(http.MethodDelete, "DELETE_dns-records_pending.json"))
 
-	resp, err := client.DeleteDNSRecord(context.Background(), "test")
+	resp, err := client.DeleteDNSRecord(t.Context(), "test")
 	require.NoError(t, err)
 
 	expected := &DeleteRecordResponse{
@@ -147,7 +146,7 @@ func TestClient_GetJob(t *testing.T) {
 
 	mux.HandleFunc("/queue-jobs/test", mockHandler(http.MethodGet, "GET_queue-jobs.json"))
 
-	resp, err := client.GetJob(context.Background(), "test")
+	resp, err := client.GetJob(t.Context(), "test")
 	require.NoError(t, err)
 
 	expected := &GetJobResponse{

--- a/providers/dns/variomedia/internal/client_test.go
+++ b/providers/dns/variomedia/internal/client_test.go
@@ -27,7 +27,7 @@ func setupTest(t *testing.T) (*Client, *http.ServeMux) {
 	return client, mux
 }
 
-func mockHandler(method string, filename string) http.HandlerFunc {
+func mockHandler(method, filename string) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != method {
 			http.Error(rw, fmt.Sprintf("invalid method, got %s want %s", req.Method, method), http.StatusBadRequest)

--- a/providers/dns/variomedia/variomedia.go
+++ b/providers/dns/variomedia/variomedia.go
@@ -178,7 +178,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	return nil
 }
 
-func (d *DNSProvider) waitJob(ctx context.Context, domain string, id string) error {
+func (d *DNSProvider) waitJob(ctx context.Context, domain, id string) error {
 	return wait.For("variomedia: apply change on "+domain, d.config.PropagationTimeout, d.config.PollingInterval, func() (bool, error) {
 		result, err := d.client.GetJob(ctx, id)
 		if err != nil {

--- a/providers/dns/vercel/internal/client.go
+++ b/providers/dns/vercel/internal/client.go
@@ -61,7 +61,7 @@ func (c *Client) CreateRecord(ctx context.Context, zone string, record Record) (
 
 // DeleteRecord deletes a DNS record.
 // https://vercel.com/docs/rest-api#endpoints/dns/delete-a-dns-record
-func (c *Client) DeleteRecord(ctx context.Context, zone string, recordID string) error {
+func (c *Client) DeleteRecord(ctx context.Context, zone, recordID string) error {
 	endpoint := c.baseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "records", recordID)
 
 	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)

--- a/providers/dns/vercel/internal/client_test.go
+++ b/providers/dns/vercel/internal/client_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -75,7 +74,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		TTL:   60,
 	}
 
-	resp, err := client.CreateRecord(context.Background(), "example.com.", record)
+	resp, err := client.CreateRecord(t.Context(), "example.com.", record)
 	require.NoError(t, err)
 
 	expected := &CreateRecordResponse{
@@ -109,6 +108,6 @@ func TestClient_DeleteRecord(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	})
 
-	err := client.DeleteRecord(context.Background(), "example.com.", "1234567")
+	err := client.DeleteRecord(t.Context(), "example.com.", "1234567")
 	require.NoError(t, err)
 }

--- a/providers/dns/versio/internal/client.go
+++ b/providers/dns/versio/internal/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username string, password string) *Client {
+func NewClient(username, password string) *Client {
 	baseURL, _ := url.Parse(DefaultBaseURL)
 
 	return &Client{

--- a/providers/dns/versio/internal/client_test.go
+++ b/providers/dns/versio/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -58,7 +57,7 @@ func TestClient_GetDomain(t *testing.T) {
 		writeFixture(rw, "get-domain.json")
 	})
 
-	records, err := client.GetDomain(context.Background(), "example.com")
+	records, err := client.GetDomain(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := &DomainInfoResponse{DomainInfo: DomainInfo{DNSRecords: []Record{
@@ -91,7 +90,7 @@ func TestClient_GetDomain_error(t *testing.T) {
 		writeFixture(rw, "get-domain-error.json")
 	})
 
-	_, err := client.GetDomain(context.Background(), "example.com")
+	_, err := client.GetDomain(t.Context(), "example.com")
 	require.ErrorAs(t, err, &ErrorMessage{})
 }
 
@@ -126,7 +125,7 @@ func TestClient_UpdateDomain(t *testing.T) {
 		{Type: "A", Name: "redirect.example.com", Value: "localhost", Priority: 10, TTL: 14400},
 	}}
 
-	records, err := client.UpdateDomain(context.Background(), "example.com", msg)
+	records, err := client.UpdateDomain(t.Context(), "example.com", msg)
 	require.NoError(t, err)
 
 	expected := &DomainInfoResponse{DomainInfo: DomainInfo{DNSRecords: []Record{
@@ -174,6 +173,6 @@ func TestClient_UpdateDomain_error(t *testing.T) {
 		{Type: "A", Name: "redirect.example.com", Value: "localhost", Priority: 10, TTL: 14400},
 	}}
 
-	_, err := client.UpdateDomain(context.Background(), "example.com", msg)
+	_, err := client.UpdateDomain(t.Context(), "example.com", msg)
 	require.ErrorAs(t, err, &ErrorMessage{})
 }

--- a/providers/dns/volcengine/volcengine.go
+++ b/providers/dns/volcengine/volcengine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/providers/dns/internal/ptr"
-	"github.com/miekg/dns"
 	"github.com/volcengine/volc-sdk-golang/base"
 	volc "github.com/volcengine/volc-sdk-golang/service/dns"
 )
@@ -175,9 +174,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func (d *DNSProvider) getZone(ctx context.Context, fqdn string) (volc.TopZoneResponse, error) {
-	for _, index := range dns.Split(fqdn) {
-		domain := fqdn[index:]
-
+	for domain := range dns01.UnFqdnDomainsSeq(fqdn) {
 		lzr := &volc.ListZonesRequest{
 			Key:        ptr.Pointer(dns01.UnFqdn(domain)),
 			SearchMode: ptr.Pointer("exact"),

--- a/providers/dns/vultr/vultr_test.go
+++ b/providers/dns/vultr/vultr_test.go
@@ -1,7 +1,6 @@
 package vultr
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -206,7 +205,7 @@ func TestDNSProvider_getHostedZone(t *testing.T) {
 				}
 			})
 
-			zone, err := p.getHostedZone(context.Background(), test.domain)
+			zone, err := p.getHostedZone(t.Context(), test.domain)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected, zone)

--- a/providers/dns/vultr/vultr_test.go
+++ b/providers/dns/vultr/vultr_test.go
@@ -189,10 +189,7 @@ func TestDNSProvider_getHostedZone(t *testing.T) {
 					start = cursor * len(domains)
 				}
 
-				end := (cursor + 1) * perPage
-				if len(domains) < end {
-					end = len(domains)
-				}
+				end := min(len(domains), (cursor+1)*perPage)
 
 				db := domainsBase{
 					Domains: domains[start:end],

--- a/providers/dns/webnames/internal/client_test.go
+++ b/providers/dns/webnames/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,7 +105,7 @@ func TestClient_AddTXTRecord(t *testing.T) {
 			subDomain := "foo"
 			content := "txtTXTtxt"
 
-			err := client.AddTXTRecord(context.Background(), domain, subDomain, content)
+			err := client.AddTXTRecord(t.Context(), domain, subDomain, content)
 			test.require(t, err)
 		})
 	}
@@ -146,7 +145,7 @@ func TestClient_RemoveTxtRecord(t *testing.T) {
 			subDomain := "foo"
 			content := "txtTXTtxt"
 
-			err := client.RemoveTXTRecord(context.Background(), domain, subDomain, content)
+			err := client.RemoveTXTRecord(t.Context(), domain, subDomain, content)
 			test.require(t, err)
 		})
 	}

--- a/providers/dns/wedos/internal/client.go
+++ b/providers/dns/wedos/internal/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username string, password string) *Client {
+func NewClient(username, password string) *Client {
 	return &Client{
 		username:   username,
 		password:   password,
@@ -87,7 +87,7 @@ func (c *Client) AddRecord(ctx context.Context, zone string, record DNSRow) erro
 // DeleteRecord deletes a record from the zone.
 // If a record does not have an ID, it will be looked up.
 // https://kb.wedos.com/en/wapi-api-interface/wapi-command-dns-row-delete/
-func (c *Client) DeleteRecord(ctx context.Context, zone string, recordID string) error {
+func (c *Client) DeleteRecord(ctx context.Context, zone, recordID string) error {
 	payload := DNSRowRequest{
 		Domain: dns01.UnFqdn(zone),
 		ID:     recordID,

--- a/providers/dns/wedos/internal/client_test.go
+++ b/providers/dns/wedos/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +57,7 @@ func TestClient_GetRecords(t *testing.T) {
 	expectedForm := `{"request":{"user":"user","auth":"xxx","command":"dns-rows-list","data":{"domain":"example.com"}}}`
 	client := setupNew(t, expectedForm, commandDNSRowsList)
 
-	records, err := client.GetRecords(context.Background(), "example.com.")
+	records, err := client.GetRecords(t.Context(), "example.com.")
 	require.NoError(t, err)
 
 	assert.Len(t, records, 4)
@@ -107,7 +106,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Data: "foobar",
 	}
 
-	err := client.AddRecord(context.Background(), "example.com.", record)
+	err := client.AddRecord(t.Context(), "example.com.", record)
 	require.NoError(t, err)
 }
 
@@ -124,7 +123,7 @@ func TestClient_AddRecord_update(t *testing.T) {
 		Data: "foobar",
 	}
 
-	err := client.AddRecord(context.Background(), "example.com.", record)
+	err := client.AddRecord(t.Context(), "example.com.", record)
 	require.NoError(t, err)
 }
 
@@ -133,7 +132,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 	client := setupNew(t, expectedForm, commandDNSRowDelete)
 
-	err := client.DeleteRecord(context.Background(), "example.com.", "1")
+	err := client.DeleteRecord(t.Context(), "example.com.", "1")
 	require.NoError(t, err)
 }
 
@@ -142,6 +141,6 @@ func TestClient_Commit(t *testing.T) {
 
 	client := setupNew(t, expectedForm, commandDNSDomainCommit)
 
-	err := client.Commit(context.Background(), "example.com.")
+	err := client.Commit(t.Context(), "example.com.")
 	require.NoError(t, err)
 }

--- a/providers/dns/wedos/internal/client_test.go
+++ b/providers/dns/wedos/internal/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupNew(t *testing.T, expectedForm string, filename string) *Client {
+func setupNew(t *testing.T, expectedForm, filename string) *Client {
 	t.Helper()
 
 	mux := http.NewServeMux()

--- a/providers/dns/wedos/internal/token.go
+++ b/providers/dns/wedos/internal/token.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func authToken(userName string, wapiPass string) string {
+func authToken(userName, wapiPass string) string {
 	return sha1string(userName + sha1string(wapiPass) + czechHourString())
 }
 

--- a/providers/dns/westcn/internal/client_test.go
+++ b/providers/dns/westcn/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -128,7 +127,7 @@ func TestClientAddRecord(t *testing.T) {
 		TTL:    60,
 	}
 
-	id, err := client.AddRecord(context.Background(), record)
+	id, err := client.AddRecord(t.Context(), record)
 	require.NoError(t, err)
 
 	assert.Equal(t, 123456, id)
@@ -145,7 +144,7 @@ func TestClientAddRecord_error(t *testing.T) {
 		TTL:    60,
 	}
 
-	_, err := client.AddRecord(context.Background(), record)
+	_, err := client.AddRecord(t.Context(), record)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "10000: username,time,token必传 (500)")
@@ -157,14 +156,14 @@ func TestClientDeleteRecord(t *testing.T) {
 		expectValue("domain", "example.com"),
 	)
 
-	err := client.DeleteRecord(context.Background(), "example.com", 123)
+	err := client.DeleteRecord(t.Context(), "example.com", 123)
 	require.NoError(t, err)
 }
 
 func TestClientDeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "error.json", noop())
 
-	err := client.DeleteRecord(context.Background(), "example.com", 123)
+	err := client.DeleteRecord(t.Context(), "example.com", 123)
 	require.Error(t, err)
 
 	require.EqualError(t, err, "10000: username,time,token必传 (500)")

--- a/providers/dns/yandex/internal/client_test.go
+++ b/providers/dns/yandex/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -124,7 +123,7 @@ func TestAddRecord(t *testing.T) {
 
 			mux.HandleFunc("/add", test.handler)
 
-			record, err := client.AddRecord(context.Background(), test.data)
+			record, err := client.AddRecord(t.Context(), test.data)
 			if test.expectError {
 				require.Error(t, err)
 				require.Nil(t, record)
@@ -219,7 +218,7 @@ func TestRemoveRecord(t *testing.T) {
 
 			mux.HandleFunc("/del", test.handler)
 
-			id, err := client.RemoveRecord(context.Background(), test.data)
+			id, err := client.RemoveRecord(t.Context(), test.data)
 			if test.expectError {
 				require.Error(t, err)
 				require.Equal(t, 0, id)
@@ -315,7 +314,7 @@ func TestGetRecords(t *testing.T) {
 
 			mux.HandleFunc("/list", test.handler)
 
-			records, err := client.GetRecords(context.Background(), test.domain)
+			records, err := client.GetRecords(t.Context(), test.domain)
 			if test.expectError {
 				require.Error(t, err)
 				require.Empty(t, records)

--- a/providers/dns/yandex360/internal/client_test.go
+++ b/providers/dns/yandex360/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +62,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Type: "TXT",
 	}
 
-	newRecord, err := client.AddRecord(context.Background(), "example.com", record)
+	newRecord, err := client.AddRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -87,7 +86,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 		Type: "TXT",
 	}
 
-	newRecord, err := client.AddRecord(context.Background(), "example.com", record)
+	newRecord, err := client.AddRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, newRecord)
@@ -96,13 +95,13 @@ func TestClient_AddRecord_error(t *testing.T) {
 func TestClient_DeleteRecord(t *testing.T) {
 	client := setupTest(t, "/directory/v1/org/123456/domains/example.com/dns/789456", http.MethodDelete, http.StatusOK, "delete-record.json")
 
-	err := client.DeleteRecord(context.Background(), "example.com", 789456)
+	err := client.DeleteRecord(t.Context(), "example.com", 789456)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := setupTest(t, "/directory/v1/org/123456/domains/example.com/dns/789456", http.MethodDelete, http.StatusUnauthorized, "error.json")
 
-	err := client.DeleteRecord(context.Background(), "example.com", 789456)
+	err := client.DeleteRecord(t.Context(), "example.com", 789456)
 	require.Error(t, err)
 }

--- a/providers/dns/zoneee/internal/client.go
+++ b/providers/dns/zoneee/internal/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username string, apiKey string) *Client {
+func NewClient(username, apiKey string) *Client {
 	baseURL, _ := url.Parse(DefaultEndpoint)
 
 	return &Client{

--- a/providers/dns/zoneee/internal/client_test.go
+++ b/providers/dns/zoneee/internal/client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,7 +58,7 @@ func setupTest(t *testing.T, method, pattern string, status int, file string) *C
 func TestClient_GetTxtRecords(t *testing.T) {
 	client := setupTest(t, http.MethodGet, "/dns/example.com/txt", http.StatusOK, "get-txt-records.json")
 
-	records, err := client.GetTxtRecords(context.Background(), "example.com")
+	records, err := client.GetTxtRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	expected := []TXTRecord{
@@ -72,7 +71,7 @@ func TestClient_GetTxtRecords(t *testing.T) {
 func TestClient_AddTxtRecord(t *testing.T) {
 	client := setupTest(t, http.MethodPost, "/dns/example.com/txt", http.StatusCreated, "create-txt-record.json")
 
-	records, err := client.AddTxtRecord(context.Background(), "example.com", TXTRecord{Name: "prefix.example.com", Destination: "server.example.com"})
+	records, err := client.AddTxtRecord(t.Context(), "example.com", TXTRecord{Name: "prefix.example.com", Destination: "server.example.com"})
 	require.NoError(t, err)
 
 	expected := []TXTRecord{
@@ -85,6 +84,6 @@ func TestClient_AddTxtRecord(t *testing.T) {
 func TestClient_RemoveTxtRecord(t *testing.T) {
 	client := setupTest(t, http.MethodDelete, "/dns/example.com/txt/123", http.StatusNoContent, "")
 
-	err := client.RemoveTxtRecord(context.Background(), "example.com", "123")
+	err := client.RemoveTxtRecord(t.Context(), "example.com", "123")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Go1.25 will happen in less than 2 months, so I think it's safe to update to go1.24.

https://go.dev/wiki/Go-Release-Cycle

- Updates the minimum Go version
- Uses go1.24 new features to simplify the code