### PR TITLE
fix: deduplicate order identifiers

### DIFF
--- a/acme/api/identifier.go
+++ b/acme/api/identifier.go
@@ -2,10 +2,32 @@ package api
 
 import (
 	"cmp"
+	"maps"
+	"net"
 	"slices"
 
 	"github.com/go-acme/lego/v4/acme"
 )
+
+func createIdentifiers(domains []string) []acme.Identifier {
+	uniqIdentifiers := make(map[string]acme.Identifier)
+
+	for _, domain := range domains {
+		if _, ok := uniqIdentifiers[domain]; ok {
+			continue
+		}
+
+		ident := acme.Identifier{Value: domain, Type: "dns"}
+
+		if net.ParseIP(domain) != nil {
+			ident.Type = "ip"
+		}
+
+		uniqIdentifiers[domain] = ident
+	}
+
+	return slices.AppendSeq(make([]acme.Identifier, 0, len(uniqIdentifiers)), maps.Values(uniqIdentifiers))
+}
 
 // compareIdentifiers compares 2 slices of [acme.Identifier].
 func compareIdentifiers(a, b []acme.Identifier) int {

--- a/acme/api/order.go
+++ b/acme/api/order.go
@@ -4,8 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"maps"
-	"net"
 	"slices"
 	"time"
 
@@ -37,23 +35,7 @@ func (o *OrderService) New(domains []string) (acme.ExtendedOrder, error) {
 
 // NewWithOptions Creates a new order.
 func (o *OrderService) NewWithOptions(domains []string, opts *OrderOptions) (acme.ExtendedOrder, error) {
-	uniqIdentifiers := make(map[string]acme.Identifier)
-
-	for _, domain := range domains {
-		if _, ok := uniqIdentifiers[domain]; ok {
-			continue
-		}
-
-		ident := acme.Identifier{Value: domain, Type: "dns"}
-
-		if net.ParseIP(domain) != nil {
-			ident.Type = "ip"
-		}
-
-		uniqIdentifiers[domain] = ident
-	}
-
-	orderReq := acme.Order{Identifiers: slices.Collect(maps.Values(uniqIdentifiers))}
+	orderReq := acme.Order{Identifiers: createIdentifiers(domains)}
 
 	if opts != nil {
 		if !opts.NotAfter.IsZero() {


### PR DESCRIPTION
The assumptions made inside #2519 were wrong, and the PR #2520 is partially wrong too.

Related to https://github.com/letsencrypt/boulder/issues/8411