### PR TITLE
feat: new HTTP-01 and TLS-ALPN-01 servers constructors

### DIFF
--- a/challenge/http01/http_challenge.go
+++ b/challenge/http01/http_challenge.go
@@ -52,10 +52,6 @@ func NewChallenge(core *api.Core, validate ValidateFunc, provider challenge.Prov
 	return chlg
 }
 
-func (c *Challenge) SetProvider(provider challenge.Provider) {
-	c.provider = provider
-}
-
 func (c *Challenge) Solve(ctx context.Context, authz acme.Authorization) error {
 	domain := challenge.GetTargetedDomain(authz)
 	log.Info("acme: Trying to solve HTTP-01.", "domain", domain)

--- a/challenge/network.go
+++ b/challenge/network.go
@@ -1,0 +1,20 @@
+package challenge
+
+type NetworkStack int
+
+const (
+	dualStack NetworkStack = iota
+	ipv4only
+	ipv6only
+)
+
+func (s NetworkStack) Network(proto string) string {
+	switch s {
+	case ipv4only:
+		return proto + "4"
+	case ipv6only:
+		return proto + "6"
+	default:
+		return proto
+	}
+}

--- a/challenge/tlsalpn01/tls_alpn_challenge.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge.go
@@ -57,10 +57,6 @@ func NewChallenge(core *api.Core, validate ValidateFunc, provider challenge.Prov
 	return chlg
 }
 
-func (c *Challenge) SetProvider(provider challenge.Provider) {
-	c.provider = provider
-}
-
 // Solve manages the provider to validate and solve the challenge.
 func (c *Challenge) Solve(ctx context.Context, authz acme.Authorization) error {
 	domain := authz.Identifier.Value

--- a/challenge/tlsalpn01/tls_alpn_challenge_test.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge_test.go
@@ -76,7 +76,7 @@ func TestChallenge(t *testing.T) {
 	solver := NewChallenge(
 		core,
 		mockValidate,
-		&ProviderServer{port: port},
+		NewProviderServerWithOptions(Options{Host: domain, Port: port}),
 	)
 
 	authz := acme.Authorization{
@@ -105,7 +105,7 @@ func TestChallengeInvalidPort(t *testing.T) {
 	solver := NewChallenge(
 		core,
 		func(_ context.Context, _ *api.Core, _ string, _ acme.Challenge) error { return nil },
-		&ProviderServer{port: "123456"},
+		NewProviderServerWithOptions(Options{Host: "127.0.0.1", Port: "123456"}),
 	)
 
 	authz := acme.Authorization{
@@ -183,7 +183,7 @@ func TestChallengeIPaddress(t *testing.T) {
 	solver := NewChallenge(
 		core,
 		mockValidate,
-		&ProviderServer{port: port},
+		NewProviderServerWithOptions(Options{Host: domain, Port: port}),
 	)
 
 	authz := acme.Authorization{


### PR DESCRIPTION
This PR introduces options to create new HTTP-01 and TLS-ALPN-01 servers.

For now, this is only available for the library.
The CLI part will be done in a separate PR when the CLI is rewritten.

Related to #2798

Related to #355
Related to #364
Related to #1406
Related to #1777
Related to #1801
Related to #1984