### PR TITLE
chore: clean up tests and code

### DIFF
--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -96,6 +96,8 @@ func (c *CertificateService) getCertificateChain(cert []byte, headers http.Heade
 		return &acme.RawCertificate{Cert: cert, Issuer: issuer}
 	}
 
+	// TODO(ldez) remove all this section.
+
 	// The issuer certificate link may be supplied via an "up" link
 	// in the response headers of a new certificate.
 	// See https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -2,15 +2,12 @@ package api
 
 import (
 	"bytes"
-	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
 
 	"github.com/go-acme/lego/v4/acme"
-	"github.com/go-acme/lego/v4/certcrypto"
-	"github.com/go-acme/lego/v4/log"
 )
 
 // maxBodySize is the maximum size of body that we will read.
@@ -77,64 +74,22 @@ func (c *CertificateService) get(certURL string, bundle bool) (*acme.RawCertific
 		return nil, resp.Header, err
 	}
 
-	cert := c.getCertificateChain(data, resp.Header, bundle, certURL)
+	cert := c.getCertificateChain(data, bundle)
 
 	return cert, resp.Header, err
 }
 
 // getCertificateChain Returns the certificate and the issuer certificate.
-func (c *CertificateService) getCertificateChain(cert []byte, headers http.Header, bundle bool, certURL string) *acme.RawCertificate {
+func (c *CertificateService) getCertificateChain(cert []byte, bundle bool) *acme.RawCertificate {
 	// Get issuerCert from bundled response from Let's Encrypt
 	// See https://community.letsencrypt.org/t/acme-v2-no-up-link-in-response/64962
 	_, issuer := pem.Decode(cert)
-	if issuer != nil {
-		// If bundle is false, we want to return a single certificate.
-		// To do this, we remove the issuer cert(s) from the issued cert.
-		if !bundle {
-			cert = bytes.TrimSuffix(cert, issuer)
-		}
-		return &acme.RawCertificate{Cert: cert, Issuer: issuer}
-	}
 
-	// TODO(ldez) remove all this section.
-
-	// The issuer certificate link may be supplied via an "up" link
-	// in the response headers of a new certificate.
-	// See https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2
-	up := getLink(headers, "up")
-
-	issuer, err := c.getIssuerFromLink(up)
-	if err != nil {
-		// If we fail to acquire the issuer cert, return the issued certificate - do not fail.
-		log.Warnf("acme: Could not bundle issuer certificate [%s]: %v", certURL, err)
-	} else if len(issuer) > 0 {
-		// If bundle is true, we want to return a certificate bundle.
-		// To do this, we append the issuer cert to the issued cert.
-		if bundle {
-			cert = append(cert, issuer...)
-		}
+	// If bundle is false, we want to return a single certificate.
+	// To do this, we remove the issuer cert(s) from the issued cert.
+	if !bundle {
+		cert = bytes.TrimSuffix(cert, issuer)
 	}
 
 	return &acme.RawCertificate{Cert: cert, Issuer: issuer}
-}
-
-// getIssuerFromLink requests the issuer certificate.
-func (c *CertificateService) getIssuerFromLink(up string) ([]byte, error) {
-	if up == "" {
-		return nil, nil
-	}
-
-	log.Infof("acme: Requesting issuer cert from %s", up)
-
-	cert, _, err := c.get(up, false)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = x509.ParseCertificate(cert.Cert)
-	if err != nil {
-		return nil, err
-	}
-
-	return certcrypto.PEMEncode(certcrypto.DERCertificateBytes(cert.Cert)), nil
 }

--- a/acme/api/certificate_test.go
+++ b/acme/api/certificate_test.go
@@ -3,8 +3,6 @@ package api
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/pem"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -77,21 +75,7 @@ rzFL1KZfz+HZdnFwFW2T2gVW8L3ii1l9AJDuKzlvjUH3p6bgihVq02sjT8mx+GM2
 
 func TestCertificateService_Get_issuerRelUp(t *testing.T) {
 	apiURL := tester.MockACMEServer().
-		Route("POST /certificate",
-			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				// TODO(ldez) remove up link.
-				rw.Header().Set("Link",
-					fmt.Sprintf(`<http://%s/issuer>; rel="up"`, req.Context().Value(http.LocalAddrContextKey)))
-
-				servermock.RawStringResponse(certResponseMock).ServeHTTP(rw, req)
-			})).
-		// TODO(ldez) remove this call.
-		Route("POST /issuer",
-			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				p, _ := pem.Decode([]byte(issuerMock))
-
-				servermock.RawResponse(p.Bytes).ServeHTTP(rw, req)
-			})).
+		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-acme/lego/v4/acme/api"
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/platform/tester"
+	"github.com/go-acme/lego/v4/platform/tester/servermock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,15 +176,9 @@ Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
 `
 
 func Test_checkResponse(t *testing.T) {
-	mux, apiURL := tester.SetupFakeAPI(t)
-
-	mux.HandleFunc("/certificate", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(certResponseMock))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+	apiURL := tester.MockACMEServer().
+		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
+		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
@@ -215,25 +210,23 @@ func Test_checkResponse(t *testing.T) {
 }
 
 func Test_checkResponse_issuerRelUp(t *testing.T) {
-	mux, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().
+		Route("POST /certificate",
+			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// TODO(ldez) remove up link.
+				rw.Header().Set("Link",
+					fmt.Sprintf(`<http://%s/issuer>; rel="up"`, req.Context().Value(http.LocalAddrContextKey)))
 
