### PR TITLE
gandiv5: update base API URL

### DIFF
--- a/providers/dns/gandiv5/internal/client.go
+++ b/providers/dns/gandiv5/internal/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 // defaultBaseURL endpoint is the Gandi API endpoint used by Present and CleanUp.
-const defaultBaseURL = "https://dns.api.gandi.net/api/v5"
+const defaultBaseURL = "https://api.gandi.net/v5/livedns"
 
 // APIKeyHeader API key header.
 const APIKeyHeader = "X-Api-Key"


### PR DESCRIPTION
This change sets the Gandi LiveDNS API URL to the one [listed in the official API docs](https://api.gandi.net/docs/livedns/).
Changes to the API URL were already mentioned in #2628 (but not causing any issues, yet).

With the old API URL (https://dns.api.gandi.net/api/v5), I am currently getting certificate expiry errors when trying to request new certificates:

```log
2025/11/07 22:30:00 Could not obtain certificates:
        error: one or more domains had a problem:
[REDACTED] [REDACTED] acme: error presenting token: unable to get TXT records for domain REDACTED and name REDACTED: unable to communicate with the API server: error: Get "https://dns.api.gandi.net/api/v5/domains/REDACTED/records/REDACTED/TXT": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-11-07T22:30:00+01:00 is after 2025-11-05T19:07:24Z
[REDACTED] [REDACTED] acme: error presenting token: unable to get TXT records for domain REDACTED and name REDACTED: unable to communicate with the API server: error: Get "https://dns.api.gandi.net/api/v5/domains/REDACTED/records/REDACTED/TXT": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-11-07T22:30:05+01:00 is after 2025-11-05T19:07:24Z
```

Since the old URL isn't mentioned in the official docs and the certificate used for that domain has now expired, I think switching to the new one is the way to go. I can't find any sources for this, but it feels like a deprecation of the old URL.

I have already built a local copy of `lego` with these changes and can confirm that the change introduced by this PR does indeed request a new certificate successfully and no longer produces expiry errors.

Disclaimer: I skimmed the code to see if this change would have any unintended effects, and couldn't find any. I'm neither an expert with lego or Go, however, and may have missed something.