### PR TITLE
fix: use IPs to define the main domain

### DIFF
--- a/certcrypto/crypto.go
+++ b/certcrypto/crypto.go
@@ -242,15 +242,15 @@ func ParsePEMCertificate(cert []byte) (*x509.Certificate, error) {
 }
 
 func GetCertificateMainDomain(cert *x509.Certificate) (string, error) {
-	return getMainDomain(cert.Subject, cert.DNSNames)
+	return getMainDomain(cert.Subject, cert.DNSNames, cert.IPAddresses)
 }
 
 func GetCSRMainDomain(cert *x509.CertificateRequest) (string, error) {
-	return getMainDomain(cert.Subject, cert.DNSNames)
+	return getMainDomain(cert.Subject, cert.DNSNames, cert.IPAddresses)
 }
 
-func getMainDomain(subject pkix.Name, dnsNames []string) (string, error) {
-	if subject.CommonName == "" && len(dnsNames) == 0 {
+func getMainDomain(subject pkix.Name, dnsNames []string, ips []net.IP) (string, error) {
+	if subject.CommonName == "" && len(dnsNames) == 0 && len(ips) == 0 {
 		return "", errors.New("missing domain")
 	}
 
@@ -258,7 +258,11 @@ func getMainDomain(subject pkix.Name, dnsNames []string) (string, error) {
 		return subject.CommonName, nil
 	}
 
-	return dnsNames[0], nil
+	if len(dnsNames) > 0 {
+		return dnsNames[0], nil
+	}
+
+	return ips[0].String(), nil
 }
 
 func ExtractDomains(cert *x509.Certificate) []string {

--- a/cmd/cmd_list.go
+++ b/cmd/cmd_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -100,6 +101,11 @@ func listCertificates(ctx *cli.Context) error {
 		} else {
 			fmt.Println("  Certificate Name:", name)
 			fmt.Println("    Domains:", strings.Join(pCert.DNSNames, ", "))
+
+			if len(pCert.IPAddresses) > 0 {
+				fmt.Println("    IPs:", formatIPAddresses(pCert.IPAddresses))
+			}
+
 			fmt.Println("    Expiry Date:", pCert.NotAfter)
 			fmt.Println("    Certificate Path:", filename)
 			fmt.Println()
@@ -149,4 +155,13 @@ func listAccount(ctx *cli.Context) error {
 	}
 
 	return nil
+}
+
+func formatIPAddresses(ipAddresses []net.IP) string {
+	var ips []string
+	for _, ip := range ipAddresses {
+		ips = append(ips, ip.String())
+	}
+
+	return strings.Join(ips, ", ")
 }


### PR DESCRIPTION
When getting a certificate for IP, use the IP as "main domain".

```
Found the following certs:
  Certificate Name: 127.0.0.1
    Domains: 
    IPs: 127.0.0.1
    Expiry Date: 2026-04-26 12:20:48 +0000 UTC
    Certificate Path: /home/ldez/sources/go-acme/lego/.lego/certificates/127.0.0.1.crt
```

The manning will be changed in v5.

Fixes #2816