### PR TITLE
Add http proxy support for namecheap provider

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -2385,6 +2385,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "NAMECHEAP_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 3600)`)
 		ew.writeln(`	- "NAMECHEAP_SANDBOX":	Activate the sandbox (boolean)`)
 		ew.writeln(`	- "NAMECHEAP_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
+		ew.writeln(`	- "NAMECHEAP_HTTP_PROXY":	HTTP(s) Proxy to use for API calls (url)`)
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/namecheap`)

--- a/docs/content/dns/zz_gen_namecheap.md
+++ b/docs/content/dns/zz_gen_namecheap.md
@@ -59,6 +59,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 | `NAMECHEAP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 3600) |
 | `NAMECHEAP_SANDBOX` | Activate the sandbox (boolean) |
 | `NAMECHEAP_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
+| `NAMECHEAP_HTTP_PROXY` | HTTP(s) Proxy to use for API calls (url) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
 More information [here]({{% ref "dns#configuration-and-credentials" %}}).

--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -26,6 +26,7 @@ lego --email you@example.com --dns namecheap -d '*.example.com' -d example.com r
     NAMECHEAP_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 3600)"
     NAMECHEAP_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
     NAMECHEAP_HTTP_TIMEOUT = "API request timeout in seconds (Default: 60)"
+    NAMECHEAP_HTTP_PROXY = "HTTP(s) Proxy to use for API calls (url)"
     NAMECHEAP_SANDBOX = "Activate the sandbox (boolean)"
 
 [Links]


### PR DESCRIPTION
I created this PR because Namecheap API needs whitelisted IPv4 (IPv4 only) and on my traefik host i don't have a static IPv4..
