### PR TITLE
chore: replace rainycape/memcache by bradfitz/gomemcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
 	github.com/aziontech/azionapi-go-sdk v0.144.0
 	github.com/baidubce/bce-sdk-go v0.9.256
+	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/dnsimple/dnsimple-go/v4 v4.0.0
 	github.com/exoscale/egoscale/v3 v3.1.33
@@ -72,7 +73,6 @@ require (
 	github.com/nzdjb/go-metaname v1.0.0
 	github.com/ovh/go-ovh v1.9.0
 	github.com/pquerna/otp v1.5.0
-	github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2
 	github.com/regfish/regfish-dnsapi-go v0.1.1
 	github.com/sacloud/api-client-go v0.3.3
 	github.com/sacloud/iaas-api-go v1.23.1

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf h1:TqhNAT4zKbTdLa62d2HDBFdvgSbIGB3eJE8HqhgiL9I=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -803,8 +805,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2 h1:dq90+d51/hQRaHEqRAsQ1rE/pC1GUS4sc2rCbbFsAIY=
-github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKcyumwBO6qip7RNQ5r77yrssm9bfCowcLEBcU5IA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/regfish/regfish-dnsapi-go v0.1.1 h1:TJFtbePHkd47q5GZwYl1h3DIYXmoxdLjW/SBsPtB5IE=

--- a/providers/http/memcached/memcached_test.go
+++ b/providers/http/memcached/memcached_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-acme/lego/v5/challenge/http01"
-	"github.com/rainycape/memcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,8 +56,9 @@ func TestMemcachedPresentSingleHost(t *testing.T) {
 
 	err = p.Present(t.Context(), domain, token, keyAuth)
 	require.NoError(t, err)
-	mc, err := memcache.New(memcachedHosts[0])
-	require.NoError(t, err)
+
+	mc := memcache.New(memcachedHosts[0])
+
 	i, err := mc.Get(challengePath)
 	require.NoError(t, err)
 	assert.Equal(t, i.Value, []byte(keyAuth))
@@ -77,8 +78,8 @@ func TestMemcachedPresentMultiHost(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, host := range memcachedHosts {
-		mc, err := memcache.New(host)
-		require.NoError(t, err)
+		mc := memcache.New(host)
+
 		i, err := mc.Get(challengePath)
 		require.NoError(t, err)
 		assert.Equal(t, i.Value, []byte(keyAuth))
@@ -100,8 +101,8 @@ func TestMemcachedPresentPartialFailureMultiHost(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, host := range memcachedHosts {
-		mc, err := memcache.New(host)
-		require.NoError(t, err)
+		mc := memcache.New(host)
+
 		i, err := mc.Get(challengePath)
 		require.NoError(t, err)
 		assert.Equal(t, i.Value, []byte(keyAuth))


### PR DESCRIPTION
[`rainycape/memcache`](https://github.com/rainycape/memcache) was a hard fork of [`bradfitz/gomemcache`](https://github.com/bradfitz/gomemcache).

But it seems that `bradfitz/gomemcache` is more actively maintained: `rainycape/memcache` has not been updated since 2015.