-	mux.HandleFunc("/certificate", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Link", "<"+apiURL+`/issuer>; rel="up"`)
-		_, err := w.Write([]byte(certResponseMock))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+				servermock.RawStringResponse(certResponseMock).ServeHTTP(rw, req)
+			})).
+		// TODO(ldez) remove this call.
+		Route("POST /issuer",
+			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				p, _ := pem.Decode([]byte(issuerMock))
 
-	mux.HandleFunc("/issuer", func(w http.ResponseWriter, _ *http.Request) {
-		p, _ := pem.Decode([]byte(issuerMock))
-		_, err := w.Write(p.Bytes)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+				servermock.RawResponse(p.Bytes).ServeHTTP(rw, req)
+			})).
+		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
@@ -265,15 +258,9 @@ func Test_checkResponse_issuerRelUp(t *testing.T) {
 }
 
 func Test_checkResponse_no_bundle(t *testing.T) {
-	mux, apiURL := tester.SetupFakeAPI(t)
-
-	mux.HandleFunc("/certificate", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(certResponseMock))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+	apiURL := tester.MockACMEServer().
+		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
+		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
@@ -305,25 +292,16 @@ func Test_checkResponse_no_bundle(t *testing.T) {
 }
 
 func Test_checkResponse_alternate(t *testing.T) {
-	mux, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().
+		Route("POST /certificate",
+			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.Header().Add("Link",
+					fmt.Sprintf(`<http://%s/certificate/1>;title="foo";rel="alternate"`, req.Context().Value(http.LocalAddrContextKey)))
 
-	mux.HandleFunc("/certificate", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Add("Link", fmt.Sprintf(`<%s/certificate/1>;title="foo";rel="alternate"`, apiURL))
-
-		_, err := w.Write([]byte(certResponseMock))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
-
-	mux.HandleFunc("/certificate/1", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(certResponseMock2))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+				servermock.RawStringResponse(certResponseMock).ServeHTTP(rw, req)
+			})).
+		Route("/certificate/1", servermock.RawStringResponse(certResponseMock2)).
+		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
@@ -358,15 +336,9 @@ func Test_checkResponse_alternate(t *testing.T) {
 }
 
 func Test_Get(t *testing.T) {
-	mux, apiURL := tester.SetupFakeAPI(t)
-
-	mux.HandleFunc("/acme/cert/test-cert", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(certResponseMock))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
+	apiURL := tester.MockACMEServer().
+		Route("POST /acme/cert/test-cert", servermock.RawStringResponse(certResponseMock)).
+		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -3,7 +3,6 @@ package certificate
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/pem"
 	"fmt"
 	"net/http"
 	"testing"
@@ -211,21 +210,7 @@ func Test_checkResponse(t *testing.T) {
 
 func Test_checkResponse_issuerRelUp(t *testing.T) {
 	apiURL := tester.MockACMEServer().
-		Route("POST /certificate",
-			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				// TODO(ldez) remove up link.
-				rw.Header().Set("Link",
-					fmt.Sprintf(`<http://%s/issuer>; rel="up"`, req.Context().Value(http.LocalAddrContextKey)))
-
-				servermock.RawStringResponse(certResponseMock).ServeHTTP(rw, req)
-			})).
-		// TODO(ldez) remove this call.
-		Route("POST /issuer",
-			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				p, _ := pem.Decode([]byte(issuerMock))
-
-				servermock.RawResponse(p.Bytes).ServeHTTP(rw, req)
-			})).
+		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/challenge/dns01/dns_challenge_test.go
+++ b/challenge/dns01/dns_challenge_test.go
@@ -32,7 +32,7 @@ func (p *providerTimeoutMock) CleanUp(domain, token, keyAuth string) error { ret
 func (p *providerTimeoutMock) Timeout() (time.Duration, time.Duration)     { return p.timeout, p.interval }
 
 func TestChallenge_PreSolve(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestChallenge_PreSolve(t *testing.T) {
 }
 
 func TestChallenge_Solve(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestChallenge_Solve(t *testing.T) {
 }
 
 func TestChallenge_CleanUp(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -67,7 +67,7 @@ func TestProviderServer_GetAddress(t *testing.T) {
 }
 
 func TestChallenge(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	providerServer := NewProviderServer("", "23457")
 
@@ -123,7 +123,7 @@ func TestChallengeUnix(t *testing.T) {
 		t.Skip("only for UNIX systems")
 	}
 
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	dir := t.TempDir()
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
@@ -188,7 +188,7 @@ func TestChallengeUnix(t *testing.T) {
 }
 
 func TestChallengeInvalidPort(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
@@ -371,7 +371,7 @@ func TestChallengeWithProxy(t *testing.T) {
 func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectError bool) {
 	t.Helper()
 
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	providerServer := NewProviderServer("localhost", "23457")
 	if header != nil {

--- a/challenge/resolver/prober_test.go
+++ b/challenge/resolver/prober_test.go
@@ -26,9 +26,9 @@ func TestProber_Solve(t *testing.T) {
 				},
 			},
 			authz: []acme.Authorization{
-				createStubAuthorizationHTTP01("acme.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("lego.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.com", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.org", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.net", acme.StatusProcessing),
 			},
 		},
 		{
@@ -41,9 +41,9 @@ func TestProber_Solve(t *testing.T) {
 				},
 			},
 			authz: []acme.Authorization{
-				createStubAuthorizationHTTP01("acme.wtf", acme.StatusValid),
-				createStubAuthorizationHTTP01("lego.wtf", acme.StatusValid),
-				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusValid),
+				createStubAuthorizationHTTP01("example.com", acme.StatusValid),
+				createStubAuthorizationHTTP01("example.org", acme.StatusValid),
+				createStubAuthorizationHTTP01("example.net", acme.StatusValid),
 			},
 		},
 		{
@@ -51,23 +51,23 @@ func TestProber_Solve(t *testing.T) {
 			solvers: map[challenge.Type]solver{
 				challenge.HTTP01: &preSolverMock{
 					preSolve: map[string]error{
-						"acme.wtf": errors.New("preSolve error acme.wtf"),
+						"example.com": errors.New("preSolve error example.com"),
 					},
 					solve: map[string]error{
-						"acme.wtf": errors.New("solve error acme.wtf"),
+						"example.com": errors.New("solve error example.com"),
 					},
 					cleanUp: map[string]error{
-						"acme.wtf": errors.New("clean error acme.wtf"),
+						"example.com": errors.New("clean error example.com"),
 					},
 				},
 			},
 			authz: []acme.Authorization{
-				createStubAuthorizationHTTP01("acme.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("lego.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.com", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.org", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.net", acme.StatusProcessing),
 			},
 			expectedError: `error: one or more domains had a problem:
-[acme.wtf] preSolve error acme.wtf
+[example.com] preSolve error example.com
 `,
 		},
 		{
@@ -75,25 +75,25 @@ func TestProber_Solve(t *testing.T) {
 			solvers: map[challenge.Type]solver{
 				challenge.HTTP01: &preSolverMock{
 					preSolve: map[string]error{
-						"acme.wtf": errors.New("preSolve error acme.wtf"),
+						"example.com": errors.New("preSolve error example.com"),
 					},
 					solve: map[string]error{
-						"acme.wtf": errors.New("solve error acme.wtf"),
-						"lego.wtf": errors.New("solve error lego.wtf"),
+						"example.com": errors.New("solve error example.com"),
+						"example.org": errors.New("solve error example.org"),
 					},
 					cleanUp: map[string]error{
-						"mydomain.wtf": errors.New("clean error mydomain.wtf"),
+						"example.net": errors.New("clean error example.net"),
 					},
 				},
 			},
 			authz: []acme.Authorization{
-				createStubAuthorizationHTTP01("acme.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("lego.wtf", acme.StatusProcessing),
-				createStubAuthorizationHTTP01("mydomain.wtf", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.com", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.org", acme.StatusProcessing),
+				createStubAuthorizationHTTP01("example.net", acme.StatusProcessing),
 			},
 			expectedError: `error: one or more domains had a problem:
-[acme.wtf] preSolve error acme.wtf
-[lego.wtf] solve error lego.wtf
+[example.com] preSolve error example.com
+[example.org] solve error example.org
 `,
 		},
 	}

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestChallenge(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	domain := "localhost"
 	port := "24457"
@@ -93,7 +93,7 @@ func TestChallenge(t *testing.T) {
 }
 
 func TestChallengeInvalidPort(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
@@ -123,7 +123,7 @@ func TestChallengeInvalidPort(t *testing.T) {
 }
 
 func TestChallengeIPaddress(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	domain := "127.0.0.1"
 	port := "24457"

--- a/lego/client_test.go
+++ b/lego/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	_, apiURL := tester.SetupFakeAPI(t)
+	apiURL := tester.MockACMEServer().Build(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")

--- a/providers/dns/constellix/internal/domains_test.go
+++ b/providers/dns/constellix/internal/domains_test.go
@@ -30,10 +30,10 @@ func TestDomainService_GetAll(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []Domain{
-		{ID: 273301, Name: "aaa.wtf", TypeID: 1, Version: 9, Status: "ACTIVE"},
-		{ID: 273302, Name: "bbb.wtf", TypeID: 1, Version: 9, Status: "ACTIVE"},
-		{ID: 273303, Name: "ccc.wtf", TypeID: 1, Version: 9, Status: "ACTIVE"},
-		{ID: 273304, Name: "ddd.wtf", TypeID: 1, Version: 9, Status: "ACTIVE"},
+		{ID: 273301, Name: "aaa.example", TypeID: 1, Version: 9, Status: "ACTIVE"},
+		{ID: 273302, Name: "bbb.example", TypeID: 1, Version: 9, Status: "ACTIVE"},
+		{ID: 273303, Name: "ccc.example", TypeID: 1, Version: 9, Status: "ACTIVE"},
+		{ID: 273304, Name: "ddd.example", TypeID: 1, Version: 9, Status: "ACTIVE"},
 	}
 
 	assert.Equal(t, expected, data)
@@ -44,14 +44,14 @@ func TestDomainService_Search(t *testing.T) {
 		Route("GET /v1/domains/search",
 			servermock.ResponseFromFixture("domains-Search.json"),
 			servermock.CheckQueryParameter().Strict().
-				With("exact", "lego.wtf")).
+				With("exact", "example.com")).
 		Build(t)
 
-	data, err := client.Domains.Search(t.Context(), Exact, "lego.wtf")
+	data, err := client.Domains.Search(t.Context(), Exact, "example.com")
 	require.NoError(t, err)
 
 	expected := []Domain{
-		{ID: 273302, Name: "lego.wtf", TypeID: 1, Version: 9, Status: "ACTIVE"},
+		{ID: 273302, Name: "example.com", TypeID: 1, Version: 9, Status: "ACTIVE"},
 	}
 
 	assert.Equal(t, expected, data)

--- a/providers/dns/constellix/internal/fixtures/domains-GetAll.json
+++ b/providers/dns/constellix/internal/fixtures/domains-GetAll.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 273301,
-    "name": "aaa.wtf",
+    "name": "aaa.example",
     "soa": {
       "primaryNameserver": "ns11.constellix.com.",
       "email": "dns.constellix.com.",
@@ -36,7 +36,7 @@
   },
   {
     "id": 273302,
-    "name": "bbb.wtf",
+    "name": "bbb.example",
     "soa": {
       "primaryNameserver": "ns11.constellix.com.",
       "email": "dns.constellix.com.",
@@ -71,7 +71,7 @@
   },
   {
     "id": 273303,
-    "name": "ccc.wtf",
+    "name": "ccc.example",
     "soa": {
       "primaryNameserver": "ns11.constellix.com.",
       "email": "dns.constellix.com.",
@@ -106,7 +106,7 @@
   },
   {
     "id": 273304,
-    "name": "ddd.wtf",
+    "name": "ddd.example",
     "soa": {
       "primaryNameserver": "ns11.constellix.com.",
       "email": "dns.constellix.com.",

--- a/providers/dns/constellix/internal/fixtures/domains-Search.json
+++ b/providers/dns/constellix/internal/fixtures/domains-Search.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 273302,
-    "name": "lego.wtf",
+    "name": "example.com",
     "soa": {
       "primaryNameserver": "ns11.constellix.com.",
       "email": "dns.constellix.com.",

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -52,7 +52,7 @@ func TestNewDNSProvider(t *testing.T) {
 				envServiceAccountFile: "",
 				// as Travis run on GCE, we have to alter env
 				envGoogleApplicationCredentials: "not-a-secret-file",
-				envMetadataHost:                 "http://lego.wtf", // defined here to avoid the client cache.
+				envMetadataHost:                 "http://example.com", // defined here to avoid the client cache.
 			},
 			// the error message varies according to the OS used.
 			expected: "googlecloud: unable to get Google Cloud client: google: error getting credentials using GOOGLE_APPLICATION_CREDENTIALS environment variable: ",
@@ -63,7 +63,7 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvProject:            "",
 				envServiceAccountFile: "",
 				// as Travis run on GCE, we have to alter env
-				envMetadataHost: "http://lego.wtf",
+				envMetadataHost: "http://example.com",
 			},
 			expected: "googlecloud: project name missing",
 		},
@@ -154,7 +154,7 @@ func TestPresentNoExistingRR(t *testing.T) {
 				},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("dnsName", "lego.wtf.").
+				With("dnsName", "example.com.").
 				With("prettyPrint", "false").
 				With("alt", "json")).
 		// findTxtRecords
@@ -163,7 +163,7 @@ func TestPresentNoExistingRR(t *testing.T) {
 				Rrsets: []*dns.ResourceRecordSet{},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("name", "_acme-challenge.lego.wtf.").
+				With("name", "_acme-challenge.example.com.").
 				With("type", "TXT").
 				With("prettyPrint", "false").
 				With("alt", "json")).
@@ -189,7 +189,7 @@ func TestPresentNoExistingRR(t *testing.T) {
 				With("alt", "json")).
 		Build(t)
 
-	domain := "lego.wtf"
+	domain := "example.com"
 
 	err := provider.Present(domain, "", "")
 	require.NoError(t, err)
@@ -205,21 +205,21 @@ func TestPresentWithExistingRR(t *testing.T) {
 				},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("dnsName", "lego.wtf.").
+				With("dnsName", "example.com.").
 				With("prettyPrint", "false").
 				With("alt", "json")).
 		// findTxtRecords
 		Route("GET /dns/v1/projects/manhattan/managedZones/test/rrsets",
 			servermock.JSONEncode(&dns.ResourceRecordSetsListResponse{
 				Rrsets: []*dns.ResourceRecordSet{{
-					Name:    "_acme-challenge.lego.wtf.",
+					Name:    "_acme-challenge.example.com.",
 					Rrdatas: []string{`"X7DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"`, `"huji"`},
 					Ttl:     120,
 					Type:    "TXT",
 				}},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("name", "_acme-challenge.lego.wtf.").
+				With("name", "_acme-challenge.example.com.").
 				With("type", "TXT").
 				With("prettyPrint", "false").
 				With("alt", "json")).
@@ -260,7 +260,7 @@ func TestPresentWithExistingRR(t *testing.T) {
 				With("alt", "json")).
 		Build(t)
 
-	domain := "lego.wtf"
+	domain := "example.com"
 
 	err := provider.Present(domain, "", "")
 	require.NoError(t, err)
@@ -276,27 +276,27 @@ func TestPresentSkipExistingRR(t *testing.T) {
 				},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("dnsName", "lego.wtf.").
+				With("dnsName", "example.com.").
 				With("prettyPrint", "false").
 				With("alt", "json")).
 		// findTxtRecords
 		Route("GET /dns/v1/projects/manhattan/managedZones/test/rrsets",
 			servermock.JSONEncode(&dns.ResourceRecordSetsListResponse{
 				Rrsets: []*dns.ResourceRecordSet{{
-					Name:    "_acme-challenge.lego.wtf.",
+					Name:    "_acme-challenge.example.com.",
 					Rrdatas: []string{`"47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"`, `"X7DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"`, `"huji"`},
 					Ttl:     120,
 					Type:    "TXT",
 				}},
 			}),
 			servermock.CheckQueryParameter().Strict().
-				With("name", "_acme-challenge.lego.wtf.").
+				With("name", "_acme-challenge.example.com.").
 				With("type", "TXT").
 				With("prettyPrint", "false").
 				With("alt", "json")).
 		Build(t)
 
-	domain := "lego.wtf"
+	domain := "example.com"
 
 	err := provider.Present(domain, "", "")
 	require.NoError(t, err)

--- a/providers/dns/servercow/internal/client_test.go
+++ b/providers/dns/servercow/internal/client_test.go
@@ -29,10 +29,10 @@ func mockBuilder() *servermock.Builder[*Client] {
 
 func TestClient_GetRecords(t *testing.T) {
 	client := mockBuilder().
-		Route("GET /lego.wtf", servermock.ResponseFromFixture("records-01.json")).
+		Route("GET /example.com", servermock.ResponseFromFixture("records-01.json")).
 		Build(t)
 
-	records, err := client.GetRecords(t.Context(), "lego.wtf")
+	records, err := client.GetRecords(t.Context(), "example.com")
 	require.NoError(t, err)
 
 	recordsJSON, err := json.Marshal(records)
@@ -46,10 +46,10 @@ func TestClient_GetRecords(t *testing.T) {
 
 func TestClient_GetRecords_error(t *testing.T) {
 	client := mockBuilder().
-		Route("GET /lego.wtf", servermock.JSONEncode(Message{ErrorMsg: "authentication failed"})).
+		Route("GET /example.com", servermock.JSONEncode(Message{ErrorMsg: "authentication failed"})).
 		Build(t)
 
-	records, err := client.GetRecords(t.Context(), "lego.wtf")
+	records, err := client.GetRecords(t.Context(), "example.com")
 	require.Error(t, err)
 
 	assert.Nil(t, records)
@@ -57,7 +57,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 
 func TestClient_CreateUpdateRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /lego.wtf",
+		Route("POST /example.com",
 			servermock.JSONEncode(Message{Message: "ok"}),
 			servermock.CheckRequestJSONBody(`{"name":"_acme-challenge.www","type":"TXT","ttl":30,"content":["aaa","bbb"]}`)).
 		Build(t)
@@ -69,7 +69,7 @@ func TestClient_CreateUpdateRecord(t *testing.T) {
 		Content: Value{"aaa", "bbb"},
 	}
 
-	msg, err := client.CreateUpdateRecord(t.Context(), "lego.wtf", record)
+	msg, err := client.CreateUpdateRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &Message{Message: "ok"}
@@ -78,7 +78,7 @@ func TestClient_CreateUpdateRecord(t *testing.T) {
 
 func TestClient_CreateUpdateRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /lego.wtf",
+		Route("POST /example.com",
 			servermock.JSONEncode(Message{ErrorMsg: "parameter type must be cname, txt, tlsa, caa, a or aaaa"})).
 		Build(t)
 
@@ -86,7 +86,7 @@ func TestClient_CreateUpdateRecord_error(t *testing.T) {
 		Name: "_acme-challenge.www",
 	}
 
-	msg, err := client.CreateUpdateRecord(t.Context(), "lego.wtf", record)
+	msg, err := client.CreateUpdateRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, msg)
@@ -94,7 +94,7 @@ func TestClient_CreateUpdateRecord_error(t *testing.T) {
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /lego.wtf",
+		Route("DELETE /example.com",
 			servermock.JSONEncode(Message{Message: "ok"}),
 			servermock.CheckRequestJSONBody(`{"name":"_acme-challenge.www","type":"TXT"}`)).
 		Build(t)
@@ -104,7 +104,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 		Type: "TXT",
 	}
 
-	msg, err := client.DeleteRecord(t.Context(), "lego.wtf", record)
+	msg, err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.NoError(t, err)
 
 	expected := &Message{Message: "ok"}
@@ -113,7 +113,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /lego.wtf",
+		Route("DELETE /example.com",
 			servermock.JSONEncode(Message{ErrorMsg: "parameter type must be cname, txt, tlsa, caa, a or aaaa"})).
 		Build(t)
 
@@ -121,7 +121,7 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 		Name: "_acme-challenge.www",
 	}
 
-	msg, err := client.DeleteRecord(t.Context(), "lego.wtf", record)
+	msg, err := client.DeleteRecord(t.Context(), "example.com", record)
 	require.Error(t, err)
 
 	assert.Nil(t, msg)


### PR DESCRIPTION
- Replaces test domains with `.example.` domains
- Uses the servermock system outside DNS providers

When I was updating tests with the new servermock system, I found a weird element:
```go
	// Get issuerCert from bundled response from Let's Encrypt
	// See https://community.letsencrypt.org/t/acme-v2-no-up-link-in-response/64962
	_, issuer := pem.Decode(cert)
	if issuer != nil {
```

The `if` is always `true` because `issuer` is a `[]byte`.

I wanted to fix that, so I read the reference inside the comment: https://community.letsencrypt.org/t/acme-v2-no-up-link-in-response/64962

And in ACME v2, there is no `up` link for the issuer.
- https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2
