### PR TITLE
feat: remove email requirement

### DIFF
--- a/cmd/cmd_list.go
+++ b/cmd/cmd_list.go
@@ -36,7 +36,7 @@ func createList() *cli.Command {
 			// fake email, needed by NewAccountsStorage
 			&cli.StringFlag{
 				Name:   flgEmail,
-				Value:  "unknown",
+				Value:  "",
 				Hidden: true,
 			},
 		},

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -144,7 +144,9 @@ func renew(ctx *cli.Context) error {
 
 	bundle := !ctx.Bool(flgNoBundle)
 
-	meta := map[string]string{hookEnvAccountEmail: account.Email}
+	meta := map[string]string{
+		hookEnvAccountEmail: account.Email,
+	}
 
 	// CSR
 	if ctx.IsSet(flgCSR) {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -40,7 +40,7 @@ func setupAccount(ctx *cli.Context, accountsStorage *AccountsStorage) (*Account,
 	if accountsStorage.ExistsAccountFilePath() {
 		account = accountsStorage.LoadAccount(privateKey)
 	} else {
-		account = &Account{Email: accountsStorage.GetUserID(), key: privateKey}
+		account = &Account{Email: accountsStorage.GetEmail(), key: privateKey}
 	}
 
 	return account, keyType
@@ -116,15 +116,6 @@ func getKeyType(ctx *cli.Context) certcrypto.KeyType {
 	log.Fatalf("Unsupported KeyType: %s", keyType)
 
 	return ""
-}
-
-func getEmail(ctx *cli.Context) string {
-	email := ctx.String(flgEmail)
-	if email == "" {
-		log.Fatalf("You have to pass an account (email address) to the program using --%s or -m", flgEmail)
-	}
-
-	return email
 }
 
 func getUserAgent(ctx *cli.Context) string {

--- a/e2e/dnschallenge/dns_challenges_test.go
+++ b/e2e/dnschallenge/dns_challenges_test.go
@@ -58,7 +58,6 @@ func TestChallengeDNS_Run(t *testing.T) {
 	loader.CleanLegoFiles()
 
 	err := load.RunLego(
-		"-m", "hubert@hubert.com",
 		"--accept-tos",
 		"--dns", "exec",
 		"--dns.resolvers", ":8053",


### PR DESCRIPTION
I decorrelated the email (used by the LE account) and the user ID (used to create files and directories).

The email is now optional, but the current file tree still works as before, no breaking changes, no extra flag.

Fixes #277
Closes #1378
Closes #2060

Related #2573
Related #1941
Related #1169
Related #836
