### PR TITLE
simply: update to API v2

### DIFF
--- a/providers/dns/simply/internal/client.go
+++ b/providers/dns/simply/internal/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/internal/errutils"
 )
 
-const defaultBaseURL = "https://api.simply.com/1/"
+const defaultBaseURL = "https://api.simply.com/2/"
 
 // Client is a Simply.com API client.
 type Client struct {
@@ -111,10 +111,12 @@ func (c *Client) DeleteRecord(ctx context.Context, zoneName string, id int64) er
 }
 
 func (c *Client) createEndpoint(zoneName, uri string) *url.URL {
-	return c.baseURL.JoinPath(c.accountName, c.apiKey, "my", "products", zoneName, "dns", "records", strings.TrimSuffix(uri, "/"))
+	return c.baseURL.JoinPath("my", "products", zoneName, "dns", "records", strings.TrimSuffix(uri, "/"))
 }
 
 func (c *Client) do(req *http.Request, result Response) error {
+	req.SetBasicAuth(c.accountName, c.apiKey)
+
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return errutils.NewHTTPDoError(req, err)

--- a/providers/dns/simply/internal/client_test.go
+++ b/providers/dns/simply/internal/client_test.go
@@ -24,12 +24,13 @@ func mockBuilder() *servermock.Builder[*Client] {
 
 			return client, nil
 		},
-		servermock.CheckHeader().WithJSONHeaders())
+		servermock.CheckHeader().WithJSONHeaders().
+			WithBasicAuth("accountname", "apikey"))
 }
 
 func TestClient_GetRecords(t *testing.T) {
 	client := mockBuilder().
-		Route("GET /accountname/apikey/my/products/azone01/dns/records",
+		Route("GET /my/products/azone01/dns/records",
 			servermock.ResponseFromFixture("get_records.json")).
 		Build(t)
 
@@ -76,7 +77,7 @@ func TestClient_GetRecords(t *testing.T) {
 
 func TestClient_GetRecords_error(t *testing.T) {
 	client := mockBuilder().
-		Route("GET /accountname/apikey/my/products/azone01/dns/records",
+		Route("GET /my/products/azone01/dns/records",
 			servermock.ResponseFromFixture("bad_auth_error.json").
 				WithStatusCode(http.StatusBadRequest)).
 		Build(t)
@@ -89,7 +90,7 @@ func TestClient_GetRecords_error(t *testing.T) {
 
 func TestClient_AddRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /accountname/apikey/my/products/azone01/dns/records",
+		Route("POST /my/products/azone01/dns/records",
 			servermock.ResponseFromFixture("add_record.json")).
 		Build(t)
 
@@ -109,7 +110,7 @@ func TestClient_AddRecord(t *testing.T) {
 
 func TestClient_AddRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /accountname/apikey/my/products/azone01/dns/records",
+		Route("POST /my/products/azone01/dns/records",
 			servermock.ResponseFromFixture("bad_zone_error.json").
 				WithStatusCode(http.StatusNotFound)).
 		Build(t)
@@ -130,7 +131,7 @@ func TestClient_AddRecord_error(t *testing.T) {
 
 func TestClient_EditRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("PUT /accountname/apikey/my/products/azone01/dns/records/123456789",
+		Route("PUT /my/products/azone01/dns/records/123456789",
 			servermock.ResponseFromFixture("success.json")).
 		Build(t)
 
@@ -148,7 +149,7 @@ func TestClient_EditRecord(t *testing.T) {
 
 func TestClient_EditRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("PUT /accountname/apikey/my/products/azone01/dns/records/123456789",
+		Route("PUT /my/products/azone01/dns/records/123456789",
 			servermock.ResponseFromFixture("invalid_record_id.json").
 				WithStatusCode(http.StatusNotFound)).
 		Build(t)
@@ -167,7 +168,7 @@ func TestClient_EditRecord_error(t *testing.T) {
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /accountname/apikey/my/products/azone01/dns/records/123456789",
+		Route("DELETE /my/products/azone01/dns/records/123456789",
 			servermock.ResponseFromFixture("success.json")).
 		Build(t)
 
@@ -177,7 +178,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /accountname/apikey/my/products/azone01/dns/records/123456789",
+		Route("DELETE /my/products/azone01/dns/records/123456789",
 			servermock.ResponseFromFixture("invalid_record_id.json").
 				WithStatusCode(http.StatusNotFound)).
 		Build(t)

--- a/providers/dns/simply/simply.toml
+++ b/providers/dns/simply/simply.toml
@@ -22,3 +22,4 @@ lego --email you@example.com --dns simply -d '*.example.com' -d example.com run
 
 [Links]
   API = "https://www.simply.com/en/docs/api/"
+  Spec = "https://generator.swagger.io/?url=https://api.simply.com/2/openapi.json#/"


### PR DESCRIPTION

<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout feat/dns/simply/api-v2
    ```
3. Compile lego:
   - if you have `make`: `make build`
   - if you don't make `make`: `go build -o dist/lego ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    SIMPLY_ACCOUNT_NAME=xxx \
    SIMPLY_API_KEY=xxx \
    ./dist/lego -m your_email@example.com --dns simply -d '*.example.com' -d example.com -s https://acme-staging-v02.api.letsencrypt.org/directory run
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>


Fixes #2630