### PR TITLE
gandiv5: fix API Key header

### DIFF
--- a/providers/dns/gandiv5/internal/client.go
+++ b/providers/dns/gandiv5/internal/client.go
@@ -17,9 +17,6 @@ import (
 // defaultBaseURL endpoint is the Gandi API endpoint used by Present and CleanUp.
 const defaultBaseURL = "https://api.gandi.net/v5/livedns"
 
-// APIKeyHeader API key header.
-const APIKeyHeader = "X-Api-Key"
-
 // Related to Personal Access Token.
 const authorizationHeader = "Authorization"
 
@@ -133,7 +130,7 @@ func (c *Client) DeleteTXTRecord(ctx context.Context, domain, name string) error
 
 func (c *Client) do(req *http.Request, result any) error {
 	if c.apiKey != "" {
-		req.Header.Set(APIKeyHeader, c.apiKey)
+		req.Header.Set(authorizationHeader, "Apikey "+c.apiKey)
 	}
 
 	if c.pat != "" {

--- a/providers/dns/gandiv5/internal/client_test.go
+++ b/providers/dns/gandiv5/internal/client_test.go
@@ -9,23 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockBuilder() *servermock.Builder[*Client] {
+func mockBuilder(apiKey, pat string) *servermock.Builder[*Client] {
+	checkHeaders := servermock.CheckHeader().WithJSONHeaders()
+
+	if apiKey != "" {
+		checkHeaders = checkHeaders.WithAuthorization("Apikey secret-apikey")
+	} else {
+		checkHeaders = checkHeaders.WithAuthorization("Bearer secret-pat")
+	}
+
 	return servermock.NewBuilder[*Client](
 		func(server *httptest.Server) (*Client, error) {
-			client := NewClient("secret", "xxx")
+			client := NewClient(apiKey, pat)
 			client.BaseURL, _ = url.Parse(server.URL)
 			client.HTTPClient = server.Client()
 
 			return client, nil
 		},
-		servermock.CheckHeader().WithJSONHeaders().
-			With("X-Api-Key", "secret").
-			WithAuthorization("Bearer xxx"),
+		checkHeaders,
 	)
 }
 
 func TestClient_AddTXTRecord(t *testing.T) {
-	client := mockBuilder().
+	client := mockBuilder("secret-apikey", "").
 		Route("GET /domains/example.com/records/foo/TXT",
 			servermock.ResponseFromFixture("add_txt_record_get.json")).
 		Route("PUT /domains/example.com/records/foo/TXT",
@@ -38,7 +44,7 @@ func TestClient_AddTXTRecord(t *testing.T) {
 }
 
 func TestClient_DeleteTXTRecord(t *testing.T) {
-	client := mockBuilder().
+	client := mockBuilder("", "secret-pat").
 		Route("DELETE /domains/example.com/records/foo/TXT",
 			servermock.ResponseFromFixture("api_response.json")).
 		Build(t)


### PR DESCRIPTION
The way to set up the API key has changed.

before:
```
X-Api-Key: xxx
```

after:
```
Authorization: Apikey xxx
```

https://api.gandi.net/docs/authentication/

Fixes #2768