### PR TITLE
fix: enforce domain into renewal command

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -225,7 +225,7 @@ func renewForDomains(ctx *cli.Context, account *Account, keyType certcrypto.KeyT
 		time.Sleep(sleepTime)
 	}
 
-	renewalDomains := domains
+	renewalDomains := slices.Clone(domains)
 	if !forceDomains {
 		renewalDomains = merge(certDomains, domains)
 	}
@@ -250,6 +250,8 @@ func renewForDomains(ctx *cli.Context, account *Account, keyType certcrypto.KeyT
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	certRes.Domain = domain
 
 	certsStorage.SaveResource(certRes)
 


### PR DESCRIPTION
The first domain from CLI, to read and write the same file during renewal.

Fixes #2575