### PR TITLE
Fix zone detection for newer gTLD domains like .dog

### DIFF
--- a/challenge/dns01/fqdn.go
+++ b/challenge/dns01/fqdn.go
@@ -2,6 +2,7 @@ package dns01
 
 import (
 	"iter"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -37,7 +38,32 @@ func UnFqdnDomainsSeq(fqdn string) iter.Seq[string] {
 	}
 }
 
+// isKnownNewerGTLD checks if a domain uses a newer gTLD that should be treated
+// as a complete zone rather than being split further.
+func isKnownNewerGTLD(domain string) bool {
+	// Known newer gTLDs that are commonly used as zones
+	// This list can be expanded as needed
+	knownNewerGTLDs := []string{
+		".dog", ".cat", ".horse", ".wiki", ".blog", ".app", ".dev",
+		".page", ".site", ".tech", ".online", ".store", ".cloud",
+		".rocks", ".space", ".world", ".fun", ".run", ".live",
+	}
+	
+	domainLower := strings.ToLower(domain)
+	for _, tld := range knownNewerGTLDs {
+		if strings.HasSuffix(domainLower, tld) || strings.HasSuffix(domainLower, tld+".") {
+			return true
+		}
+	}
+	
+	return false
+}
+
 // DomainsSeq generates a sequence of domain names derived from a domain (FQDN or not) in descending order.
+// It includes special handling for newer gTLDs to prevent oversplitting during zone detection.
+// 
+// For example, "play.app4.dog" will generate ["play.app4.dog", "app4.dog"] instead of 
+// ["play.app4.dog", "app4.dog", "dog"], since "dog" is not a valid zone for "app4.dog" domains.
 func DomainsSeq(fqdn string) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		if fqdn == "" {
@@ -45,8 +71,17 @@ func DomainsSeq(fqdn string) iter.Seq[string] {
 		}
 
 		for _, index := range dns.Split(fqdn) {
-			if !yield(fqdn[index:]) {
+			candidate := fqdn[index:]
+			if !yield(candidate) {
 				return
+			}
+			
+			// For newer gTLDs, stop splitting when we reach the likely zone
+			if isKnownNewerGTLD(candidate) {
+				cleanDomain := strings.TrimSuffix(candidate, ".")
+				if strings.Count(cleanDomain, ".") == 1 {
+					return
+				}
 			}
 		}
 	}

--- a/challenge/dns01/fqdn_test.go
+++ b/challenge/dns01/fqdn_test.go
@@ -125,6 +125,9 @@ func TestDomainsSeq(t *testing.T) {
 		},
 	}
 
+	// Add tests for newer gTLD handling
+	testCases = append(testCases, getNewerGTLDTestCases()...)
+
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
@@ -133,5 +136,48 @@ func TestDomainsSeq(t *testing.T) {
 
 			assert.Equal(t, test.expected, actual)
 		})
+	}
+}
+
+func getNewerGTLDTestCases() []struct {
+	desc     string
+	fqdn     string
+	expected []string
+} {
+	return []struct {
+		desc     string
+		fqdn     string
+		expected []string
+	}{
+		{
+			desc:     ".dog gTLD - simple domain",
+			fqdn:     "app4.dog",
+			expected: []string{"app4.dog"},
+		},
+		{
+			desc:     ".dog gTLD - simple domain FQDN",
+			fqdn:     "app4.dog.",
+			expected: []string{"app4.dog."},
+		},
+		{
+			desc:     ".dog gTLD - subdomain",
+			fqdn:     "play.app4.dog",
+			expected: []string{"play.app4.dog", "app4.dog"},
+		},
+		{
+			desc:     ".dog gTLD - deep subdomain",
+			fqdn:     "_acme-challenge.play.app4.dog",
+			expected: []string{"_acme-challenge.play.app4.dog", "play.app4.dog", "app4.dog"},
+		},
+		{
+			desc:     ".app gTLD - subdomain", 
+			fqdn:     "test.myapp.app",
+			expected: []string{"test.myapp.app", "myapp.app"},
+		},
+		{
+			desc:     "traditional TLD - unchanged behavior",
+			fqdn:     "sub.example.com",
+			expected: []string{"sub.example.com", "example.com", "com"},
+		},
 	}
 }


### PR DESCRIPTION
## Summary

Fixes zone detection for newer gTLD domains like .dog, .cat, .app, etc. The current zone detection algorithm fails for these domains because it treats them like traditional TLDs and tries to split "app4.dog" into ["app4.dog", "dog"], then looks for a zone named "dog" which doesn't exist.

## Problem

When using DNS challenges with newer gTLD domains like:
- app4.dog
- play.app4.dog  
- api.app4.dog

The zone detection fails with errors like:
```
cloudflare: failed to find zone dog.: zone could not be found
```

This happens because the `DomainsSeq` function in `challenge/dns01/fqdn.go` uses `dns.Split()` which correctly splits domains but doesn't account for the fact that newer gTLDs like ".dog" are typically used as complete zones rather than being split further.

## Solution

This patch adds special handling for known newer gTLDs to prevent oversplitting while maintaining compatibility with traditional domains.

### Changes:
1. Added `isKnownNewerGTLD()` function that identifies common newer gTLDs
2. Modified `DomainsSeq()` to stop splitting when it reaches a likely zone for newer gTLDs
3. Added comprehensive test cases covering various newer gTLD scenarios

### Test Coverage:
- .dog gTLD domains (simple, subdomain, deep subdomain)
- .app gTLD domains  
- Traditional TLD behavior unchanged
- FQDN and non-FQDN variants

## Example Behavior

**Before (broken):**
- `play.app4.dog` → `["play.app4.dog", "app4.dog", "dog"]` ❌ tries to find "dog" zone

**After (fixed):**
- `play.app4.dog` → `["play.app4.dog", "app4.dog"]` ✅ stops at likely zone

Traditional domains remain unchanged:
- `sub.example.com` → `["sub.example.com", "example.com", "com"]` ✅

## Testing

All existing tests pass. New test cases added specifically for newer gTLD scenarios.

## Related Issues

- Fixes DNS challenge failures with newer gTLD domains
- Maintains backward compatibility with existing behavior
- Improves zone detection accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)