### PR TITLE
fix: remove wrong env var

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -90,9 +90,8 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			Usage:   "Email used for registration and recovery contact.",
 		},
 		&cli.BoolFlag{
-			Name:    flgDisableCommonName,
-			EnvVars: []string{flgDisableCommonName},
-			Usage:   "Disable the use of the common name in the CSR.",
+			Name:  flgDisableCommonName,
+			Usage: "Disable the use of the common name in the CSR.",
 		},
 		&cli.StringFlag{
 			Name:    flgCSR,

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -23,7 +23,7 @@ GLOBAL OPTIONS:
    --server value, -s value                                     CA hostname (and optionally :port). The server certificate must be trusted in order to avoid further modifications to the client. (default: "https://acme-v02.api.letsencrypt.org/directory") [$LEGO_SERVER]
    --accept-tos, -a                                             By setting this flag to true you indicate that you accept the current Let's Encrypt terms of service. (default: false)
    --email value, -m value                                      Email used for registration and recovery contact. [$LEGO_EMAIL]
-   --disable-cn                                                 Disable the use of the common name in the CSR. (default: false) [$disable-cn]
+   --disable-cn                                                 Disable the use of the common name in the CSR. (default: false)
    --csr value, -c value                                        Certificate signing request filename, if an external CSR is to be used.
    --eab                                                        Use External Account Binding for account registration. Requires --kid and --hmac. (default: false) [$LEGO_EAB]
    --kid value                                                  Key identifier from External CA. Used for External Account Binding. [$LEGO_EAB_KID]


### PR DESCRIPTION
Related to a wrong copy/paste and replace: I used the name of the flag as env var name.
