### PR TITLE
Prepare release v4.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.25.1](https://github.com/go-acme/lego/releases/tag/v4.25.1) (2025-07-21)
+
+### Fixed
+
+- **[cli]** fix: wrong CLI flag type
+
 ## [v4.25.0](https://github.com/go-acme/lego/releases/tag/v4.25.0) (2025-07-21)
 
 The binary size of this release is about ~50% smaller compared to previous releases.

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -9,5 +9,5 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -4,10 +4,10 @@ package sender
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme/4.25.0"
+	ourUserAgent = "xenolf-acme/4.25.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )

--- a/cmd/lego/zz_gen_version.go
+++ b/cmd/lego/zz_gen_version.go
@@ -2,7 +2,7 @@
 
 package main
 
-const defaultVersion = "v4.25.1+dev-release"
+const defaultVersion = "v4.25.1+dev-detach"
 
 var version = ""
 

--- a/cmd/lego/zz_gen_version.go
+++ b/cmd/lego/zz_gen_version.go
@@ -2,7 +2,7 @@
 
 package main
 
-const defaultVersion = "v4.25.0+dev-detach"
+const defaultVersion = "v4.25.1+dev-release"
 
 var version = ""
 

--- a/providers/dns/internal/useragent/useragent.go
+++ b/providers/dns/internal/useragent/useragent.go
@@ -10,12 +10,12 @@ import (
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "goacme-lego/4.25.0"
+	ourUserAgent = "goacme-lego/4.25.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )
 
 // Get builds and returns the User-Agent string.

--- a/providers/dns/internal/useragent/useragent.go
+++ b/providers/dns/internal/useragent/useragent.go
@@ -15,7 +15,7 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )
 
 // Get builds and returns the User-Agent string.


### PR DESCRIPTION
**IMPORTANT**

The 2 commits must be kept: the merge must be done with a **rebase** (neither merge commit nor squash)

2 commits:
- one for the future tagged version
- one for after the release (`detach`)
