### PR TITLE
vinyldns: add an option to add quotes around the TXT record value

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -3249,6 +3249,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "VINYLDNS_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 4)`)
 		ew.writeln(`	- "VINYLDNS_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 120)`)
+		ew.writeln(`	- "VINYLDNS_QUOTE_VALUE":	Adds quotes around the TXT record value (Default: false)`)
 		ew.writeln(`	- "VINYLDNS_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 30)`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_vinyldns.md
+++ b/docs/content/dns/zz_gen_vinyldns.md
@@ -53,6 +53,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 |--------------------------------|-------------|
 | `VINYLDNS_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 4) |
 | `VINYLDNS_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 120) |
+| `VINYLDNS_QUOTE_VALUE` | Adds quotes around the TXT record value (Default: false) |
 | `VINYLDNS_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 30) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/vinyldns/vinyldns.go
+++ b/providers/dns/vinyldns/vinyldns.go
@@ -105,7 +105,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("vinyldns: %w", err)
 	}
 
-	record := vinyldns.Record{Text: info.Value}
+	record := vinyldns.Record{Text: fmt.Sprintf("\"%s\"", info.Value)}
 
 	if existingRecord == nil || existingRecord.ID == "" {
 		err = d.createRecordSet(info.EffectiveFQDN, []vinyldns.Record{record})
@@ -117,7 +117,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	for _, i := range existingRecord.Records {
-		if i.Text == info.Value {
+		if i.Text == fmt.Sprintf("\"%s\"", info.Value) {
 			return nil
 		}
 	}
@@ -148,7 +148,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	var records []vinyldns.Record
 	for _, i := range existingRecord.Records {
-		if i.Text != info.Value {
+		if i.Text != fmt.Sprintf("\"%s\"", info.Value) {
 			records = append(records, i)
 		}
 	}

--- a/providers/dns/vinyldns/vinyldns.go
+++ b/providers/dns/vinyldns/vinyldns.go
@@ -4,6 +4,7 @@ package vinyldns
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge"
@@ -17,9 +18,10 @@ import (
 const (
 	envNamespace = "VINYLDNS_"
 
-	EnvAccessKey = envNamespace + "ACCESS_KEY"
-	EnvSecretKey = envNamespace + "SECRET_KEY"
-	EnvHost      = envNamespace + "HOST"
+	EnvAccessKey  = envNamespace + "ACCESS_KEY"
+	EnvSecretKey  = envNamespace + "SECRET_KEY"
+	EnvHost       = envNamespace + "HOST"
+	EnvQuoteValue = envNamespace + "QUOTE_VALUE"
 
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
@@ -30,9 +32,11 @@ var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
-	AccessKey          string
-	SecretKey          string
-	Host               string
+	AccessKey  string
+	SecretKey  string
+	Host       string
+	QuoteValue bool
+
 	TTL                int
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
@@ -66,6 +70,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config.AccessKey = values[EnvAccessKey]
 	config.SecretKey = values[EnvSecretKey]
 	config.Host = values[EnvHost]
+	config.QuoteValue = env.GetOrDefaultBool(EnvQuoteValue, false)
 
 	return NewDNSProviderConfig(config)
 }
@@ -105,7 +110,9 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("vinyldns: %w", err)
 	}
 
-	record := vinyldns.Record{Text: fmt.Sprintf("\"%s\"", info.Value)}
+	value := d.formatValue(info.Value)
+
+	record := vinyldns.Record{Text: value}
 
 	if existingRecord == nil || existingRecord.ID == "" {
 		err = d.createRecordSet(info.EffectiveFQDN, []vinyldns.Record{record})
@@ -117,7 +124,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	}
 
 	for _, i := range existingRecord.Records {
-		if i.Text == fmt.Sprintf("\"%s\"", info.Value) {
+		if i.Text == value {
 			return nil
 		}
 	}
@@ -146,9 +153,11 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return nil
 	}
 
+	value := d.formatValue(info.Value)
+
 	var records []vinyldns.Record
 	for _, i := range existingRecord.Records {
-		if i.Text != fmt.Sprintf("\"%s\"", info.Value) {
+		if i.Text != value {
 			records = append(records, i)
 		}
 	}
@@ -174,4 +183,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 // Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+func (d *DNSProvider) formatValue(v string) string {
+	if d.config.QuoteValue {
+		return strconv.Quote(v)
+	}
+
+	return v
 }

--- a/providers/dns/vinyldns/vinyldns.toml
+++ b/providers/dns/vinyldns/vinyldns.toml
@@ -22,6 +22,7 @@ Users are required to have DELETE ACL level or zone admin permissions on the Vin
     VINYLDNS_SECRET_KEY = "The VinylDNS API Secret key"
     VINYLDNS_HOST = "The VinylDNS API URL"
   [Configuration.Additional]
+    VINYLDNS_QUOTE_VALUE = "Adds quotes around the TXT record value (Default: false)"
     VINYLDNS_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 4)"
     VINYLDNS_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 120)"
     VINYLDNS_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 30)"


### PR DESCRIPTION
**Description**
This PR adds quotes to DNS records to ensure Route53 compatibility during the DNS-01 ACME/Let's Encrypt validation process.

**Problem**
The current code didn't include quotes in DNS record values, causing DNS-01 challenge failures when used with Route53. Route53 has specific formatting requirements that require certain values to be quoted.