### PR TITLE
tencentcloud: replace tencentcloud-sdk-go with a fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dnsimple/dnsimple-go/v4 v4.0.0
 	github.com/exoscale/egoscale/v3 v3.1.13
+	github.com/go-acme/tencentclouddnspod v1.0.1208
 	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-cmp v0.7.0
@@ -75,8 +76,7 @@ require (
 	github.com/selectel/go-selvpcclient/v4 v4.1.0
 	github.com/softlayer/softlayer-go v1.1.7
 	github.com/stretchr/testify v1.10.0
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1128
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.1128
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1208
 	github.com/transip/gotransip/v6 v6.26.0
 	github.com/ultradns/ultradns-go-sdk v1.8.0-20241010134910-243eeec
 	github.com/urfave/cli/v2 v2.27.6

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-acme/tencentclouddnspod v1.0.1208 h1:xAVy1lmg2KcKKeYmFSBQUttwc1o1S++9QTjAotGC+BM=
+github.com/go-acme/tencentclouddnspod v1.0.1208/go.mod h1:yxG02mkbbVd7lTb97nOn7oj09djhm7hAwxNQw4B9dpQ=
 github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -891,10 +893,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1128 h1:NGnqDc8FQL0YdiCHgTO4Wkso6ToD8rE3JW9VOzoPBNA=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1128/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.1128 h1:mrJ5Fbkd7sZIJ5F6oRfh5zebPQaudPH9Y0+GUmFytYU=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.1128/go.mod h1:zbsYIBT+VTX4z4ocjTAdLBIWyNYj3z0BRqd0iPdnjsk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1208 h1:hE2rM9GoqISu4lgQVbx9+bTlPOB000pdUfbT9lwrC50=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1208/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tjfoc/gmsm v1.3.2/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=
 github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
 github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=

--- a/providers/dns/tencentcloud/tencentcloud.go
+++ b/providers/dns/tencentcloud/tencentcloud.go
@@ -11,9 +11,9 @@ import (
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
+	dnspod "github.com/go-acme/tencentclouddnspod/v20210323"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
-	dnspod "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod/v20210323"
 )
 
 // Environment variables names.
@@ -139,7 +139,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	request.Value = common.StringPtr(info.Value)
 	request.TTL = common.Uint64Ptr(uint64(d.config.TTL))
 
-	_, err = d.client.CreateRecordWithContext(ctx, request)
+	_, err = dnspod.CreateRecordWithContext(ctx, d.client, request)
 	if err != nil {
 		return fmt.Errorf("dnspod: API call failed: %w", err)
 	}
@@ -169,7 +169,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		request.DomainId = zone.DomainId
 		request.RecordId = record.RecordId
 
-		_, err := d.client.DeleteRecordWithContext(ctx, request)
+		_, err := dnspod.DeleteRecordWithContext(ctx, d.client, request)
 		if err != nil {
 			return fmt.Errorf("tencentcloud: delete record failed: %w", err)
 		}

--- a/providers/dns/tencentcloud/wrapper.go
+++ b/providers/dns/tencentcloud/wrapper.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/go-acme/lego/v4/challenge/dns01"
+	dnspod "github.com/go-acme/tencentclouddnspod/v20210323"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	errorsdk "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
-	dnspod "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod/v20210323"
 	"golang.org/x/net/idna"
 )
 
@@ -18,7 +18,7 @@ func (d *DNSProvider) getHostedZone(ctx context.Context, domain string) (*dnspod
 	var domains []*dnspod.DomainListItem
 
 	for {
-		response, err := d.client.DescribeDomainListWithContext(ctx, request)
+		response, err := dnspod.DescribeDomainListWithContext(ctx, d.client, request)
 		if err != nil {
 			return nil, fmt.Errorf("API call failed: %w", err)
 		}
@@ -65,7 +65,7 @@ func (d *DNSProvider) findTxtRecords(ctx context.Context, zone *dnspod.DomainLis
 	request.RecordType = common.StringPtr("TXT")
 	request.RecordLine = common.StringPtr("默认")
 
-	response, err := d.client.DescribeRecordListWithContext(ctx, request)
+	response, err := dnspod.DescribeRecordListWithContext(ctx, d.client, request)
 	if err != nil {
 		var sdkError *errorsdk.TencentCloudSDKError
 		if errors.As(err, &sdkError) {


### PR DESCRIPTION
This is a special fork: the methods of the structure `Client` are converted to functions that use `Client` as a parameter.

The goal is to break the link between the `Client` structure and the other structures to reduce the binary size.

This automatic approach for the fork is possible because the official `tencentcloud-sdk-go` library is 100 % generated.

https://github.com/go-acme/tencentclouddnspod

| Version  | Size inside the binary | Module size (`GOCACHE`) |
|----------|------------------------|-------------------------|
| official | 3.9 MB                 | 1.1 MB                  |
| fork     | 183 kB                 | 1.1 MB                  |
