### PR TITLE
huaweicloud: lightweight client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -170,6 +170,9 @@ linters:
     presets:
       - comments
       - std-error-handling
+    paths:
+      # Those elements a related to code borrowed from the official HuaweiCloud API client.
+      - providers/dns/huaweicloud/internal
     rules:
       - path: (.+)_test.go
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,7 +171,7 @@ linters:
       - comments
       - std-error-handling
     paths:
-      # Those elements a related to code borrowed from the official HuaweiCloud API client.
+      # Those elements are related to code borrowed from the official HuaweiCloud API client.
       - providers/dns/huaweicloud/internal
     rules:
       - path: (.+)_test.go

--- a/providers/dns/huaweicloud/huaweicloud.go
+++ b/providers/dns/huaweicloud/huaweicloud.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/platform/config/env"
 	"github.com/go-acme/lego/v4/platform/wait"
+	"github.com/go-acme/lego/v4/providers/dns/huaweicloud/internal"
 	"github.com/go-acme/lego/v4/providers/dns/internal/ptr"
 	hwauthbasic "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/basic"
 	hwconfig "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/config"
@@ -62,7 +63,7 @@ func NewDefaultConfig() *Config {
 // DNSProvider implements the challenge.Provider interface.
 type DNSProvider struct {
 	config *Config
-	client *hwdns.DnsClient
+	client *internal.DnsClient
 
 	recordIDs   map[string]string
 	recordIDsMu sync.Mutex
@@ -119,7 +120,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	return &DNSProvider{
 		config:    config,
-		client:    hwdns.NewDnsClient(client),
+		client:    internal.NewDnsClient(client),
 		recordIDs: map[string]string{},
 	}, nil
 }

--- a/providers/dns/huaweicloud/internal/client.go
+++ b/providers/dns/huaweicloud/internal/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package internal partial copy of https://github.com/huaweicloud/huaweicloud-sdk-go-v3/blob/v0.1.159/services/dns/v2/dns_client.go
+// Package internal is a partial copy of https://github.com/huaweicloud/huaweicloud-sdk-go-v3/blob/v0.1.159/services/dns/v2/dns_client.go
 package internal
 
 import (

--- a/providers/dns/huaweicloud/internal/client.go
+++ b/providers/dns/huaweicloud/internal/client.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Huawei Technologies Co., Ltd. 2020-present. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package internal partial copy of https://github.com/huaweicloud/huaweicloud-sdk-go-v3/blob/v0.1.159/services/dns/v2/dns_client.go
+package internal
+
+import (
+	httpclient "github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+	hwdns "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/dns/v2"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/dns/v2/model"
+)
+
+type DnsClient struct {
+	HcClient *httpclient.HcHttpClient
+}
+
+func NewDnsClient(hcClient *httpclient.HcHttpClient) *DnsClient {
+	return &DnsClient{HcClient: hcClient}
+}
+
+func (c *DnsClient) ShowRecordSet(request *model.ShowRecordSetRequest) (*model.ShowRecordSetResponse, error) {
+	requestDef := hwdns.GenReqDefForShowRecordSet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowRecordSetResponse), nil
+	}
+}
+
+func (c *DnsClient) CreateRecordSet(request *model.CreateRecordSetRequest) (*model.CreateRecordSetResponse, error) {
+	requestDef := hwdns.GenReqDefForCreateRecordSet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateRecordSetResponse), nil
+	}
+}
+
+func (c *DnsClient) UpdateRecordSet(request *model.UpdateRecordSetRequest) (*model.UpdateRecordSetResponse, error) {
+	requestDef := hwdns.GenReqDefForUpdateRecordSet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateRecordSetResponse), nil
+	}
+}
+
+func (c *DnsClient) DeleteRecordSet(request *model.DeleteRecordSetRequest) (*model.DeleteRecordSetResponse, error) {
+	requestDef := hwdns.GenReqDefForDeleteRecordSet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteRecordSetResponse), nil
+	}
+}
+
+func (c *DnsClient) ListRecordSetsByZone(request *model.ListRecordSetsByZoneRequest) (*model.ListRecordSetsByZoneResponse, error) {
+	requestDef := hwdns.GenReqDefForListRecordSetsByZone()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListRecordSetsByZoneResponse), nil
+	}
+}
+
+func (c *DnsClient) ListPublicZones(request *model.ListPublicZonesRequest) (*model.ListPublicZonesResponse, error) {
+	requestDef := hwdns.GenReqDefForListPublicZones()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListPublicZonesResponse), nil
+	}
+}


### PR DESCRIPTION
Same problem as alidns or dnspod, the client depends on too many structures.

The client is 100% generated code, but the huaweicloud client can be easily recreated without forking.

The client methods contain only plumbing, and it's always the same pattern.
We still depend on the official client, so we will receive the benefits of bug fixes but without the binary cost.

| branch | Size inside the binary |
|--------|------------------------|
| master | 1.1 MB                 |
| PR     | 259 kB                 |
