### PR TITLE
feat: add structured logging with key-value field support

### DIFF
--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -1,6 +1,7 @@
 package certificate
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-acme/lego/v4/acme"
@@ -40,7 +41,7 @@ func (c *Certifier) getAuthorizations(order acme.ExtendedOrder) ([]acme.Authoriz
 	}
 
 	for i, auth := range order.Authorizations {
-		log.Infof("[%s] AuthURL: %s", order.Identifiers[i].Value, auth)
+		log.Info(fmt.Sprintf("AuthURL: %s", auth), "domain", order.Identifiers[i].Value)
 	}
 
 	close(resc)

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -164,9 +164,9 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 	domains := sanitizeDomain(request.Domains)
 
 	if request.Bundle {
-		log.Infof("[%s] acme: Obtaining bundled SAN certificate", strings.Join(domains, ", "))
+		log.Info(fmt.Sprintf("acme: Obtaining bundled SAN certificate for %s", strings.Join(domains, ", ")), "domain", domains[0])
 	} else {
-		log.Infof("[%s] acme: Obtaining SAN certificate", strings.Join(domains, ", "))
+		log.Info(fmt.Sprintf("acme: Obtaining SAN certificate for %s", strings.Join(domains, ", ")), "domain", domains[0])
 	}
 
 	orderOpts := &api.OrderOptions{
@@ -195,7 +195,7 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 		return nil, err
 	}
 
-	log.Infof("[%s] acme: Validations succeeded; requesting certificates", strings.Join(domains, ", "))
+	log.Info(fmt.Sprintf("acme: Validations succeeded; requesting certificates for %s", strings.Join(domains, ", ")), "domain", domains[0])
 
 	failures := newObtainError()
 
@@ -232,9 +232,9 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 	domains := certcrypto.ExtractDomainsCSR(request.CSR)
 
 	if request.Bundle {
-		log.Infof("[%s] acme: Obtaining bundled SAN certificate given a CSR", strings.Join(domains, ", "))
+		log.Info(fmt.Sprintf("acme: Obtaining bundled SAN certificate given a CSR for %s", strings.Join(domains, ", ")), "domain", domains[0])
 	} else {
-		log.Infof("[%s] acme: Obtaining SAN certificate given a CSR", strings.Join(domains, ", "))
+		log.Info(fmt.Sprintf("acme: Obtaining SAN certificate given a CSR for %s", strings.Join(domains, ", ")), "domain", domains[0])
 	}
 
 	orderOpts := &api.OrderOptions{
@@ -263,7 +263,7 @@ func (c *Certifier) ObtainForCSR(request ObtainForCSRRequest) (*Resource, error)
 		return nil, err
 	}
 
-	log.Infof("[%s] acme: Validations succeeded; requesting certificates", strings.Join(domains, ", "))
+	log.Info(fmt.Sprintf("acme: Validations succeeded; requesting certificates for %s", strings.Join(domains, ", ")), "domain", domains[0])
 
 	failures := newObtainError()
 
