### PR TITLE
chore: update vegadns client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/nrdcg/oci-go-sdk/common/v1065 v1065.102.0
 	github.com/nrdcg/oci-go-sdk/dns/v1065 v1065.102.0
 	github.com/nrdcg/porkbun v0.4.0
-	github.com/nrdcg/vegadns v0.1.0
+	github.com/nrdcg/vegadns v0.2.0
 	github.com/nzdjb/go-metaname v1.0.0
 	github.com/ovh/go-ovh v1.9.0
 	github.com/pquerna/otp v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -709,8 +709,8 @@ github.com/nrdcg/oci-go-sdk/dns/v1065 v1065.102.0 h1:gAOs1dkE7LFoWflzqrDqAhOprc0
 github.com/nrdcg/oci-go-sdk/dns/v1065 v1065.102.0/go.mod h1:EUBSYwop1K40VpcKy1haIK6kFK/gPT1atEk89OkY0Kg=
 github.com/nrdcg/porkbun v0.4.0 h1:rWweKlwo1PToQ3H+tEO9gPRW0wzzgmI/Ob3n2Guticw=
 github.com/nrdcg/porkbun v0.4.0/go.mod h1:/QMskrHEIM0IhC/wY7iTCUgINsxdT2WcOphktJ9+Q54=
-github.com/nrdcg/vegadns v0.1.0 h1:RUhO3ynDycknjxA849KRyTn4V12L12aDS2IHntb55is=
-github.com/nrdcg/vegadns v0.1.0/go.mod h1:NqSyRKZuJlAsv8VI/7rSubfPXN68NwaJ0aG9KxQVFVo=
+github.com/nrdcg/vegadns v0.2.0 h1:tLs8WDuWORJP+YlDOKf+eQCKtIwXeUW17R5Ls5NcyB8=
+github.com/nrdcg/vegadns v0.2.0/go.mod h1:NqSyRKZuJlAsv8VI/7rSubfPXN68NwaJ0aG9KxQVFVo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/providers/dns/vegadns/vegadns_test.go
+++ b/providers/dns/vegadns/vegadns_test.go
@@ -61,7 +61,7 @@ func TestDNSProvider_Present(t *testing.T) {
 				Route("GET /1.0/domains",
 					servermock.Noop().
 						WithStatusCode(http.StatusNotFound)),
-			expectedError: "vegadns: can't find Authoritative Zone for _acme-challenge.example.com. in Present: unable to find auth zone for fqdn _acme-challenge.example.com",
+			expectedError: "vegadns: find domain ID for _acme-challenge.example.com.: domain not found",
 		},
 		{
 			desc: "FailToCreateTXT",
@@ -72,7 +72,7 @@ func TestDNSProvider_Present(t *testing.T) {
 				Route("POST /1.0/records",
 					servermock.Noop().
 						WithStatusCode(http.StatusBadRequest)),
-			expectedError: "vegadns: bad answer from VegaDNS (code: 400, message: )",
+			expectedError: "vegadns: create TXT record: bad answer from VegaDNS (code: 400, message: )",
 		},
 	}
 
@@ -119,7 +119,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 				Route("GET /1.0/domains",
 					servermock.Noop().
 						WithStatusCode(http.StatusNotFound)),
-			expectedError: "vegadns: can't find Authoritative Zone for _acme-challenge.example.com. in CleanUp: unable to find auth zone for fqdn _acme-challenge.example.com",
+			expectedError: "vegadns: find domain ID for _acme-challenge.example.com.: domain not found",
 		},
 		{
 			desc: "FailToGetRecordID",
@@ -131,7 +131,7 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 					servermock.Noop().
 						WithStatusCode(http.StatusNotFound),
 					servermock.CheckQueryParameter().With("domain_id", "1")),
-			expectedError: "vegadns: couldn't get Record ID in CleanUp: bad answer from VegaDNS (code: 404, message: )",
+			expectedError: "vegadns: get Record ID: bad answer from VegaDNS (code: 404, message: )",
 		},
 	}
 


### PR DESCRIPTION
[`OpenDNS/vegadns2client`](https://github.com/OpenDNS/vegadns2client) has only one commit created 7 years ago.

The code was not Go idiomatic; there was no go.mod, no tests, and no CI.

I created a [fork](https://github.com/nrdcg/vegadns) to update the implementation

https://github.com/opendns/vegadns2client/compare/master...nrdcg:vegadns:master
