### PR TITLE
feat: replace --run-hook and --renew-hook with --deploy-hook

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -209,7 +209,7 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 
 	hook.AddPathToMetadata(meta, certRes.Domain, certRes, certsStorage)
 
-	return hook.Launch(ctx, cmd.String(flgRenewHook), cmd.Duration(flgRenewHookTimeout), meta)
+	return hook.Launch(ctx, cmd.String(flgDeployHook), cmd.Duration(flgDeployHookTimeout), meta)
 }
 
 func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account, keyType certcrypto.KeyType, certsStorage *storage.CertificatesStorage, meta map[string]string) error {
@@ -302,7 +302,7 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 
 	hook.AddPathToMetadata(meta, domain, certRes, certsStorage)
 
-	return hook.Launch(ctx, cmd.String(flgRenewHook), cmd.Duration(flgRenewHookTimeout), meta)
+	return hook.Launch(ctx, cmd.String(flgDeployHook), cmd.Duration(flgDeployHookTimeout), meta)
 }
 
 func needRenewal(x509Cert *x509.Certificate, domain string, days int, dynamic bool) bool {

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -88,7 +88,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 
 	hook.AddPathToMetadata(meta, cert.Domain, cert, certsStorage)
 
-	return hook.Launch(ctx, cmd.String(flgRunHook), cmd.Duration(flgRunHookTimeout), meta)
+	return hook.Launch(ctx, cmd.String(flgDeployHook), cmd.Duration(flgDeployHookTimeout), meta)
 }
 
 func obtainCertificate(ctx context.Context, cmd *cli.Command, client *lego.Client) (*certificate.Resource, error) {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -88,11 +88,8 @@ const (
 
 // Flags names related to hooks.
 const (
-	flgRenewHook        = "renew-hook"
-	flgRenewHookTimeout = "renew-hook-timeout"
-
-	flgRunHook        = "run-hook"
-	flgRunHookTimeout = "run-hook-timeout"
+	flgDeployHook        = "deploy-hook"
+	flgDeployHookTimeout = "deploy-hook-timeout"
 )
 
 // Flag names related to the specific run command.
@@ -388,14 +385,14 @@ func CreateObtainFlags() []cli.Flag {
 	}
 }
 
-func CreateHookFlags(name, timeoutName string) []cli.Flag {
+func CreateHookFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:  name,
+			Name:  flgDeployHook,
 			Usage: "Define a hook. The hook is executed only when the certificates are effectively created/renewed.",
 		},
 		&cli.DurationFlag{
-			Name:  timeoutName,
+			Name:  flgDeployHookTimeout,
 			Usage: "Define the timeout for the hook execution.",
 			Value: 2 * time.Minute,
 		},
@@ -418,7 +415,7 @@ func createRunFlags() []cli.Flag {
 
 	flags = append(flags, CreateChallengesFlags()...)
 	flags = append(flags, CreateObtainFlags()...)
-	flags = append(flags, CreateHookFlags(flgRunHook, flgRunHookTimeout)...)
+	flags = append(flags, CreateHookFlags()...)
 
 	flags = append(flags,
 		&cli.StringFlag{
@@ -435,7 +432,7 @@ func createRenewFlags() []cli.Flag {
 
 	flags = append(flags, CreateChallengesFlags()...)
 	flags = append(flags, CreateObtainFlags()...)
-	flags = append(flags, CreateHookFlags(flgRenewHook, flgRenewHookTimeout)...)
+	flags = append(flags, CreateHookFlags()...)
 
 	flags = append(flags,
 		&cli.IntFlag{

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -76,8 +76,8 @@ OPTIONS:
    --preferred-chain string                                       If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --profile string                                               If the CA offers multiple certificate profiles (draft-ietf-acme-profiles), choose this one.
    --always-deactivate-authorizations string                      Force the authorizations to be relinquished even if the certificate request was successful.
-   --run-hook string                                              Define a hook. The hook is executed only when the certificates are effectively created/renewed.
-   --run-hook-timeout duration                                    Define the timeout for the hook execution. (default: 2m0s)
+   --deploy-hook string                                           Define a hook. The hook is executed only when the certificates are effectively created/renewed.
+   --deploy-hook-timeout duration                                 Define the timeout for the hook execution. (default: 2m0s)
    --private-key string                                           Path to private key (in PEM encoding) for the certificate. By default, the private key is generated.
    --help, -h                                                     show help
 """
@@ -136,8 +136,8 @@ OPTIONS:
    --preferred-chain string                                       If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
    --profile string                                               If the CA offers multiple certificate profiles (draft-ietf-acme-profiles), choose this one.
    --always-deactivate-authorizations string                      Force the authorizations to be relinquished even if the certificate request was successful.
-   --renew-hook string                                            Define a hook. The hook is executed only when the certificates are effectively created/renewed.
-   --renew-hook-timeout duration                                  Define the timeout for the hook execution. (default: 2m0s)
+   --deploy-hook string                                           Define a hook. The hook is executed only when the certificates are effectively created/renewed.
+   --deploy-hook-timeout duration                                 Define the timeout for the hook execution. (default: 2m0s)
    --days int                                                     The number of days left on a certificate to renew it. (default: 30)
    --dynamic                                                      Compute dynamically, based on the lifetime of the certificate(s), when to renew: use 1/3rd of the lifetime left, or 1/2 of the lifetime for short-lived certificates). This supersedes --days and will be the default behavior in Lego v5.
    --ari-disable                                                  Do not use the renewalInfo endpoint (RFC9773) to check if a certificate should be renewed.


### PR DESCRIPTION
The `--run-hook` and `--renew-hook` flags are replaced by `--deploy-hook`.

There is no need to use two different flags for the same purpose, as the commands are independent.

These hooks are executed after the certificate is obtained or renewed, as before.

This will ease the introduction of new hooks (pre/post).
