### PR TITLE
refactor(cmd): replace Fatal with error

### DIFF
--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -64,7 +64,7 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("get the key type: %w", err)
 	}
 
-	account, err := setupAccount(ctx, keyType, accountsStorage)
+	account, err := accountsStorage.Get(ctx, keyType)
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -54,14 +54,14 @@ func createRenew() *cli.Command {
 }
 
 func renew(ctx context.Context, cmd *cli.Command) error {
-	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
-	if err != nil {
-		return fmt.Errorf("accounts storage initialization: %w", err)
-	}
-
 	keyType, err := getKeyType(cmd.String(flgKeyType))
 	if err != nil {
 		return fmt.Errorf("get the key type: %w", err)
+	}
+
+	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
+	if err != nil {
+		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
 	account, err := accountsStorage.Get(ctx, keyType)

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -56,20 +56,26 @@ func createRenew() *cli.Command {
 func renew(ctx context.Context, cmd *cli.Command) error {
 	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
 	if err != nil {
-		log.Fatal("Accounts storage initialization", log.ErrorAttr(err))
+		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	keyType := getKeyType(cmd)
+	keyType, err := getKeyType(cmd.String(flgKeyType))
+	if err != nil {
+		return fmt.Errorf("get the key type: %w", err)
+	}
 
-	account := setupAccount(ctx, keyType, accountsStorage)
+	account, err := setupAccount(ctx, keyType, accountsStorage)
+	if err != nil {
+		return fmt.Errorf("set up account: %w", err)
+	}
 
 	if account.Registration == nil {
-		log.Fatal("The account is not registered. Use 'run' to register a new account.", slog.String("email", account.Email))
+		return fmt.Errorf("the account %s is not registered", account.Email)
 	}
 
 	certsStorage, err := storage.NewCertificatesStorage(newCertificatesWriterConfig(cmd))
 	if err != nil {
-		log.Fatal("Certificates storage", log.ErrorAttr(err))
+		return fmt.Errorf("certificates storage initialization: %w", err)
 	}
 
 	meta := map[string]string{
@@ -94,10 +100,7 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 	// as web servers would not be able to work with a combined file.
 	certificates, err := certsStorage.ReadCertificate(domain, storage.ExtCert)
 	if err != nil {
-		log.Fatal("Error while loading the certificate.",
-			log.DomainAttr(domain),
-			log.ErrorAttr(err),
-		)
+		return fmt.Errorf("error while reading the certificate for domain %q: %w", domain, err)
 	}
 
 	cert := certificates[0]
@@ -110,7 +113,10 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 	var client *lego.Client
 
 	if !cmd.Bool(flgARIDisable) {
-		client = setupClient(cmd, account, keyType)
+		client, err = setupClient(cmd, account, keyType)
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
 
 		willingToSleep := cmd.Duration(flgARIWaitToRenewDuration)
 
@@ -125,13 +131,14 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 					slog.Duration("sleep", ariRenewalTime.Sub(now)),
 					slog.Time("renewalTime", *ariRenewalTime),
 				)
+
 				time.Sleep(ariRenewalTime.Sub(now))
 			}
 		}
 
 		replacesCertID, err = certificate.MakeARICertID(cert)
 		if err != nil {
-			log.Fatal("Error while construction the ARI CertID.", log.DomainAttr(domain), log.ErrorAttr(err))
+			return fmt.Errorf("error while constructing the ARI CertID for domain %q: %w", domain, err)
 		}
 	}
 
@@ -145,11 +152,15 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 	}
 
 	if client == nil {
-		client = setupClient(cmd, account, keyType)
+		client, err = setupClient(cmd, account, keyType)
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
 	}
 
 	// This is just meant to be informal for the user.
 	timeLeft := cert.NotAfter.Sub(time.Now().UTC())
+
 	log.Info("acme: Trying renewal.",
 		log.DomainAttr(domain),
 		slog.Int("hoursRemaining", int(timeLeft.Hours())),
@@ -160,15 +171,12 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 	if cmd.Bool(flgReuseKey) {
 		keyBytes, errR := certsStorage.ReadFile(domain, storage.ExtKey)
 		if errR != nil {
-			log.Fatal("Error while loading the private key.",
-				log.DomainAttr(domain),
-				log.ErrorAttr(errR),
-			)
+			return fmt.Errorf("error while reading the private key for domain %q: %w", domain, errR)
 		}
 
 		privateKey, errR = certcrypto.ParsePEMPrivateKey(keyBytes)
 		if errR != nil {
-			return errR
+			return fmt.Errorf("error while parsing the private key for domain %q: %w", domain, errR)
 		}
 	}
 
@@ -200,12 +208,15 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 
 	certRes, err := client.Certificate.Obtain(ctx, request)
 	if err != nil {
-		log.Fatal("Could not obtain the certificate.", log.ErrorAttr(err))
+		return fmt.Errorf("could not obtain the certificate for domain %q: %w", domain, err)
 	}
 
 	certRes.Domain = domain
 
-	certsStorage.SaveResource(certRes)
+	err = certsStorage.SaveResource(certRes)
+	if err != nil {
+		return fmt.Errorf("could not save the resource: %w", err)
+	}
 
 	hook.AddPathToMetadata(meta, certRes.Domain, certRes, certsStorage)
 
@@ -215,15 +226,12 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, account *storage.Acc
 func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account, keyType certcrypto.KeyType, certsStorage *storage.CertificatesStorage, meta map[string]string) error {
 	csr, err := readCSRFile(cmd.String(flgCSR))
 	if err != nil {
-		log.Fatal("Could not read CSR file.",
-			slog.String(flgCSR, cmd.String(flgCSR)),
-			log.ErrorAttr(err),
-		)
+		return fmt.Errorf("could not read CSR file %q: %w", cmd.String(flgCSR), err)
 	}
 
 	domain, err := certcrypto.GetCSRMainDomain(csr)
 	if err != nil {
-		log.Fatal("Could not get CSR main domain.", log.ErrorAttr(err))
+		return fmt.Errorf("could not get CSR main domain: %w", err)
 	}
 
 	// load the cert resource from files.
@@ -231,10 +239,7 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 	// as web servers would not be able to work with a combined file.
 	certificates, err := certsStorage.ReadCertificate(domain, storage.ExtCert)
 	if err != nil {
-		log.Fatal("Error while loading the certificate.",
-			log.DomainAttr(domain),
-			log.ErrorAttr(err),
-		)
+		return fmt.Errorf("error while reading the certificate for domain %q: %w", domain, err)
 	}
 
 	cert := certificates[0]
@@ -247,7 +252,10 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 	var client *lego.Client
 
 	if !cmd.Bool(flgARIDisable) {
-		client = setupClient(cmd, account, keyType)
+		client, err = setupClient(cmd, account, keyType)
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
 
 		willingToSleep := cmd.Duration(flgARIWaitToRenewDuration)
 
@@ -262,13 +270,14 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 					slog.Duration("sleep", ariRenewalTime.Sub(now)),
 					slog.Time("renewalTime", *ariRenewalTime),
 				)
+
 				time.Sleep(ariRenewalTime.Sub(now))
 			}
 		}
 
 		replacesCertID, err = certificate.MakeARICertID(cert)
 		if err != nil {
-			log.Fatal("Error while construction the ARI CertID.", log.DomainAttr(domain), log.ErrorAttr(err))
+			return fmt.Errorf("error while constructing the ARI CertID for domain %q: %w", domain, err)
 		}
 	}
 