@@ -413,7 +413,7 @@ func (c *Certifier) checkResponse(order acme.ExtendedOrder, certRes *Resource, b
 	certRes.CertStableURL = order.Certificate
 
 	if preferredChain == "" {
-		log.Infof("[%s] Server responded with a certificate.", certRes.Domain)
+		log.Info("Server responded with a certificate.", "domain", certRes.Domain)
 
 		return true, nil
 	}
@@ -425,7 +425,7 @@ func (c *Certifier) checkResponse(order acme.ExtendedOrder, certRes *Resource, b
 		}
 
 		if ok {
-			log.Infof("[%s] Server responded with a certificate for the preferred certificate chains %q.", certRes.Domain, preferredChain)
+			log.Info(fmt.Sprintf("Server responded with a certificate for the preferred certificate chains %q.", preferredChain), "domain", certRes.Domain)
 
 			certRes.IssuerCertificate = cert.Issuer
 			certRes.Certificate = cert.Cert
@@ -528,7 +528,7 @@ func (c *Certifier) RenewWithOptions(certRes Resource, options *RenewOptions) (*
 
 	// This is just meant to be informal for the user.
 	timeLeft := x509Cert.NotAfter.Sub(time.Now().UTC())
-	log.Infof("[%s] acme: Trying renewal with %d hours remaining", certRes.Domain, int(timeLeft.Hours()))
+	log.Info(fmt.Sprintf("acme: Trying renewal with %d hours remaining", int(timeLeft.Hours())), "domain", certRes.Domain)
 
 	// We always need to request a new certificate to renew.
 	// Start by checking to see if the certificate was based off a CSR,

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -76,7 +76,7 @@ func NewChallenge(core *api.Core, validate ValidateFunc, provider challenge.Prov
 // It does not validate record propagation, or do anything at all with the acme server.
 func (c *Challenge) PreSolve(authz acme.Authorization) error {
 	domain := challenge.GetTargetedDomain(authz)
-	log.Infof("[%s] acme: Preparing to solve DNS-01", domain)
+	log.Info("acme: Preparing to solve DNS-01", "domain", domain)
 
 	chlng, err := challenge.FindChallenge(challenge.DNS01, authz)
 	if err != nil {
@@ -103,7 +103,7 @@ func (c *Challenge) PreSolve(authz acme.Authorization) error {
 
 func (c *Challenge) Solve(authz acme.Authorization) error {
 	domain := challenge.GetTargetedDomain(authz)
-	log.Infof("[%s] acme: Trying to solve DNS-01", domain)
+	log.Info("acme: Trying to solve DNS-01", "domain", domain)
 
 	chlng, err := challenge.FindChallenge(challenge.DNS01, authz)
 	if err != nil {
@@ -127,14 +127,14 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 		timeout, interval = DefaultPropagationTimeout, DefaultPollingInterval
 	}
 
-	log.Infof("[%s] acme: Checking DNS record propagation. [nameservers=%s]", domain, strings.Join(recursiveNameservers, ","))
+	log.Info(fmt.Sprintf("acme: Checking DNS record propagation. [nameservers=%s]", strings.Join(recursiveNameservers, ",")), "domain", domain)
 
 	time.Sleep(interval)
 
 	err = wait.For("propagation", timeout, interval, func() (bool, error) {
 		stop, errP := c.preCheck.call(domain, info.EffectiveFQDN, info.Value)
 		if !stop || errP != nil {
-			log.Infof("[%s] acme: Waiting for DNS record propagation.", domain)
+			log.Info("acme: Waiting for DNS record propagation.", "domain", domain)
 		}
 
 		return stop, errP
@@ -150,7 +150,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 
 // CleanUp cleans the challenge.
 func (c *Challenge) CleanUp(authz acme.Authorization) error {
-	log.Infof("[%s] acme: Cleaning DNS-01 challenge", challenge.GetTargetedDomain(authz))
+	log.Info("acme: Cleaning DNS-01 challenge", "domain", challenge.GetTargetedDomain(authz))
 
 	chlng, err := challenge.FindChallenge(challenge.DNS01, authz)
 	if err != nil {

--- a/challenge/http01/http_challenge.go
+++ b/challenge/http01/http_challenge.go
@@ -57,7 +57,7 @@ func (c *Challenge) SetProvider(provider challenge.Provider) {
 
 func (c *Challenge) Solve(authz acme.Authorization) error {
 	domain := challenge.GetTargetedDomain(authz)
-	log.Infof("[%s] acme: Trying to solve HTTP-01", domain)
+	log.Info("acme: Trying to solve HTTP-01", "domain", domain)
 
 	chlng, err := challenge.FindChallenge(challenge.HTTP01, authz)
 	if err != nil {
@@ -78,7 +78,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 	defer func() {
 		err := c.provider.CleanUp(authz.Identifier.Value, chlng.Token, keyAuth)
 		if err != nil {
-			log.Warnf("[%s] acme: cleaning up failed: %v", domain, err)
+			log.Warn(fmt.Sprintf("acme: cleaning up failed: %v", err), "domain", domain)
 		}
 	}()
 

--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -120,7 +120,7 @@ func (s *ProviderServer) serve(domain, token, keyAuth string) {
 				return
 			}
 
-			log.Infof("[%s] Served key authentication", domain)
+			log.Info("Served key authentication", "domain", domain)
 
 			return
 		}

--- a/challenge/resolver/prober.go
+++ b/challenge/resolver/prober.go
@@ -62,7 +62,7 @@ func (p *Prober) Solve(authorizations []acme.Authorization) error {
 		domain := challenge.GetTargetedDomain(authz)
 		if authz.Status == acme.StatusValid {
 			// Boulder might recycle recent validated authz (see issue #267)
-			log.Infof("[%s] acme: authorization already valid; skipping challenge", domain)
+			log.Info("acme: authorization already valid; skipping challenge", "domain", domain)
 			continue
 		}
 
@@ -177,7 +177,7 @@ func cleanUp(solvr solver, authz acme.Authorization) {
 
 		err := solvr.CleanUp(authz)
 		if err != nil {
-			log.Warnf("[%s] acme: cleaning up failed: %v ", domain, err)
+			log.Warn(fmt.Sprintf("acme: cleaning up failed: %v", err), "domain", domain)
 		}
 	}
 }

--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -68,11 +68,11 @@ func (c *SolverManager) chooseSolver(authz acme.Authorization) solver {
 	domain := challenge.GetTargetedDomain(authz)
 	for _, chlg := range authz.Challenges {
 		if solvr, ok := c.solvers[challenge.Type(chlg.Type)]; ok {
-			log.Infof("[%s] acme: use %s solver", domain, chlg.Type)
+			log.Info(fmt.Sprintf("acme: use %s solver", chlg.Type), "domain", domain)
 			return solvr
 		}
 
-		log.Infof("[%s] acme: Could not find solver for: %s", domain, chlg.Type)
+		log.Info(fmt.Sprintf("acme: Could not find solver for: %s", chlg.Type), "domain", domain)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func validate(core *api.Core, domain string, chlg acme.Challenge) error {
 	}
 
 	if valid {
-		log.Infof("[%s] The server validated our request", domain)
+		log.Info("The server validated our request", "domain", domain)
 		return nil
 	}
 
@@ -125,7 +125,7 @@ func validate(core *api.Core, domain string, chlg acme.Challenge) error {
 		}
 
 		if valid {
-			log.Infof("[%s] The server validated our request", domain)
+			log.Info("The server validated our request", "domain", domain)
 			return nil
 		}
 

--- a/challenge/tlsalpn01/tls_alpn_challenge.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge.go
@@ -63,7 +63,7 @@ func (c *Challenge) SetProvider(provider challenge.Provider) {
 // Solve manages the provider to validate and solve the challenge.
 func (c *Challenge) Solve(authz acme.Authorization) error {
 	domain := authz.Identifier.Value
-	log.Infof("[%s] acme: Trying to solve TLS-ALPN-01", challenge.GetTargetedDomain(authz))
+	log.Info("acme: Trying to solve TLS-ALPN-01", "domain", challenge.GetTargetedDomain(authz))
 
 	chlng, err := challenge.FindChallenge(challenge.TLSALPN01, authz)
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 	defer func() {
 		err := c.provider.CleanUp(domain, chlng.Token, keyAuth)
 		if err != nil {
-			log.Warnf("[%s] acme: cleaning up failed: %v", challenge.GetTargetedDomain(authz), err)
+			log.Warn(fmt.Sprintf("acme: cleaning up failed: %v", err), "domain", challenge.GetTargetedDomain(authz))
 		}
 	}()
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,9 +3,30 @@ package log
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 // Logger is an optional custom logger.
+// Users can assign their own logger (e.g., logrus) to get structured logging.
+//
+// Example with logrus JSON output and structured fields:
+//
+//	import (
+//		"github.com/go-acme/lego/v4/log"
+//		"github.com/sirupsen/logrus"
+//	)
+//
+//	type LogrusWrapper struct {
+//		*logrus.Logger
+//	}
+//
+//	func (l *LogrusWrapper) WithFields(fields map[string]any) log.FieldEntry {
+//		return l.Logger.WithFields(logrus.Fields(fields))
+//	}
+//
+//	logger := logrus.New()
+//	logger.SetFormatter(&logrus.JSONFormatter{})
+//	log.Logger = &LogrusWrapper{Logger: logger}
 var Logger StdLogger = log.New(os.Stderr, "", log.LstdFlags)
 
 // StdLogger interface for Standard Logger.
@@ -18,42 +39,157 @@ type StdLogger interface {
 	Printf(format string, args ...any)
 }
 
+// LevelLogger extends StdLogger with level-specific methods.
+type LevelLogger interface {
+	StdLogger
+	Warn(args ...any)
+	Warnf(format string, args ...any)
+	Info(args ...any)
+	Infof(format string, args ...any)
+}
+
+// FieldLogger is an optional interface for structured logging.
+// Loggers like logrus implement this interface.
+// The returned value must have Info(args ...any) and Warn(args ...any) methods.
+type FieldLogger interface {
+	WithFields(fields map[string]any) FieldEntry
+}
+
+// FieldEntry is the interface for the object returned by WithFields.
+type FieldEntry interface {
+	Info(args ...any)
+	Warn(args ...any)
+}
+
 // Fatal writes a log entry.
-// It uses Logger if not nil, otherwise it uses the default log.Logger.
 func Fatal(args ...any) {
 	Logger.Fatal(args...)
 }
 
 // Fatalf writes a log entry.
-// It uses Logger if not nil, otherwise it uses the default log.Logger.
 func Fatalf(format string, args ...any) {
 	Logger.Fatalf(format, args...)
 }
 
 // Print writes a log entry.
-// It uses Logger if not nil, otherwise it uses the default log.Logger.
 func Print(args ...any) {
 	Logger.Print(args...)
 }
 
 // Println writes a log entry.
-// It uses Logger if not nil, otherwise it uses the default log.Logger.
 func Println(args ...any) {
 	Logger.Println(args...)
 }
 
 // Printf writes a log entry.
-// It uses Logger if not nil, otherwise it uses the default log.Logger.
 func Printf(format string, args ...any) {
 	Logger.Printf(format, args...)
 }
 
-// Warnf writes a log entry.
+// Warnf writes a warning log entry.
 func Warnf(format string, args ...any) {
-	Printf("[WARN] "+format, args...)
+	if levelLogger, ok := Logger.(LevelLogger); ok {
+		levelLogger.Warnf(format, args...)
+	} else {
+		Printf("[WARN] "+format, args...)
+	}
 }
 
-// Infof writes a log entry.
+// Infof writes an info log entry.
 func Infof(format string, args ...any) {
-	Printf("[INFO] "+format, args...)
+	if levelLogger, ok := Logger.(LevelLogger); ok {
+		levelLogger.Infof(format, args...)
+	} else {
+		Printf("[INFO] "+format, args...)
+	}
+}
+
+// Info writes an info log entry with structured fields.
+// When the logger implements FieldLogger (e.g., logrus), fields are logged
+// as structured data. Otherwise, fields are appended to the message.
+//
+// Example:
+//
+//	log.Info("acme: Obtaining certificate", "domain", "example.com")
+//	log.Info("acme: Obtaining certificate", "domain", "example.com", "domains", []string{"example.com", "www.example.com"})
+func Info(msg string, keyvals ...any) {
+	fields := keyValsToMap(keyvals)
+
+	if len(fields) > 0 {
+		if fl, ok := Logger.(FieldLogger); ok {
+			fl.WithFields(fields).Info(msg)
+			return
+		}
+	}
+
+	if len(fields) == 0 {
+		Infof("%s", msg)
+	} else {
+		Infof("%s %s", msg, formatFields(fields))
+	}
+}
+
+// Warn writes a warning log entry with structured fields.
+func Warn(msg string, keyvals ...any) {
+	fields := keyValsToMap(keyvals)
+
+	if len(fields) > 0 {
+		if fl, ok := Logger.(FieldLogger); ok {
+			fl.WithFields(fields).Warn(msg)
+			return
+		}
+	}
+
+	if len(fields) == 0 {
+		Warnf("%s", msg)
+	} else {
+		Warnf("%s %s", msg, formatFields(fields))
+	}
+}
+
+// keyValsToMap converts key-value pairs to a map.
+func keyValsToMap(keyvals []any) map[string]any {
+	fields := make(map[string]any)
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if key, ok := keyvals[i].(string); ok {
+			fields[key] = keyvals[i+1]
+		}
+	}
+	return fields
+}
+
+// formatFields formats fields for fallback text logging.
+func formatFields(fields map[string]any) string {
+	if len(fields) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for k, v := range fields {
+		parts = append(parts, formatKeyValue(k, v))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// formatKeyValue formats a single key-value pair.
+func formatKeyValue(key string, value any) string {
+	switch v := value.(type) {
+	case string:
+		return key + "=" + v
+	case []string:
+		return key + "=[" + strings.Join(v, ", ") + "]"
+	default:
+		return key + "=" + stringify(v)
+	}
+}
+
+// stringify converts a value to string.
+func stringify(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if stringer, ok := v.(interface{ String() string }); ok {
+		return stringer.String()
+	}
+	return ""
 }


### PR DESCRIPTION
Hi,

First, thanks for providing this lib which is very useful and complete, I use it for my project [acme-manager](https://github.com/fgouteroux/acme-manager).

I have only one point about logging format, because when we have multiple certificates ordered or renewed in a same time it is hard to filter logs correctly for one domain.

I try to extend the desired log format in the most transparency as possible with current implementation.

Let me know your thoughs about it.

## Summary

  - Add structured logging support with optional `FieldLogger` interface
  - Introduce `log.Info()` and `log.Warn()` functions with key-value pair support
  - Migrate existing log calls to use structured fields for the `domain` context
  - Maintain backward compatibility with standard loggers

## Motivation

  This change enables users to integrate structured logging libraries (e.g., logrus, zap, slog)
  for better log aggregation and parsing in production environments. The domain information
  is now passed as a structured field rather than being embedded in the log message format.

## Changes

  **log/logger.go:**
  - Added `LevelLogger`, `FieldLogger`, and `FieldEntry` interfaces
  - Added `Info()` and `Warn()` functions supporting key-value structured fields
  - Updated `Infof()` and `Warnf()` to use level-aware logging when available
  - Added helper functions for field formatting fallback

  **Affected packages:**
  - `certificate/` - authorization and certificate operations
  - `challenge/dns01/` - DNS-01 challenge solver
  - `challenge/http01/` - HTTP-01 challenge solver
  - `challenge/tlsalpn01/` - TLS-ALPN-01 challenge solver
  - `challenge/resolver/` - challenge solver management
  - `cmd/` - renewal command

## Example Usage

  ```go
  // With standard logger (backward compatible)
  log.Info("acme: Obtaining certificate", "domain", "example.com")
  // Output: [INFO] acme: Obtaining certificate [domain=example.com]

  // With logrus (structured JSON)
  type LogrusWrapper struct {
      *logrus.Logger
  }

  func (l *LogrusWrapper) WithFields(fields map[string]any) log.FieldEntry {
      return l.Logger.WithFields(logrus.Fields(fields))
  }

  logger := logrus.New()
  logger.SetFormatter(&logrus.JSONFormatter{})
  log.Logger = &LogrusWrapper{Logger: logger}

  log.Info("acme: Obtaining certificate", "domain", "example.com")
  // Output: {"level":"info","msg":"acme: Obtaining certificate","domain":"example.com","time":"..."}

