### PR TITLE
chore: fix attest-build-provenance subject-checksums path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
 
       # https://goreleaser.com/ci/actions/
       - name: Run GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: v2.13.0
@@ -78,7 +79,7 @@ jobs:
 
       - uses: actions/attest-build-provenance@v3
         with:
-          subject-checksums: ./dist/lego_*_checksums.txt
+          subject-checksums: ./dist/lego_${{ fromJSON(steps.goreleaser.outputs.metadata).version }}_checksums.txt
           github-token: ${{ secrets.GH_TOKEN_REPO }}
       - uses: actions/attest-build-provenance@v3
         with:


### PR DESCRIPTION
Unlike subject-path, subject-checksums does not take a glob:

- https://github.com/actions/attest/blob/9902fb2594e0b5bbab9995737abd2547cde67f22/src/subject.ts#L145-L151

But the metadata of goreleaser can be used to get the version:

- https://github.com/goreleaser/goreleaser-action/blob/d31d51ab5501a8d6d0f08c7a080136a1d0adb7a3/action.yml#L33
- https://github.com/goreleaser/goreleaser-action/blob/d31d51ab5501a8d6d0f08c7a080136a1d0adb7a3/src/goreleaser.ts#L104-L114

<details>
<summary>Example of metadata.json</summary>

```json
{
  "project_name": "lego",
  "tag": "v4.30.0",
  "previous_tag": "v4.29.0",
  "version": "4.30.0-SNAPSHOT-6ca45141e",
  "commit": "6ca45141e7b48ae90e76c38f56833f12bd997653",
  "date": "2025-12-16T18:32:49.965067305+01:00",
  "runtime": {
    "goos": "linux",
    "goarch": "amd64"
  }
}

```

</details>

FYI, the name of the file is `lego_4.29.0_checksums.txt` https://github.com/go-acme/lego/releases/tag/v4.29.0
