### PR TITLE
tests: change the signature of the method BuildHTTPS

### DIFF
--- a/acme/api/certificate_test.go
+++ b/acme/api/certificate_test.go
@@ -73,34 +73,34 @@ rzFL1KZfz+HZdnFwFW2T2gVW8L3ii1l9AJDuKzlvjUH3p6bgihVq02sjT8mx+GM2
 `
 
 func TestCertificateService_Get_issuerRelUp(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
-	cert, issuer, err := core.Certificates.Get(apiURL+"/certificate", true)
+	cert, issuer, err := core.Certificates.Get(server.URL+"/certificate", true)
 	require.NoError(t, err)
 	assert.Equal(t, certResponseMock, string(cert), "Certificate")
 	assert.Equal(t, issuerMock, string(issuer), "IssuerCertificate")
 }
 
 func TestCertificateService_Get_embeddedIssuer(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
-	cert, issuer, err := core.Certificates.Get(apiURL+"/certificate", true)
+	cert, issuer, err := core.Certificates.Get(server.URL+"/certificate", true)
 	require.NoError(t, err)
 	assert.Equal(t, certResponseMock, string(cert), "Certificate")
 	assert.Equal(t, issuerMock, string(issuer), "IssuerCertificate")

--- a/acme/api/internal/nonces/nonce_manager_test.go
+++ b/acme/api/internal/nonces/nonce_manager_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNotHoldingLockWhileMakingHTTPRequests(t *testing.T) {
-	manager, _ := servermock.NewBuilder(
+	manager := servermock.NewBuilder(
 		func(server *httptest.Server) (*Manager, error) {
 			doer := sender.NewDoer(server.Client(), "lego-test")
 

--- a/acme/api/internal/secure/jws_test.go
+++ b/acme/api/internal/secure/jws_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNotHoldingLockWhileMakingHTTPRequests(t *testing.T) {
-	manager, _ := servermock.NewBuilder(
+	manager := servermock.NewBuilder(
 		func(server *httptest.Server) (*nonces.Manager, error) {
 			doer := sender.NewDoer(server.Client(), "lego-test")
 

--- a/acme/api/order_test.go
+++ b/acme/api/order_test.go
@@ -22,7 +22,7 @@ func TestOrderService_NewWithOptions(t *testing.T) {
 	privateKey, errK := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, errK, "Could not generate test key")
 
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /newOrder",
 			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				body, err := readSignedBody(req, privateKey)
@@ -54,7 +54,7 @@ func TestOrderService_NewWithOptions(t *testing.T) {
 			})).
 		BuildHTTPS(t)
 
-	core, err := New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -175,14 +175,14 @@ Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
 `
 
 func Test_checkResponse(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
@@ -190,7 +190,7 @@ func Test_checkResponse(t *testing.T) {
 	order := acme.ExtendedOrder{
 		Order: acme.Order{
 			Status:      acme.StatusValid,
-			Certificate: apiURL + "/certificate",
+			Certificate: server.URL + "/certificate",
 		},
 	}
 	certRes := &Resource{}
@@ -209,14 +209,14 @@ func Test_checkResponse(t *testing.T) {
 }
 
 func Test_checkResponse_issuerRelUp(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
@@ -224,7 +224,7 @@ func Test_checkResponse_issuerRelUp(t *testing.T) {
 	order := acme.ExtendedOrder{
 		Order: acme.Order{
 			Status:      acme.StatusValid,
-			Certificate: apiURL + "/certificate",
+			Certificate: server.URL + "/certificate",
 		},
 	}
 	certRes := &Resource{}
@@ -243,14 +243,14 @@ func Test_checkResponse_issuerRelUp(t *testing.T) {
 }
 
 func Test_checkResponse_no_bundle(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
@@ -258,7 +258,7 @@ func Test_checkResponse_no_bundle(t *testing.T) {
 	order := acme.ExtendedOrder{
 		Order: acme.Order{
 			Status:      acme.StatusValid,
-			Certificate: apiURL + "/certificate",
+			Certificate: server.URL + "/certificate",
 		},
 	}
 	certRes := &Resource{}
@@ -277,7 +277,7 @@ func Test_checkResponse_no_bundle(t *testing.T) {
 }
 
 func Test_checkResponse_alternate(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /certificate",
 			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.Header().Add("Link",
@@ -291,7 +291,7 @@ func Test_checkResponse_alternate(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
@@ -299,7 +299,7 @@ func Test_checkResponse_alternate(t *testing.T) {
 	order := acme.ExtendedOrder{
 		Order: acme.Order{
 			Status:      acme.StatusValid,
-			Certificate: apiURL + "/certificate",
+			Certificate: server.URL + "/certificate",
 		},
 	}
 	certRes := &Resource{
@@ -321,25 +321,25 @@ func Test_checkResponse_alternate(t *testing.T) {
 }
 
 func Test_Get(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /acme/cert/test-cert", servermock.RawStringResponse(certResponseMock)).
 		BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	certRes, err := certifier.Get(apiURL+"/acme/cert/test-cert", true)
+	certRes, err := certifier.Get(server.URL+"/acme/cert/test-cert", true)
 	require.NoError(t, err)
 
 	assert.NotNil(t, certRes)
 	assert.Equal(t, "acme.wtf", certRes.Domain)
-	assert.Equal(t, apiURL+"/acme/cert/test-cert", certRes.CertStableURL)
-	assert.Equal(t, apiURL+"/acme/cert/test-cert", certRes.CertURL)
+	assert.Equal(t, server.URL+"/acme/cert/test-cert", certRes.CertStableURL)
+	assert.Equal(t, server.URL+"/acme/cert/test-cert", certRes.CertURL)
 	assert.Nil(t, certRes.CSR)
 	assert.Nil(t, certRes.PrivateKey)
 	assert.Equal(t, certResponseMock, string(certRes.Certificate), "Certificate")

--- a/challenge/dns01/dns_challenge_test.go
+++ b/challenge/dns01/dns_challenge_test.go
@@ -31,12 +31,12 @@ func (p *providerTimeoutMock) CleanUp(domain, token, keyAuth string) error { ret
 func (p *providerTimeoutMock) Timeout() (time.Duration, time.Duration)     { return p.timeout, p.interval }
 
 func TestChallenge_PreSolve(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -113,12 +113,12 @@ func TestChallenge_PreSolve(t *testing.T) {
 }
 
 func TestChallenge_Solve(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -200,12 +200,12 @@ func TestChallenge_Solve(t *testing.T) {
 }
 
 func TestChallenge_CleanUp(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -67,7 +67,7 @@ func TestProviderServer_GetAddress(t *testing.T) {
 }
 
 func TestChallenge(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	providerServer := NewProviderServer("", "23457")
 
@@ -100,7 +100,7 @@ func TestChallenge(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(core, validate, providerServer)
@@ -123,7 +123,7 @@ func TestChallengeUnix(t *testing.T) {
 		t.Skip("only for UNIX systems")
 	}
 
-	apiURL, httpsClient := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	dir := t.TempDir()
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
@@ -169,7 +169,7 @@ func TestChallengeUnix(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(httpsClient, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(core, validate, providerServer)
@@ -188,12 +188,12 @@ func TestChallengeUnix(t *testing.T) {
 }
 
 func TestChallengeInvalidPort(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	validate := func(_ *api.Core, _ string, _ acme.Challenge) error { return nil }
@@ -371,7 +371,7 @@ func TestChallengeWithProxy(t *testing.T) {
 func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectError bool) {
 	t.Helper()
 
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	providerServer := NewProviderServer("localhost", "23457")
 	if header != nil {
@@ -414,7 +414,7 @@ func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectErro
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(core, validate, providerServer)

--- a/challenge/resolver/solver_manager_test.go
+++ b/challenge/resolver/solver_manager_test.go
@@ -37,7 +37,7 @@ func TestValidate(t *testing.T) {
 
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 1024)
 
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("POST /chlg",
 			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				if err := validateNoBody(privateKey, req); err != nil {
@@ -76,7 +76,7 @@ func TestValidate(t *testing.T) {
 			})).
 		BuildHTTPS(t)
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -118,7 +118,7 @@ func TestValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			statuses = test.statuses
 
-			err := validate(core, "example.com", acme.Challenge{Type: "http-01", Token: "token", URL: apiURL + "/chlg"})
+			err := validate(core, "example.com", acme.Challenge{Type: "http-01", Token: "token", URL: server.URL + "/chlg"})
 			if test.want == "" {
 				require.NoError(t, err)
 			} else {

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestChallenge(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	domain := "localhost"
 	port := "24457"
@@ -68,7 +68,7 @@ func TestChallenge(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(
@@ -92,12 +92,12 @@ func TestChallenge(t *testing.T) {
 }
 
 func TestChallengeInvalidPort(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(
@@ -122,7 +122,7 @@ func TestChallengeInvalidPort(t *testing.T) {
 }
 
 func TestChallengeIPaddress(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	domain := "127.0.0.1"
 	port := "24457"
@@ -169,7 +169,7 @@ func TestChallengeIPaddress(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", privateKey)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", privateKey)
 	require.NoError(t, err)
 
 	solver := NewChallenge(

--- a/lego/client_test.go
+++ b/lego/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	apiURL, httpsClient := tester.MockACMEServer().BuildHTTPS(t)
+	server := tester.MockACMEServer().BuildHTTPS(t)
 
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "Could not generate test key")
@@ -25,8 +25,8 @@ func TestNewClient(t *testing.T) {
 	}
 
 	config := NewConfig(user)
-	config.CADirURL = apiURL + "/dir"
-	config.HTTPClient = httpsClient
+	config.CADirURL = server.URL + "/dir"
+	config.HTTPClient = server.Client()
 
 	client, err := NewClient(config)
 	require.NoError(t, err, "Could not create client")

--- a/platform/tester/api.go
+++ b/platform/tester/api.go
@@ -11,10 +11,10 @@ import (
 )
 
 // MockACMEServer Minimal stub ACME server for validation.
-func MockACMEServer() *servermock.Builder[string] {
+func MockACMEServer() *servermock.Builder[*httptest.Server] {
 	return servermock.NewBuilder(
-		func(server *httptest.Server) (string, error) {
-			return server.URL, nil
+		func(server *httptest.Server) (*httptest.Server, error) {
+			return server, nil
 		}).
 		Route("GET /dir", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			serverURL := fmt.Sprintf("https://%s", req.Context().Value(http.LocalAddrContextKey))

--- a/platform/tester/servermock/builder.go
+++ b/platform/tester/servermock/builder.go
@@ -71,7 +71,7 @@ func (b *Builder[T]) Build(t *testing.T) T {
 	return client
 }
 
-func (b *Builder[T]) BuildHTTPS(t *testing.T) (T, *http.Client) {
+func (b *Builder[T]) BuildHTTPS(t *testing.T) T {
 	t.Helper()
 
 	server := httptest.NewTLSServer(b.mux)
@@ -80,5 +80,5 @@ func (b *Builder[T]) BuildHTTPS(t *testing.T) (T, *http.Client) {
 	client, err := b.clientBuilder(server)
 	require.NoError(t, err)
 
-	return client, server.Client()
+	return client
 }

--- a/registration/registar_test.go
+++ b/registration/registar_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRegistrar_ResolveAccountByKey(t *testing.T) {
-	apiURL, client := tester.MockACMEServer().
+	server := tester.MockACMEServer().
 		Route("/account",
 			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.Header().Set("Location",
@@ -35,7 +35,7 @@ func TestRegistrar_ResolveAccountByKey(t *testing.T) {
 		privatekey: key,
 	}
 
-	core, err := api.New(client, "lego-test", apiURL+"/dir", "", key)
+	core, err := api.New(server.Client(), "lego-test", server.URL+"/dir", "", key)
 	require.NoError(t, err)
 
 	registrar := NewRegistrar(core, user)


### PR DESCRIPTION
I'm not happy with the signature of the method `BuildHTTPS`.
`Build` and `BuildHTTPS` should have the same signature.
