### PR TITLE
fix: downgrade aliyun credentials to v1.4.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v11 v11.1.0
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.13
 	github.com/alibabacloud-go/tea v1.3.14
-	github.com/aliyun/credentials-go v1.4.10
+	github.com/aliyun/credentials-go v1.4.7
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.5

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6q
 github.com/aliyun/credentials-go v1.3.1/go.mod h1:8jKYhQuDawt8x2+fusqa1Y6mPxemTsBEN04dgcAcYz0=
 github.com/aliyun/credentials-go v1.3.6/go.mod h1:1LxUuX7L5YrZUWzBrRyk0SwSdH4OmPrib8NVePL3fxM=
 github.com/aliyun/credentials-go v1.4.5/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
-github.com/aliyun/credentials-go v1.4.10 h1:4PtFGTW6eMpKd8YUNL6yVh52c/3PZdEOklELEbn2ui8=
-github.com/aliyun/credentials-go v1.4.10/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
+github.com/aliyun/credentials-go v1.4.7 h1:T17dLqEtPUFvjDRRb5giVvLh6dFT8IcNFJJb7MeyCxw=
+github.com/aliyun/credentials-go v1.4.7/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
`aliyun/credentials-go` still misuse syscalls.

They "fixed" the problem on Windows, but they forget all the other platforms.

- https://github.com/aliyun/credentials-go/issues/138
- The problem has been introduced in v1.4.8 by the PR https://github.com/aliyun/credentials-go/pull/136
- The AI attempts to fix the problem is in https://github.com/aliyun/credentials-go/pull/143

A beautiful illustration of dumb AI usage.

https://github.com/go-acme/lego/actions/runs/20276369237/job/58226154691

```
     error=
    │ build failed: exit status 1: # github.com/aliyun/credentials-go/credentials/providers
Error:     │ ../../../go/pkg/mod/github.com/aliyun/credentials-go@v1.4.10/credentials/providers/lock_unix.go:11:17: undefined: syscall.Flock
Error:     │ ../../../go/pkg/mod/github.com/aliyun/credentials-go@v1.4.10/credentials/providers/lock_unix.go:11:35: undefined: syscall.LOCK_EX
Error:     │ ../../../go/pkg/mod/github.com/aliyun/credentials-go@v1.4.10/credentials/providers/lock_unix.go:16:17: undefined: syscall.Flock
Error:     │ ../../../go/pkg/mod/github.com/aliyun/credentials-go@v1.4.10/credentials/providers/lock_unix.go:16:35: undefined: syscall.LOCK_UN
    target=solaris_amd64_v1
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.13.0/x64/goreleaser' failed with exit code 1
```

Related to #2753
Related to #2733