@@ -277,11 +286,15 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 	}
 
 	if client == nil {
-		client = setupClient(cmd, account, keyType)
+		client, err = setupClient(cmd, account, keyType)
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
 	}
 
 	// This is just meant to be informal for the user.
 	timeLeft := cert.NotAfter.Sub(time.Now().UTC())
+
 	log.Info("acme: Trying renewal.",
 		log.DomainAttr(domain),
 		slog.Int("hoursRemaining", int(timeLeft.Hours())),
@@ -295,10 +308,13 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, account *storage.Account
 
 	certRes, err := client.Certificate.ObtainForCSR(ctx, request)
 	if err != nil {
-		log.Fatal("Could not obtain the certificate for CSR.", log.ErrorAttr(err))
+		return fmt.Errorf("could not obtain the certificate for CSR: %w", err)
 	}
 
-	certsStorage.SaveResource(certRes)
+	err = certsStorage.SaveResource(certRes)
+	if err != nil {
+		return fmt.Errorf("could not save the resource: %w", err)
+	}
 
 	hook.AddPathToMetadata(meta, domain, certRes, certsStorage)
 

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -30,7 +30,7 @@ func revoke(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("get the key type: %w", err)
 	}
 
-	account, err := setupAccount(ctx, keyType, accountsStorage)
+	account, err := accountsStorage.Get(ctx, keyType)
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -20,14 +20,14 @@ func createRevoke() *cli.Command {
 }
 
 func revoke(ctx context.Context, cmd *cli.Command) error {
-	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
-	if err != nil {
-		return fmt.Errorf("accounts storage initialization: %w", err)
-	}
-
 	keyType, err := getKeyType(cmd.String(flgKeyType))
 	if err != nil {
 		return fmt.Errorf("get the key type: %w", err)
+	}
+
+	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
+	if err != nil {
+		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
 	account, err := accountsStorage.Get(ctx, keyType)

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
-	"log/slog"
+	"fmt"
 
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
+	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 	"github.com/urfave/cli/v3"
 )
@@ -21,56 +22,81 @@ func createRevoke() *cli.Command {
 func revoke(ctx context.Context, cmd *cli.Command) error {
 	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
 	if err != nil {
-		log.Fatal("Accounts storage initialization", log.ErrorAttr(err))
+		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	keyType := getKeyType(cmd)
+	keyType, err := getKeyType(cmd.String(flgKeyType))
+	if err != nil {
+		return fmt.Errorf("get the key type: %w", err)
+	}
 
-	account := setupAccount(ctx, keyType, accountsStorage)
+	account, err := setupAccount(ctx, keyType, accountsStorage)
+	if err != nil {
+		return fmt.Errorf("set up account: %w", err)
+	}
 
 	if account.Registration == nil {
-		log.Fatal("Account is not registered. Use 'run' to register a new account.", slog.String("email", account.Email))
+		return fmt.Errorf("the account %s is not registered", account.Email)
 	}
 
-	client := newClient(cmd, account, keyType)
+	client, err := newClient(cmd, account, keyType)
+	if err != nil {
+		return fmt.Errorf("new client: %w", err)
+	}
 
 	certsStorage, err := storage.NewCertificatesStorage(newCertificatesWriterConfig(cmd))
 	if err != nil {
-		log.Fatal("Certificates storage", log.ErrorAttr(err))
+		return fmt.Errorf("certificates storage initialization: %w", err)
 	}
 
-	certsStorage.CreateRootFolder()
+	err = certsStorage.CreateRootFolder()
+	if err != nil {
+		return fmt.Errorf("root folder creation: %w", err)
+	}
+
+	reason := cmd.Uint(flgReason)
+	keep := cmd.Bool(flgKeep)
 
 	for _, domain := range cmd.StringSlice(flgDomains) {
-		log.Info("Trying to revoke the certificate.", log.DomainAttr(domain))
-
-		certBytes, err := certsStorage.ReadFile(domain, storage.ExtCert)
-		if err != nil {
-			log.Fatal("Error while revoking the certificate.", log.DomainAttr(domain), log.ErrorAttr(err))
-		}
-
-		reason := cmd.Uint(flgReason)
-
-		err = client.Certificate.RevokeWithReason(ctx, certBytes, &reason)
-		if err != nil {
-			log.Fatal("Error while revoking the certificate.", log.DomainAttr(domain), log.ErrorAttr(err))
-		}
-
-		log.Info("Certificate was revoked.", log.DomainAttr(domain))
-
-		if cmd.Bool(flgKeep) {
-			return nil
-		}
-
-		certsStorage.CreateArchiveFolder()
-
-		err = certsStorage.MoveToArchive(domain)
+		err := revokeCertificate(ctx, client, certsStorage, domain, reason, keep)
 		if err != nil {
 			return err
 		}
-
-		log.Info("Certificate was archived", log.DomainAttr(domain))
 	}
+
+	return nil
+}
+
+func revokeCertificate(ctx context.Context, client *lego.Client, certsStorage *storage.CertificatesStorage, domain string, reason uint, keep bool) error {
+	log.Info("Trying to revoke the certificate.", log.DomainAttr(domain))
+
+	certBytes, err := certsStorage.ReadFile(domain, storage.ExtCert)
+	if err != nil {
+		return fmt.Errorf("certificate reading for domain %s: %w", domain, err)
+	}
+
+	err = client.Certificate.RevokeWithReason(ctx, certBytes, &reason)
+	if err != nil {
+		return fmt.Errorf("certificate revocation for domain %s: %w", domain, err)
+	}
+
+	log.Info("The certificate has been revoked.", log.DomainAttr(domain))
+
+	if keep {
+		return nil
+	}
+
+	err = certsStorage.CreateArchiveFolder()
+	if err != nil {
+		return fmt.Errorf("archive folder creation: %w", err)
+	}
+
+	err = certsStorage.MoveToArchive(domain)
+	if err != nil {
+		return err
+	}
+
+	log.Info("The certificate has been archived.", log.DomainAttr(domain))
 
 	return nil
 }

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -49,7 +49,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("get the key type: %w", err)
 	}
 
-	account, err := setupAccount(ctx, keyType, accountsStorage)
+	account, err := accountsStorage.Get(ctx, keyType)
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -39,14 +39,14 @@ func createRun() *cli.Command {
 }
 
 func run(ctx context.Context, cmd *cli.Command) error {
-	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
-	if err != nil {
-		return fmt.Errorf("accounts storage initialization: %w", err)
-	}
-
 	keyType, err := getKeyType(cmd.String(flgKeyType))
 	if err != nil {
 		return fmt.Errorf("get the key type: %w", err)
+	}
+
+	accountsStorage, err := storage.NewAccountsStorage(newAccountsStorageConfig(cmd))
+	if err != nil {
+		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
 	account, err := accountsStorage.Get(ctx, keyType)

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -10,7 +10,8 @@ import (
 type Account struct {
 	Email        string                 `json:"email"`
 	Registration *registration.Resource `json:"registration"`
-	key          crypto.PrivateKey
+
+	key crypto.PrivateKey
 }
 
 func NewAccount(email string, key crypto.PrivateKey) *Account {

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -108,29 +108,8 @@ func NewAccountsStorage(config AccountsStorageConfig) (*AccountsStorage, error) 
 	}, nil
 }
 
-func (s *AccountsStorage) ExistsAccountFilePath() bool {
-	if _, err := os.Stat(s.accountFilePath); os.IsNotExist(err) {
-		return false
-	} else if err != nil {
-		log.Fatal("Could not read the account file.",
-			slog.String("filepath", s.accountFilePath),
-			log.ErrorAttr(err),
-		)
-	}
-
-	return true
-}
-
 func (s *AccountsStorage) GetRootPath() string {
 	return s.rootPath
-}
-
-func (s *AccountsStorage) GetUserID() string {
-	return s.userID
-}
-
-func (s *AccountsStorage) GetEmail() string {
-	return s.email
 }
 
 func (s *AccountsStorage) Save(account *Account) error {
@@ -142,17 +121,30 @@ func (s *AccountsStorage) Save(account *Account) error {
 	return os.WriteFile(s.accountFilePath, jsonBytes, filePerm)
 }
 
-func (s *AccountsStorage) LoadAccount(ctx context.Context, privateKey crypto.PrivateKey) (*Account, error) {
+func (s *AccountsStorage) Get(ctx context.Context, keyType certcrypto.KeyType) (*Account, error) {
+	privateKey, err := s.getPrivateKey(keyType)
+	if err != nil {
+		return nil, fmt.Errorf("get private key: %w", err)
+	}
+
+	if s.existsAccountFilePath() {
+		return s.load(ctx, privateKey)
+	}
+
+	return NewAccount(s.email, privateKey), nil
+}
+
+func (s *AccountsStorage) load(ctx context.Context, privateKey crypto.PrivateKey) (*Account, error) {
 	fileBytes, err := os.ReadFile(s.accountFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("could not read the account file (userID: %s): %w", s.GetUserID(), err)
+		return nil, fmt.Errorf("could not read the account file (userID: %s): %w", s.userID, err)
 	}
 
 	var account Account
 
 	err = json.Unmarshal(fileBytes, &account)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse the account file (userID: %s): %w", s.GetUserID(), err)
+		return nil, fmt.Errorf("could not parse the account file (userID: %s): %w", s.userID, err)
 	}
 
 	account.key = privateKey
@@ -160,38 +152,38 @@ func (s *AccountsStorage) LoadAccount(ctx context.Context, privateKey crypto.Pri
 	if account.Registration == nil || account.Registration.Body.Status == "" {
 		reg, err := s.tryRecoverRegistration(ctx, privateKey)
 		if err != nil {
-			return nil, fmt.Errorf("could not load the account file, registration is nil (userID: %s): %w", s.GetUserID(), err)
+			return nil, fmt.Errorf("could not load the account file, registration is nil (userID: %s): %w", s.userID, err)
 		}
 
 		account.Registration = reg
 
 		err = s.Save(&account)
 		if err != nil {
-			return nil, fmt.Errorf("could not save the account file, registration is nil (userID: %s): %w", s.GetUserID(), err)
+			return nil, fmt.Errorf("could not save the account file, registration is nil (userID: %s): %w", s.userID, err)
 		}
 	}
 
 	return &account, nil
 }
 
-func (s *AccountsStorage) GetPrivateKey(keyType certcrypto.KeyType) (crypto.PrivateKey, error) {
-	accKeyPath := filepath.Join(s.keysPath, s.GetUserID()+".key")
+func (s *AccountsStorage) getPrivateKey(keyType certcrypto.KeyType) (crypto.PrivateKey, error) {
+	accKeyPath := filepath.Join(s.keysPath, s.userID+".key")
 
 	if _, err := os.Stat(accKeyPath); os.IsNotExist(err) {
 		// TODO(ldez): debug level?
 		log.Info("No key found for the account. Generating a new private key.",
-			slog.String("userID", s.GetUserID()),
+			slog.String("userID", s.userID),
 			slog.Any("keyType", keyType),
 		)
 
 		err := CreateNonExistingFolder(s.keysPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not check/create the directory %q for the account (userID: %s): %w", s.keysPath, s.GetUserID(), err)
+			return nil, fmt.Errorf("could not check/create the directory %q for the account (userID: %s): %w", s.keysPath, s.userID, err)
 		}
 
 		privateKey, err := generatePrivateKey(accKeyPath, keyType)
 		if err != nil {
-			return nil, fmt.Errorf("could not generate the private account key (userID: %s): %w", s.GetUserID(), err)
+			return nil, fmt.Errorf("could not generate the private account key (userID: %s): %w", s.userID, err)
 		}
 
 		// TODO(ldez): debug level?
@@ -206,6 +198,19 @@ func (s *AccountsStorage) GetPrivateKey(keyType certcrypto.KeyType) (crypto.Priv
 	}
 
 	return privateKey, nil
+}
+
+func (s *AccountsStorage) existsAccountFilePath() bool {
+	if _, err := os.Stat(s.accountFilePath); os.IsNotExist(err) {
+		return false
+	} else if err != nil {
+		log.Fatal("Could not read the account file.",
+			slog.String("filepath", s.accountFilePath),
+			log.ErrorAttr(err),
+		)
+	}
+
+	return true
 }
 
 func (s *AccountsStorage) tryRecoverRegistration(ctx context.Context, privateKey crypto.PrivateKey) (*registration.Resource, error) {

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -42,7 +42,7 @@ func TestNewAccountsStorage_userID(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, test.email, storage.userID)
+			assert.Equal(t, test.email, storage.email)
 			assert.Equal(t, test.expected, storage.userID)
 		})
 	}

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -164,7 +164,8 @@ func TestAccountsStorage_LoadAccount(t *testing.T) {
 
 	storage.accountFilePath = filepath.Join("testdata", accountFileName)
 
-	account := storage.LoadAccount(t.Context(), "")
+	account, err := storage.LoadAccount(t.Context(), "")
+	require.NoError(t, err)
 
 	expected := &Account{
 		Email: "account@example.com",
@@ -213,7 +214,8 @@ func TestAccountsStorage_GetPrivateKey(t *testing.T) {
 
 			expectedPath := filepath.Join(test.basePath, baseAccountsRootFolderName, "test@example.com", baseKeysFolderName, "test@example.com.key")
 
-			privateKey := storage.GetPrivateKey(certcrypto.RSA4096)
+			privateKey, err := storage.GetPrivateKey(certcrypto.RSA4096)
+			require.NoError(t, err)
 
 			assert.FileExists(t, expectedPath)
 

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccountsStorage_GetUserID(t *testing.T) {
+func TestNewAccountsStorage_userID(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		email    string
@@ -42,51 +42,8 @@ func TestAccountsStorage_GetUserID(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, test.email, storage.GetEmail())
-			assert.Equal(t, test.expected, storage.GetUserID())
-		})
-	}
-}
-
-func TestAccountsStorage_ExistsAccountFilePath(t *testing.T) {
-	testCases := []struct {
-		desc   string
-		setup  func(t *testing.T, storage *AccountsStorage)
-		assert assert.BoolAssertionFunc
-	}{
-		{
-			desc: "an account file exists",
-			setup: func(t *testing.T, storage *AccountsStorage) {
-				t.Helper()
-
-				err := os.MkdirAll(filepath.Dir(storage.accountFilePath), 0o755)
-				require.NoError(t, err)
-
-				err = os.WriteFile(storage.accountFilePath, []byte("test"), 0o644)
-				require.NoError(t, err)
-			},
-			assert: assert.True,
-		},
-		{
-			desc:   "no account file",
-			assert: assert.False,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			storage, err := NewAccountsStorage(AccountsStorageConfig{
-				BasePath: t.TempDir(),
-			})
-			require.NoError(t, err)
-
-			if test.setup != nil {
-				test.setup(t, storage)
-			}
-
-			test.assert(t, storage.ExistsAccountFilePath())
+			assert.Equal(t, test.email, storage.userID)
+			assert.Equal(t, test.expected, storage.userID)
 		})
 	}
 }
@@ -155,7 +112,46 @@ func TestAccountsStorage_Save(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(file))
 }
 
-func TestAccountsStorage_LoadAccount(t *testing.T) {
+func TestAccountsStorage_Get_newAccount(t *testing.T) {
+	storage, err := NewAccountsStorage(AccountsStorageConfig{
+		Email:    "test@example.com",
+		BasePath: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	account, err := storage.Get(t.Context(), certcrypto.RSA4096)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test@example.com", account.GetEmail())
+	assert.Nil(t, account.GetRegistration())
+	assert.NotNil(t, account.GetPrivateKey())
+}
+
+func TestAccountsStorage_Get_existingAccount(t *testing.T) {
+	storage, err := NewAccountsStorage(AccountsStorageConfig{
+		Email:    "test@example.com",
+		BasePath: "testdata",
+	})
+	require.NoError(t, err)
+
+	account, err := storage.Get(t.Context(), certcrypto.RSA4096)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test@example.com", account.GetEmail())
+
+	expectedRegistration := &registration.Resource{
+		Body: acme.Account{
+			Status: "valid",
+		},
+		URI: "https://example.org/acme/acct/123456",
+	}
+
+	assert.Equal(t, expectedRegistration, account.GetRegistration())
+
+	assert.NotNil(t, account.GetPrivateKey())
+}
+
+func TestAccountsStorage_load(t *testing.T) {
 	storage, err := NewAccountsStorage(AccountsStorageConfig{
 		Email:    "test@example.com",
 		BasePath: t.TempDir(),
@@ -164,7 +160,7 @@ func TestAccountsStorage_LoadAccount(t *testing.T) {
 
 	storage.accountFilePath = filepath.Join("testdata", accountFileName)
 
-	account, err := storage.LoadAccount(t.Context(), "")
+	account, err := storage.load(t.Context(), "")
 	require.NoError(t, err)
 
 	expected := &Account{
@@ -186,7 +182,7 @@ func TestAccountsStorage_LoadAccount(t *testing.T) {
 	assert.Equal(t, expected, account)
 }
 
-func TestAccountsStorage_GetPrivateKey(t *testing.T) {
+func TestAccountsStorage_getPrivateKey(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		basePath string
@@ -214,12 +210,55 @@ func TestAccountsStorage_GetPrivateKey(t *testing.T) {
 
 			expectedPath := filepath.Join(test.basePath, baseAccountsRootFolderName, "test@example.com", baseKeysFolderName, "test@example.com.key")
 
-			privateKey, err := storage.GetPrivateKey(certcrypto.RSA4096)
+			privateKey, err := storage.getPrivateKey(certcrypto.RSA4096)
 			require.NoError(t, err)
 
 			assert.FileExists(t, expectedPath)
 
 			assert.IsType(t, &rsa.PrivateKey{}, privateKey)
+		})
+	}
+}
+
+func TestAccountsStorage_existsAccountFilePath(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		setup  func(t *testing.T, storage *AccountsStorage)
+		assert assert.BoolAssertionFunc
+	}{
+		{
+			desc: "an account file exists",
+			setup: func(t *testing.T, storage *AccountsStorage) {
+				t.Helper()
+
+				err := os.MkdirAll(filepath.Dir(storage.accountFilePath), 0o755)
+				require.NoError(t, err)
+
+				err = os.WriteFile(storage.accountFilePath, []byte("test"), 0o644)
+				require.NoError(t, err)
+			},
+			assert: assert.True,
+		},
+		{
+			desc:   "no account file",
+			assert: assert.False,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			storage, err := NewAccountsStorage(AccountsStorageConfig{
+				BasePath: t.TempDir(),
+			})
+			require.NoError(t, err)
+
+			if test.setup != nil {
+				test.setup(t, storage)
+			}
+
+			test.assert(t, storage.existsAccountFilePath())
 		})
 	}
 }

--- a/cmd/internal/storage/certificates_reader.go
+++ b/cmd/internal/storage/certificates_reader.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -22,24 +23,18 @@ func NewCertificatesReader(basePath string) *CertificatesReader {
 	}
 }
 
-func (s *CertificatesReader) ReadResource(domain string) certificate.Resource {
+func (s *CertificatesReader) ReadResource(domain string) (certificate.Resource, error) {
 	raw, err := s.ReadFile(domain, ExtResource)
 	if err != nil {
-		log.Fatal("Error while loading the metadata.",
-			log.DomainAttr(domain),
-			log.ErrorAttr(err),
-		)
+		return certificate.Resource{}, fmt.Errorf("unable to load resource for domain %q: %w", domain, err)
 	}
 
 	var resource certificate.Resource
 	if err = json.Unmarshal(raw, &resource); err != nil {
-		log.Fatal("Error while marshaling the metadata.",
-			log.DomainAttr(domain),
-			log.ErrorAttr(err),
-		)
+		return certificate.Resource{}, fmt.Errorf("unable to unmarshal resource for domain %q: %w", domain, err)
 	}
 
-	return resource
+	return resource, nil
 }
 
 func (s *CertificatesReader) ExistsFile(domain, extension string) bool {

--- a/cmd/internal/storage/certificates_reader_test.go
+++ b/cmd/internal/storage/certificates_reader_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCertificatesWriter_ReadResource(t *testing.T) {
 	reader := NewCertificatesReader("testdata")
 
-	resource := reader.ReadResource("example.com")
+	resource, err := reader.ReadResource("example.com")
+	require.NoError(t, err)
 
 	expected := certificate.Resource{
 		Domain:        "example.com",

--- a/cmd/internal/storage/certificates_writer_test.go
+++ b/cmd/internal/storage/certificates_writer_test.go
@@ -19,7 +19,8 @@ func TestCertificatesWriter_CreateRootFolder(t *testing.T) {
 
 	require.NoDirExists(t, writer.rootPath)
 
-	writer.CreateRootFolder()
+	err = writer.CreateRootFolder()
+	require.NoError(t, err)
 
 	require.DirExists(t, writer.rootPath)
 }
@@ -32,7 +33,8 @@ func TestCertificatesWriter_CreateArchiveFolder(t *testing.T) {
 
 	require.NoDirExists(t, writer.GetArchivePath())
 
-	writer.CreateArchiveFolder()
+	err = writer.CreateArchiveFolder()
+	require.NoError(t, err)
 
 	require.DirExists(t, writer.GetArchivePath())
 }
@@ -53,7 +55,7 @@ func TestCertificatesWriter_SaveResource(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.key"))
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.json"))
 
-	writer.SaveResource(&certificate.Resource{
+	err = writer.SaveResource(&certificate.Resource{
 		Domain:            "example.com",
 		CertURL:           "https://acme.example.org/cert/123",
 		CertStableURL:     "https://acme.example.org/cert/456",
@@ -62,6 +64,7 @@ func TestCertificatesWriter_SaveResource(t *testing.T) {
 		IssuerCertificate: []byte("IssuerCertificate"),
 		CSR:               []byte("CSR"),
 	})
+	require.NoError(t, err)
 
 	require.FileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.crt"))
 	require.FileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.issuer.crt"))
@@ -262,8 +265,11 @@ func setupCertificatesWriter(t *testing.T) *CertificatesWriter {
 	)
 	require.NoError(t, err)
 
-	writer.CreateRootFolder()
-	writer.CreateArchiveFolder()
+	err = writer.CreateRootFolder()
+	require.NoError(t, err)
+
+	err = writer.CreateArchiveFolder()
+	require.NoError(t, err)
 
 	return writer
 }

--- a/cmd/internal/storage/testdata/accounts/test@example.com/account.json
+++ b/cmd/internal/storage/testdata/accounts/test@example.com/account.json
@@ -1,0 +1,9 @@
+{
+	"email": "test@example.com",
+	"registration": {
+		"body": {
+			"status": "valid"
+		},
+		"uri": "https://example.org/acme/acct/123456"
+	}
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -35,19 +35,6 @@ func setupClient(cmd *cli.Command, account *storage.Account, keyType certcrypto.
 	return client, nil
 }
 
-func setupAccount(ctx context.Context, keyType certcrypto.KeyType, accountsStorage *storage.AccountsStorage) (*storage.Account, error) {
-	privateKey, err := accountsStorage.GetPrivateKey(keyType)
-	if err != nil {
-		return nil, fmt.Errorf("get private key: %w", err)
-	}
-
-	if accountsStorage.ExistsAccountFilePath() {
-		return accountsStorage.LoadAccount(ctx, privateKey)
-	}
-
-	return storage.NewAccount(accountsStorage.GetEmail(), privateKey), nil
-}
-
 func newClient(cmd *cli.Command, acc registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
 	client, err := lego.NewClient(newClientConfig(cmd, acc, keyType))
 	if err != nil {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
-	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 	"github.com/go-acme/lego/v5/registration"
@@ -24,7 +23,7 @@ import (
 )
 
 // setupClient creates a new client with challenge settings.
-func setupClient(cmd *cli.Command, account *storage.Account, keyType certcrypto.KeyType) (*lego.Client, error) {
+func setupClient(cmd *cli.Command, account registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
 	client, err := newClient(cmd, account, keyType)
 	if err != nil {
 		return nil, fmt.Errorf("new client: %w", err)
@@ -35,8 +34,8 @@ func setupClient(cmd *cli.Command, account *storage.Account, keyType certcrypto.
 	return client, nil
 }
 
-func newClient(cmd *cli.Command, acc registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
-	client, err := lego.NewClient(newClientConfig(cmd, acc, keyType))
+func newClient(cmd *cli.Command, account registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
+	client, err := lego.NewClient(newClientConfig(cmd, account, keyType))
 	if err != nil {
 		return nil, fmt.Errorf("new client: %w", err)
 	}
@@ -48,8 +47,8 @@ func newClient(cmd *cli.Command, acc registration.User, keyType certcrypto.KeyTy
 	return client, nil
 }
 
-func newClientConfig(cmd *cli.Command, acc registration.User, keyType certcrypto.KeyType) *lego.Config {
-	config := lego.NewConfig(acc)
+func newClientConfig(cmd *cli.Command, account registration.User, keyType certcrypto.KeyType) *lego.Config {
+	config := lego.NewConfig(account)
 	config.CADirURL = cmd.String(flgServer)
 
 	config.Certificate = lego.CertificateConfig{


### PR DESCRIPTION
Replace `log.Fatal` with `return` + `error`.

This is a better practice, and it allows some simplifications.

Some `log.Fatal` are still present, but only for edge cases that should never happen.
