### PR TITLE
tests: improve function naming

### DIFF
--- a/platform/tester/servermock/handler_file.go
+++ b/platform/tester/servermock/handler_file.go
@@ -15,6 +15,7 @@ type ResponseFromFileHandler struct {
 	filename   string
 }
 
+// ResponseFromFile creates a [ResponseFromFileHandler] using a filename.
 func ResponseFromFile(filename string) *ResponseFromFileHandler {
 	return &ResponseFromFileHandler{
 		statusCode: http.StatusOK,
@@ -23,8 +24,14 @@ func ResponseFromFile(filename string) *ResponseFromFileHandler {
 	}
 }
 
+// ResponseFromFixture creates a [ResponseFromFileHandler] using a filename from the `fixtures` directory.
 func ResponseFromFixture(filename string) *ResponseFromFileHandler {
 	return ResponseFromFile(filepath.Join("fixtures", filename))
+}
+
+// ResponseFromInternal creates a [ResponseFromFileHandler] using a filename from the `internal/fixtures` directory.
+func ResponseFromInternal(filename string) *ResponseFromFileHandler {
+	return ResponseFromFile(filepath.Join("internal", "fixtures", filename))
 }
 
 func (h *ResponseFromFileHandler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {

--- a/platform/tester/servermock/link_request_body.go
+++ b/platform/tester/servermock/link_request_body.go
@@ -27,6 +27,16 @@ func CheckRequestBodyFromFile(filename string) *RequestBodyLink {
 	return &RequestBodyLink{filename: filename}
 }
 
+// CheckRequestBodyFromFixture creates a [RequestBodyLink] initialized with the provided request body file from the `fixtures` directory.
+func CheckRequestBodyFromFixture(filename string) *RequestBodyLink {
+	return CheckRequestBodyFromFile(filepath.Join("fixtures", filename))
+}
+
+// CheckRequestBodyFromInternal creates a [RequestBodyLink] initialized with the provided request body file from the `internal/fixtures directory.
+func CheckRequestBodyFromInternal(filename string) *RequestBodyLink {
+	return CheckRequestBodyFromFile(filepath.Join("internal", "fixtures", filename))
+}
+
 func (l *RequestBodyLink) Bind(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.ContentLength == 0 {
@@ -45,7 +55,7 @@ func (l *RequestBodyLink) Bind(next http.Handler) http.Handler {
 		expectedRaw := slices.Clone(l.body)
 
 		if l.filename != "" {
-			expectedRaw, err = os.ReadFile(filepath.Join("fixtures", l.filename))
+			expectedRaw, err = os.ReadFile(l.filename)
 			if err != nil {
 				http.Error(rw, err.Error(), http.StatusInternalServerError)
 				return

--- a/platform/tester/servermock/link_request_body_json.go
+++ b/platform/tester/servermock/link_request_body_json.go
@@ -14,10 +14,9 @@ import (
 
 // RequestBodyJSONLink validates JSON request bodies.
 type RequestBodyJSONLink struct {
-	body      []byte
-	filename  string
-	directory string
-	data      any
+	body     []byte
+	filename string
+	data     any
 }
 
 // CheckRequestJSONBody creates a [RequestBodyJSONLink] initialized with a string.
@@ -33,9 +32,18 @@ func CheckRequestJSONBodyFromStruct(data any) *RequestBodyJSONLink {
 // CheckRequestJSONBodyFromFile creates a [RequestBodyJSONLink] initialized with the provided request body file.
 func CheckRequestJSONBodyFromFile(filename string) *RequestBodyJSONLink {
 	return &RequestBodyJSONLink{
-		filename:  filename,
-		directory: "fixtures",
+		filename: filename,
 	}
+}
+
+// CheckRequestJSONBodyFromFixture creates a [RequestBodyJSONLink] initialized with the provided request body file from the `fixtures` directory.
+func CheckRequestJSONBodyFromFixture(filename string) *RequestBodyJSONLink {
+	return CheckRequestJSONBodyFromFile(filepath.Join("fixtures", filename))
+}
+
+// CheckRequestJSONBodyFromInternal creates a [RequestBodyJSONLink] initialized with the provided request body file from the `internal/fixtures` directory.
+func CheckRequestJSONBodyFromInternal(filename string) *RequestBodyJSONLink {
+	return CheckRequestJSONBodyFromFile(filepath.Join("internal", "fixtures", filename))
 }
 
 func (l *RequestBodyJSONLink) Bind(next http.Handler) http.Handler {
@@ -59,7 +67,7 @@ func (l *RequestBodyJSONLink) Bind(next http.Handler) http.Handler {
 
 		switch {
 		case l.filename != "":
-			expectedRaw, err = os.ReadFile(filepath.Join(l.directory, l.filename))
+			expectedRaw, err = os.ReadFile(l.filename)
 			if err != nil {
 				http.Error(rw, err.Error(), http.StatusInternalServerError)
 				return
@@ -100,10 +108,4 @@ func (l *RequestBodyJSONLink) Bind(next http.Handler) http.Handler {
 
 		next.ServeHTTP(rw, req)
 	})
-}
-
-func (l *RequestBodyJSONLink) WithDirectory(directory string) *RequestBodyJSONLink {
-	l.directory = directory
-
-	return l
 }

--- a/providers/dns/acmedns/internal/http_storage_test.go
+++ b/providers/dns/acmedns/internal/http_storage_test.go
@@ -98,7 +98,7 @@ func TestHTTPStorage_FetchAll_error(t *testing.T) {
 func TestHTTPStorage_Put(t *testing.T) {
 	storage := mockBuilder().
 		Route("POST /example.com", nil,
-			servermock.CheckRequestJSONBodyFromFile("request-body.json")).
+			servermock.CheckRequestJSONBodyFromFixture("request-body.json")).
 		Build(t)
 
 	account := goacmedns.Account{
@@ -137,7 +137,7 @@ func TestHTTPStorage_Put_CNAME_created(t *testing.T) {
 		Route("POST /example.com",
 			servermock.Noop().
 				WithStatusCode(http.StatusCreated),
-			servermock.CheckRequestJSONBodyFromFile("request-body.json")).
+			servermock.CheckRequestJSONBodyFromFixture("request-body.json")).
 		Build(t)
 
 	account := goacmedns.Account{

--- a/providers/dns/allinkl/internal/client_test.go
+++ b/providers/dns/allinkl/internal/client_test.go
@@ -20,7 +20,7 @@ func setupClient(server *httptest.Server) (*Client, error) {
 func TestClient_GetDNSSettings(t *testing.T) {
 	client := servermock.NewBuilder[*Client](setupClient).
 		Route("POST /", servermock.ResponseFromFixture("get_dns_settings.xml"),
-			servermock.CheckRequestBodyFromFile("get_dns_settings-request.xml").
+			servermock.CheckRequestBodyFromFixture("get_dns_settings-request.xml").
 				IgnoreWhitespace()).
 		Build(t)
 
@@ -99,7 +99,7 @@ func TestClient_GetDNSSettings(t *testing.T) {
 func TestClient_AddDNSSettings(t *testing.T) {
 	client := servermock.NewBuilder[*Client](setupClient).
 		Route("POST /", servermock.ResponseFromFixture("add_dns_settings.xml"),
-			servermock.CheckRequestBodyFromFile("add_dns_settings-request.xml").
+			servermock.CheckRequestBodyFromFixture("add_dns_settings-request.xml").
 				IgnoreWhitespace()).
 		Build(t)
 
@@ -119,7 +119,7 @@ func TestClient_AddDNSSettings(t *testing.T) {
 func TestClient_DeleteDNSSettings(t *testing.T) {
 	client := servermock.NewBuilder[*Client](setupClient).
 		Route("POST /", servermock.ResponseFromFixture("delete_dns_settings.xml"),
-			servermock.CheckRequestBodyFromFile("delete_dns_settings-request.xml").
+			servermock.CheckRequestBodyFromFixture("delete_dns_settings-request.xml").
 				IgnoreWhitespace()).
 		Build(t)
 

--- a/providers/dns/arvancloud/internal/client_test.go
+++ b/providers/dns/arvancloud/internal/client_test.go
@@ -48,7 +48,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		Route("POST /cdn/4.0/domains/"+domain+"/dns-records",
 			servermock.ResponseFromFixture("create_txt_record.json").
 				WithStatusCode(http.StatusCreated),
-			servermock.CheckRequestJSONBodyFromFile("create_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json")).
 		Build(t)
 
 	record := DNSRecord{

--- a/providers/dns/autodns/internal/client_test.go
+++ b/providers/dns/autodns/internal/client_test.go
@@ -28,7 +28,7 @@ func TestClient_AddTxtRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /zone/example.com/_stream",
 			servermock.ResponseFromFixture("add_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("add_record-request.json"),
+			servermock.CheckRequestJSONBodyFromFixture("add_record-request.json"),
 			servermock.CheckHeader().
 				With("X-Domainrobot-Context", "123")).
 		Build(t)
@@ -58,7 +58,7 @@ func TestClient_RemoveTXTRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /zone/example.com/_stream",
 			servermock.ResponseFromFixture("remove_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("remove_record-request.json"),
+			servermock.CheckRequestJSONBodyFromFixture("remove_record-request.json"),
 			servermock.CheckHeader().
 				With("X-Domainrobot-Context", "123")).
 		Build(t)

--- a/providers/dns/checkdomain/internal/client_test.go
+++ b/providers/dns/checkdomain/internal/client_test.go
@@ -59,7 +59,7 @@ func TestClient_CheckNameservers(t *testing.T) {
 func TestClient_CreateRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /v1/domains/1/nameservers/records", nil,
-			servermock.CheckRequestJSONBodyFromFile("create_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json")).
 		Build(t)
 
 	record := &Record{
@@ -110,7 +110,7 @@ func TestClient_DeleteTXTRecord(t *testing.T) {
 				},
 			})).
 		Route("PUT /v1/domains/1/nameservers/records", nil,
-			servermock.CheckRequestJSONBodyFromFile("delete_txt_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("delete_txt_record-request.json")).
 		Build(t)
 
 	info := dns01.GetChallengeInfo(domainName, "abc")

--- a/providers/dns/civo/civo_test.go
+++ b/providers/dns/civo/civo_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -155,14 +154,13 @@ func TestDNSProvider_Present(t *testing.T) {
 	provider := mockBuilder().
 		// https://www.civo.com/api/dns#list-domain-names
 		Route("GET /dns",
-			responseFromFixture("list_domain_names.json"),
+			servermock.ResponseFromInternal("list_domain_names.json"),
 			servermock.CheckQueryParameter().Strict().
 				With("region", "LON1")).
 		// https://www.civo.com/api/dns#create-a-new-dns-record
 		Route("POST /dns/7088fcea-7658-43e6-97fa-273f901978fd/records",
-			responseFromFixture("create_dns_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("create_dns_record-request.json").
-				WithDirectory(filepath.Join("internal", "fixtures"))).
+			servermock.ResponseFromInternal("create_dns_record.json"),
+			servermock.CheckRequestJSONBodyFromInternal("create_dns_record-request.json")).
 		Build(t)
 
 	err := provider.Present("example.com", "abd", "123d==")
@@ -173,25 +171,21 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 	provider := mockBuilder().
 		// https://www.civo.com/api/dns#list-domain-names
 		Route("GET /dns",
-			responseFromFixture("list_domain_names.json"),
+			servermock.ResponseFromInternal("list_domain_names.json"),
 			servermock.CheckQueryParameter().
 				With("region", "LON1")).
 		// https://www.civo.com/api/dns#list-dns-records
 		Route("GET /dns/7088fcea-7658-43e6-97fa-273f901978fd/records",
-			responseFromFixture("list_dns_records.json"),
+			servermock.ResponseFromInternal("list_dns_records.json"),
 			servermock.CheckQueryParameter().Strict().
 				With("region", "LON1")).
 		// https://www.civo.com/api/dns#deleting-a-dns-record
 		Route("DELETE /dns/edc5dacf-a2ad-4757-41ee-c12f06259c70/records/76cc107f-fbef-4e2b-b97f-f5d34f4075d3",
-			responseFromFixture("delete_dns_record.json"),
+			servermock.ResponseFromInternal("delete_dns_record.json"),
 			servermock.CheckQueryParameter().Strict().
 				With("region", "LON1")).
 		Build(t)
 
 	err := provider.CleanUp("example.com", "abd", "123d==")
 	require.NoError(t, err)
-}
-
-func responseFromFixture(filename string) *servermock.ResponseFromFileHandler {
-	return servermock.ResponseFromFile(filepath.Join("internal", "fixtures", filename))
 }

--- a/providers/dns/civo/internal/client_test.go
+++ b/providers/dns/civo/internal/client_test.go
@@ -108,7 +108,7 @@ func TestClient_CreateDNSRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /dns/7088fcea-7658-43e6-97fa-273f901978fd/records",
 			servermock.ResponseFromFixture("create_dns_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("create_dns_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_dns_record-request.json")).
 		Build(t)
 
 	record := Record{

--- a/providers/dns/clouddns/internal/client_test.go
+++ b/providers/dns/clouddns/internal/client_test.go
@@ -27,14 +27,14 @@ func TestClient_AddRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /api/domain/search",
 			servermock.ResponseFromFixture("domain_search.json"),
-			servermock.CheckRequestJSONBodyFromFile("domain_search-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("domain_search-request.json")).
 		Route("POST /api/record-txt", nil,
-			servermock.CheckRequestJSONBodyFromFile("record_txt-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("record_txt-request.json")).
 		Route("PUT /api/domain/A/publish", nil,
-			servermock.CheckRequestJSONBodyFromFile("publish-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("publish-request.json")).
 		Route("POST /login",
 			servermock.ResponseFromFixture("login.json"),
-			servermock.CheckRequestJSONBodyFromFile("login-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("login-request.json")).
 		Build(t)
 
 	ctx, err := client.CreateAuthenticatedContext(t.Context())
@@ -48,15 +48,15 @@ func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /api/domain/search",
 			servermock.ResponseFromFixture("domain_search.json"),
-			servermock.CheckRequestJSONBodyFromFile("domain_search-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("domain_search-request.json")).
 		Route("GET /api/domain/A",
 			servermock.ResponseFromFixture("domain-request.json")).
 		Route("DELETE /api/record/R01", nil).
 		Route("PUT /api/domain/A/publish", nil,
-			servermock.CheckRequestJSONBodyFromFile("publish-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("publish-request.json")).
 		Route("POST /login",
 			servermock.ResponseFromFixture("login.json"),
-			servermock.CheckRequestJSONBodyFromFile("login-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("login-request.json")).
 		Build(t)
 
 	ctx, err := client.CreateAuthenticatedContext(t.Context())

--- a/providers/dns/clouddns/internal/identity_test.go
+++ b/providers/dns/clouddns/internal/identity_test.go
@@ -12,7 +12,7 @@ func TestClient_CreateAuthenticatedContext(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /login",
 			servermock.ResponseFromFixture("login.json"),
-			servermock.CheckRequestJSONBodyFromFile("login-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("login-request.json")).
 		Route("DELETE /api/record/xxx", nil).
 		Build(t)
 

--- a/providers/dns/cloudflare/internal/client_test.go
+++ b/providers/dns/cloudflare/internal/client_test.go
@@ -39,7 +39,7 @@ func TestClient_CreateDNSRecord(t *testing.T) {
 			servermock.ResponseFromFixture("create_record.json"),
 			servermock.CheckHeader().
 				WithContentType("application/json"),
-			servermock.CheckRequestJSONBodyFromFile("create_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json")).
 		Build(t)
 
 	record := Record{

--- a/providers/dns/dnsmadeeasy/internal/client_test.go
+++ b/providers/dns/dnsmadeeasy/internal/client_test.go
@@ -91,7 +91,7 @@ func TestClient_GetRecords(t *testing.T) {
 func TestClient_CreateRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /dns/managed/1/records", nil,
-			servermock.CheckRequestJSONBodyFromFile("create_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json")).
 		Build(t)
 
 	domain := &Domain{ID: 1, Name: "foo"}

--- a/providers/dns/domeneshop/internal/client_test.go
+++ b/providers/dns/domeneshop/internal/client_test.go
@@ -28,7 +28,7 @@ func TestClient_CreateTXTRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /domains/1/dns",
 			servermock.ResponseFromFixture("create_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("create_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json")).
 		Build(t)
 
 	err := client.CreateTXTRecord(t.Context(), &Domain{ID: 1}, "example.com", "txtTXTtxt")

--- a/providers/dns/dynu/internal/client_test.go
+++ b/providers/dns/dynu/internal/client_test.go
@@ -215,7 +215,7 @@ func TestAddNewRecord(t *testing.T) {
 
 			client := mockBuilder().
 				Route(test.pattern, servermock.ResponseFromFixture(test.file).WithStatusCode(test.status),
-					servermock.CheckRequestJSONBodyFromFile("add_new_record-request.json")).
+					servermock.CheckRequestJSONBodyFromFixture("add_new_record-request.json")).
 				Build(t)
 
 			record := DNSRecord{

--- a/providers/dns/gandi/internal/client_test.go
+++ b/providers/dns/gandi/internal/client_test.go
@@ -25,7 +25,7 @@ func mockBuilder() *servermock.Builder[*Client] {
 func TestClient_GetZoneID(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("get_zone_id.xml"),
-			servermock.CheckRequestBodyFromFile("get_zone_id-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("get_zone_id-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	zoneID, err := client.GetZoneID(t.Context(), "example.com")
@@ -37,7 +37,7 @@ func TestClient_GetZoneID(t *testing.T) {
 func TestClient_CloneZone(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("clone_zone.xml"),
-			servermock.CheckRequestBodyFromFile("clone_zone-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("clone_zone-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	zoneID, err := client.CloneZone(t.Context(), 6, "foo")
@@ -49,7 +49,7 @@ func TestClient_CloneZone(t *testing.T) {
 func TestClient_NewZoneVersion(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("new_zone_version.xml"),
-			servermock.CheckRequestBodyFromFile("new_zone_version-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("new_zone_version-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	zoneID, err := client.NewZoneVersion(t.Context(), 6)
@@ -61,7 +61,7 @@ func TestClient_NewZoneVersion(t *testing.T) {
 func TestClient_AddTXTRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("empty.xml"),
-			servermock.CheckRequestBodyFromFile("add_txt_record-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("add_txt_record-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	err := client.AddTXTRecord(t.Context(), 1, 123, "foo", "content", 120)
@@ -71,7 +71,7 @@ func TestClient_AddTXTRecord(t *testing.T) {
 func TestClient_SetZoneVersion(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("set_zone_version.xml"),
-			servermock.CheckRequestBodyFromFile("set_zone_version-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("set_zone_version-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	err := client.SetZoneVersion(t.Context(), 1, 123)
@@ -81,7 +81,7 @@ func TestClient_SetZoneVersion(t *testing.T) {
 func TestClient_SetZone(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("set_zone.xml"),
-			servermock.CheckRequestBodyFromFile("set_zone-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("set_zone-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	err := client.SetZone(t.Context(), "example.com", 1)
@@ -91,7 +91,7 @@ func TestClient_SetZone(t *testing.T) {
 func TestClient_DeleteZone(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("delete_zone.xml"),
-			servermock.CheckRequestBodyFromFile("delete_zone-request.xml").IgnoreWhitespace()).
+			servermock.CheckRequestBodyFromFixture("delete_zone-request.xml").IgnoreWhitespace()).
 		Build(t)
 
 	err := client.DeleteZone(t.Context(), 1)

--- a/providers/dns/godaddy/internal/client_test.go
+++ b/providers/dns/godaddy/internal/client_test.go
@@ -58,7 +58,7 @@ func TestClient_GetRecords_errors(t *testing.T) {
 func TestClient_UpdateTxtRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("PUT /v1/domains/example.com/records/TXT/lego", nil,
-			servermock.CheckRequestJSONBodyFromFile("update_records-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("update_records-request.json")).
 		Build(t)
 
 	records := []DNSRecord{
@@ -78,7 +78,7 @@ func TestClient_UpdateTxtRecords_errors(t *testing.T) {
 	client := mockBuilder().
 		Route("PUT /v1/domains/example.com/records/TXT/lego",
 			servermock.ResponseFromFixture("errors.json").WithStatusCode(http.StatusUnprocessableEntity),
-			servermock.CheckRequestJSONBodyFromFile("update_records-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("update_records-request.json")).
 		Build(t)
 
 	records := []DNSRecord{

--- a/providers/dns/hetzner/internal/client_test.go
+++ b/providers/dns/hetzner/internal/client_test.go
@@ -53,7 +53,7 @@ func TestClient_CreateRecord(t *testing.T) {
 
 	client := mockBuilder("myKeyB").
 		Route("POST /api/v1/records", servermock.ResponseFromFixture("create_txt_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("create_txt_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_txt_record-request.json")).
 		Build(t)
 
 	record := DNSRecord{

--- a/providers/dns/infomaniak/internal/client_test.go
+++ b/providers/dns/infomaniak/internal/client_test.go
@@ -27,7 +27,7 @@ func TestClient_CreateDNSRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /1/domain/666/dns/record",
 			servermock.RawStringResponse(`{"result":"success","data": "123"}`),
-			servermock.CheckRequestJSONBodyFromFile("create_dns_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("create_dns_record-request.json")).
 		Build(t)
 
 	domain := &DNSDomain{

--- a/providers/dns/internal/hostingde/client_test.go
+++ b/providers/dns/internal/hostingde/client_test.go
@@ -23,7 +23,7 @@ func TestClient_ListZoneConfigs(t *testing.T) {
 	client := servermock.NewBuilder[*Client](setupClient).
 		Route("POST /zoneConfigsFind",
 			servermock.ResponseFromFixture("zoneConfigsFind.json"),
-			servermock.CheckRequestJSONBodyFromFile("zoneConfigsFind-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("zoneConfigsFind-request.json")).
 		Build(t)
 
 	zonesFind := ZoneConfigsFindRequest{
@@ -88,7 +88,7 @@ func TestClient_UpdateZone(t *testing.T) {
 	client := servermock.NewBuilder[*Client](setupClient).
 		Route("POST /zoneUpdate",
 			servermock.ResponseFromFixture("zoneUpdate.json"),
-			servermock.CheckRequestJSONBodyFromFile("zoneUpdate-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("zoneUpdate-request.json")).
 		Build(t)
 
 	request := ZoneUpdateRequest{

--- a/providers/dns/internal/selectel/client_test.go
+++ b/providers/dns/internal/selectel/client_test.go
@@ -80,7 +80,7 @@ func TestClient_AddRecord(t *testing.T) {
 			With(tokenHeader, "token")).
 		Route("POST /123/records/",
 			servermock.ResponseFromFixture("add_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("add_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("add_record-request.json")).
 		Build(t)
 
 	record, err := client.AddRecord(t.Context(), 123, Record{

--- a/providers/dns/namecheap/namecheap_test.go
+++ b/providers/dns/namecheap/namecheap_test.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -54,7 +53,7 @@ func TestDNSProvider_Present(t *testing.T) {
 
 			provider := mockBuilder().
 				Route("GET /",
-					servermock.ResponseFromFile(filepath.Join("internal", "fixtures", test.getHostsResponse)),
+					servermock.ResponseFromInternal(test.getHostsResponse),
 					servermock.CheckForm().Strict().
 						With("ClientIp", "10.0.0.1").
 						With("Command", "namecheap.domains.dns.getHosts").
@@ -65,7 +64,7 @@ func TestDNSProvider_Present(t *testing.T) {
 						With("ApiUser", "foo"),
 				).
 				Route("POST /",
-					servermock.ResponseFromFile(filepath.Join("internal", "fixtures", test.setHostsResponse)),
+					servermock.ResponseFromInternal(test.setHostsResponse),
 					servermock.CheckForm().
 						With("ClientIp", "10.0.0.1").
 						With("Command", "namecheap.domains.dns.setHosts").
@@ -94,7 +93,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 
 			provider := mockBuilder().
 				Route("GET /",
-					servermock.ResponseFromFile(filepath.Join("internal", "fixtures", test.getHostsResponse)),
+					servermock.ResponseFromInternal(test.getHostsResponse),
 					servermock.CheckForm().Strict().
 						With("ClientIp", "10.0.0.1").
 						With("Command", "namecheap.domains.dns.getHosts").
@@ -105,7 +104,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 						With("ApiUser", "foo"),
 				).
 				Route("POST /",
-					servermock.ResponseFromFile(filepath.Join("internal", "fixtures", test.setHostsResponse)),
+					servermock.ResponseFromInternal(test.setHostsResponse),
 					servermock.CheckForm().
 						With("ClientIp", "10.0.0.1").
 						With("Command", "namecheap.domains.dns.setHosts").

--- a/providers/dns/netcup/internal/client_test.go
+++ b/providers/dns/netcup/internal/client_test.go
@@ -131,7 +131,7 @@ func TestGetDNSRecordIdx(t *testing.T) {
 func TestClient_GetDNSRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("get_dns_records.json"),
-			servermock.CheckRequestJSONBodyFromFile("get_dns_records-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("get_dns_records-request.json")).
 		Build(t)
 
 	expected := []DNSRecord{{

--- a/providers/dns/netcup/internal/session_test.go
+++ b/providers/dns/netcup/internal/session_test.go
@@ -19,7 +19,7 @@ func mockContext(t *testing.T) context.Context {
 func TestClient_Login(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("login.json"),
-			servermock.CheckRequestJSONBodyFromFile("login-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("login-request.json")).
 		Build(t)
 
 	sessionID, err := client.login(t.Context())
@@ -69,7 +69,7 @@ func TestClient_Login_errors(t *testing.T) {
 func TestClient_Logout(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /", servermock.ResponseFromFixture("logout.json"),
-			servermock.CheckRequestJSONBodyFromFile("logout-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("logout-request.json")).
 		Build(t)
 
 	err := client.Logout(mockContext(t))

--- a/providers/dns/njalla/internal/client_test.go
+++ b/providers/dns/njalla/internal/client_test.go
@@ -24,7 +24,7 @@ func TestClient_AddRecord(t *testing.T) {
 	).
 		Route("POST /",
 			servermock.ResponseFromFixture("add_record.json"),
-			servermock.CheckRequestJSONBodyFromFile("add_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("add_record-request.json")).
 		Build(t)
 
 	record := Record{
@@ -80,7 +80,7 @@ func TestClient_ListRecords(t *testing.T) {
 	).
 		Route("POST /",
 			servermock.ResponseFromFixture("list_records.json"),
-			servermock.CheckRequestJSONBodyFromFile("list_records-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("list_records-request.json")).
 		Build(t)
 
 	records, err := client.ListRecords(t.Context(), "example.com")
@@ -131,7 +131,7 @@ func TestClient_RemoveRecord(t *testing.T) {
 	).
 		Route("POST /",
 			servermock.RawStringResponse(`{"jsonrpc":"2.0"}`),
-			servermock.CheckRequestJSONBodyFromFile("remove_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("remove_record-request.json")).
 		Build(t)
 
 	err := client.RemoveRecord(t.Context(), "123", "example.com")

--- a/providers/dns/pdns/internal/client_test.go
+++ b/providers/dns/pdns/internal/client_test.go
@@ -231,7 +231,7 @@ func TestClient_UpdateRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("PATCH /api/v1/servers/localhost/zones/example.org.",
 			servermock.ResponseFromFixture("zone.json"),
-			servermock.CheckRequestJSONBodyFromFile("zone-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("zone-request.json")).
 		Build(t)
 
 	client.apiVersion = 1
@@ -266,7 +266,7 @@ func TestClient_UpdateRecords_NonRootApi(t *testing.T) {
 	client := mockBuilder().
 		Route("PATCH /some/path/api/v1/servers/localhost/zones/example.org.",
 			servermock.ResponseFromFixture("zone.json"),
-			servermock.CheckRequestJSONBodyFromFile("zone-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("zone-request.json")).
 		Build(t)
 
 	client.Host = client.Host.JoinPath("some", "path")
@@ -302,7 +302,7 @@ func TestClient_UpdateRecords_v0(t *testing.T) {
 	client := mockBuilder().
 		Route("PATCH /servers/localhost/zones/example.org.",
 			servermock.ResponseFromFixture("zone.json"),
-			servermock.CheckRequestJSONBodyFromFile("zone-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("zone-request.json")).
 		Build(t)
 
 	client.apiVersion = 0

--- a/providers/dns/safedns/internal/client_test.go
+++ b/providers/dns/safedns/internal/client_test.go
@@ -29,7 +29,7 @@ func TestClient_AddRecord(t *testing.T) {
 		Route("POST /zones/example.com/records",
 			servermock.ResponseFromFixture("add_record.json").
 				WithStatusCode(http.StatusCreated),
-			servermock.CheckRequestJSONBodyFromFile("add_record-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("add_record-request.json")).
 		Build(t)
 
 	record := Record{

--- a/providers/dns/versio/internal/client_test.go
+++ b/providers/dns/versio/internal/client_test.go
@@ -68,7 +68,7 @@ func TestClient_UpdateDomain(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /domains/example.com/update",
 			servermock.ResponseFromFixture("update-domain.json"),
-			servermock.CheckRequestJSONBodyFromFile("update-domain-request.json")).
+			servermock.CheckRequestJSONBodyFromFixture("update-domain-request.json")).
 		Build(t)
 
 	msg := &DomainInfo{DNSRecords: []Record{


### PR DESCRIPTION
Use the same naming pattern with handlers that read files:
- `XXXFromFile`: reads a file from a path
- `XXXFromFixture`: reads a file from a `./fixtures` directory
- `XXXFromInternal`: reads a file from a `./internal/fixtures` directory
