### PR TITLE
alidns: replace alidns-20150109 with a fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/OpenDNS/vegadns2client v0.0.0-20180418235048-a3fa4a771d87
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
-	github.com/alibabacloud-go/alidns-20150109/v4 v4.5.10
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.11
 	github.com/aliyun/credentials-go v1.4.5
 	github.com/aws/aws-sdk-go-v2 v1.36.3
@@ -31,6 +30,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dnsimple/dnsimple-go/v4 v4.0.0
 	github.com/exoscale/egoscale/v3 v3.1.13
+	github.com/go-acme/alidns-20150109/v4 v4.5.10
 	github.com/go-acme/tencentclouddnspod v1.0.1208
 	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-viper/mapstructure/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.6/go.mod h1:4EUIoxs/do2
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.4/go.mod h1:sCavSAvdzOjul4cEqeVtvlSaSScfNsTQ+46HwlTL1hc=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 h1:zE8vH9C7JiZLNJJQ5OwjU9mSi4T9ef9u3BURT6LCLC8=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5/go.mod h1:tWnyE9AjF8J8qqLk645oUmVUnFybApTQWklQmi5tY6g=
-github.com/alibabacloud-go/alidns-20150109/v4 v4.5.10 h1:lEYfSDh8puQigWN2pyOxE1gaI6o2bxFhJSSeX+ZJSf4=
-github.com/alibabacloud-go/alidns-20150109/v4 v4.5.10/go.mod h1:EdHRU3Y2j8OXc2ljp00A0zMLQ8sORHxI4yPnODNztRc=
 github.com/alibabacloud-go/darabonba-array v0.1.0 h1:vR8s7b1fWAQIjEjWnuF0JiKsCvclSRTfDzZHTYqfufY=
 github.com/alibabacloud-go/darabonba-array v0.1.0/go.mod h1:BLKxr0brnggqOJPqT09DFJ8g3fsDshapUD3C3aOEFaI=
 github.com/alibabacloud-go/darabonba-encode-util v0.0.2 h1:1uJGrbsGEVqWcWxrS9MyC2NG0Ax+GpOM5gtupki31XE=
@@ -313,6 +311,8 @@ github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-acme/alidns-20150109/v4 v4.5.10 h1:epLD0VaHR5XUpiM6mjm4MzQFICrk+zpuqDz2aO1/R/k=
+github.com/go-acme/alidns-20150109/v4 v4.5.10/go.mod h1:qGRq8kD0xVgn82qRSQmhHwh/oWxKRjF4Db5OI4ScV5g=
 github.com/go-acme/tencentclouddnspod v1.0.1208 h1:xAVy1lmg2KcKKeYmFSBQUttwc1o1S++9QTjAotGC+BM=
 github.com/go-acme/tencentclouddnspod v1.0.1208/go.mod h1:yxG02mkbbVd7lTb97nOn7oj09djhm7hAwxNQw4B9dpQ=
 github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=

--- a/providers/dns/alidns/alidns.go
+++ b/providers/dns/alidns/alidns.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	alidns "github.com/alibabacloud-go/alidns-20150109/v4/client"
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	"github.com/aliyun/credentials-go/credentials"
+	alidns "github.com/go-acme/alidns-20150109/v4/client"
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
@@ -162,7 +162,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return err
 	}
 
-	_, err = d.client.AddDomainRecord(recordRequest)
+	_, err = alidns.AddDomainRecord(d.client, recordRequest)
 	if err != nil {
 		return fmt.Errorf("alicloud: API call failed: %w", err)
 	}
@@ -188,7 +188,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 			RecordId: rec.RecordId,
 		}
 
-		_, err = d.client.DeleteDomainRecord(request)
+		_, err = alidns.DeleteDomainRecord(d.client, request)
 		if err != nil {
 			return fmt.Errorf("alicloud: %w", err)
 		}
@@ -206,7 +206,7 @@ func (d *DNSProvider) getHostedZone(domain string) (string, error) {
 	for {
 		request.SetPageNumber(startPage)
 
-		response, err := d.client.DescribeDomains(request)
+		response, err := alidns.DescribeDomains(d.client, request)
 		if err != nil {
 			return "", fmt.Errorf("API call failed: %w", err)
 		}
@@ -265,7 +265,7 @@ func (d *DNSProvider) findTxtRecords(fqdn string) ([]*alidns.DescribeDomainRecor
 
 	var records []*alidns.DescribeDomainRecordsResponseBodyDomainRecordsRecord
 
-	result, err := d.client.DescribeDomainRecords(request)
+	result, err := alidns.DescribeDomainRecords(d.client, request)
 	if err != nil {
 		return records, fmt.Errorf("API call has failed: %w", err)
 	}


### PR DESCRIPTION
This is a special fork: the methods of the structure `Client` are converted to functions that use `Client` as a parameter.

The goal is to break the link between the `Client` structure and the other structures to reduce the binary size.

This automatic approach for the fork is possible because the official `alidns-20150109` library is 100 % generated.

https://github.com/go-acme/alidns-20150109

| Version  | Size inside the binary | Module size (`GOCACHE`) |
|----------|------------------------|-------------------------|
| official | 4.6 MB                 | 2.04 MiB                |
| fork     | 112 kB                 | 2.04 MiB                |

The cache size has been reduced from 88.654 MiB to 2.04 MiB inside https://github.com/go-acme/lego/pull/2558
