### PR TITLE
refactor(storage): move constructor options to method options

### DIFF
--- a/cmd/cmd_list.go
+++ b/cmd/cmd_list.go
@@ -35,7 +35,7 @@ func list(ctx context.Context, cmd *cli.Command) error {
 }
 
 func listCertificates(_ context.Context, cmd *cli.Command) error {
-	certsStorage := storage.NewCertificatesReader(cmd.String(flgPath))
+	certsStorage := storage.NewCertificatesStorage(cmd.String(flgPath))
 
 	matches, err := filepath.Glob(filepath.Join(certsStorage.GetRootPath(), "*.crt"))
 	if err != nil {

--- a/cmd/cmd_list.go
+++ b/cmd/cmd_list.go
@@ -126,6 +126,7 @@ func listAccount(_ context.Context, cmd *cli.Command) error {
 			return err
 		}
 
+		fmt.Println("  ID:", account.GetID())
 		fmt.Println("  Email:", account.Email)
 		fmt.Println("  Server:", uri.Host)
 		fmt.Println("  Path:", filepath.Dir(filename))

--- a/cmd/cmd_register.go
+++ b/cmd/cmd_register.go
@@ -46,7 +46,7 @@ func register(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType)
+	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flgEmail), cmd.String(flgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -64,18 +64,19 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType)
+	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flgEmail), cmd.String(flgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
 	if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.Email)
+		return fmt.Errorf("the account %s is not registered", account.GetID())
 	}
 
 	certsStorage := storage.NewCertificatesStorage(cmd.String(flgPath))
 
 	meta := map[string]string{
+		// TODO(ldez) add account ID.
 		hook.EnvAccountEmail: account.Email,
 	}
 

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -44,10 +44,7 @@ func revoke(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("new client: %w", err)
 	}
 
-	certsStorage, err := storage.NewCertificatesStorage(newCertificatesWriterConfig(cmd))
-	if err != nil {
-		return fmt.Errorf("certificates storage initialization: %w", err)
-	}
+	certsStorage := storage.NewCertificatesStorage(cmd.String(flgPath))
 
 	err = certsStorage.CreateRootFolder()
 	if err != nil {

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -30,13 +30,13 @@ func revoke(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType)
+	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flgEmail), cmd.String(flgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
 	if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.Email)
+		return fmt.Errorf("the account %s is not registered", account.GetID())
 	}
 
 	client, err := newClient(cmd, account, keyType)

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -49,7 +49,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType)
+	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flgEmail), cmd.String(flgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
@@ -97,6 +97,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	meta := map[string]string{
+		// TODO(ldez) add account ID.
 		hook.EnvAccountEmail: account.Email,
 	}
 

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -75,10 +75,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf(rootPathWarningMessage, accountsStorage.GetRootPath())
 	}
 
-	certsStorage, err := storage.NewCertificatesStorage(newCertificatesWriterConfig(cmd))
-	if err != nil {
-		return fmt.Errorf("certificates storage initialization: %w", err)
-	}
+	certsStorage := storage.NewCertificatesStorage(cmd.String(flgPath))
 
 	err = certsStorage.CreateRootFolder()
 	if err != nil {
@@ -92,7 +89,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("obtain certificate: %w", err)
 	}
 
-	err = certsStorage.SaveResource(cert)
+	options := newSaveOptions(cmd)
+
+	err = certsStorage.SaveResource(cert, options)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -101,7 +100,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		hook.EnvAccountEmail: account.Email,
 	}
 
-	hook.AddPathToMetadata(meta, cert.Domain, cert, certsStorage)
+	hook.AddPathToMetadata(meta, cert.Domain, cert, certsStorage, options)
 
 	return hook.Launch(ctx, cmd.String(flgDeployHook), cmd.Duration(flgDeployHookTimeout), meta)
 }

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -117,7 +117,7 @@ func obtainCertificate(ctx context.Context, cmd *cli.Command, client *lego.Clien
 		if cmd.IsSet(flgPrivateKey) {
 			var err error
 
-			request.PrivateKey, err = storage.LoadPrivateKey(cmd.String(flgPrivateKey))
+			request.PrivateKey, err = storage.ReadPrivateKeyFile(cmd.String(flgPrivateKey))
 			if err != nil {
 				return nil, fmt.Errorf("load private key: %w", err)
 			}
@@ -139,7 +139,7 @@ func obtainCertificate(ctx context.Context, cmd *cli.Command, client *lego.Clien
 	if cmd.IsSet(flgPrivateKey) {
 		var err error
 
-		request.PrivateKey, err = storage.LoadPrivateKey(cmd.String(flgPrivateKey))
+		request.PrivateKey, err = storage.ReadPrivateKeyFile(cmd.String(flgPrivateKey))
 		if err != nil {
 			return nil, fmt.Errorf("load private key: %w", err)
 		}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -495,9 +495,8 @@ func createRenewFlags() []cli.Flag {
 }
 
 func createRevokeFlags() []cli.Flag {
-	flags := CreateBaseFlags()
-
-	flags = append(flags,
+	flags := []cli.Flag{
+		CreatePathFlag(false),
 		&cli.BoolFlag{
 			Name:    flgKeep,
 			Aliases: []string{"k"},
@@ -513,7 +512,11 @@ func createRevokeFlags() []cli.Flag {
 				" 9 (privilegeWithdrawn), or 10 (aACompromise).",
 			Value: acme.CRLReasonUnspecified,
 		},
-	)
+	}
+
+	flags = append(flags, CreateDomainFlag())
+	flags = append(flags, CreateAccountFlags()...)
+	flags = append(flags, CreateACMEClientFlags()...)
 
 	return flags
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -19,6 +19,7 @@ const (
 	flgDomains   = "domains"
 	flgAcceptTOS = "accept-tos"
 	flgEmail     = "email"
+	flgAccountID = "account-id"
 	flgEAB       = "eab"
 	flgKID       = "kid"
 	flgHMAC      = "hmac"
@@ -132,6 +133,7 @@ const (
 	envEABHMAC     = "LEGO_EAB_HMAC"
 	envEABKID      = "LEGO_EAB_KID"
 	envEmail       = "LEGO_EMAIL"
+	envAccountID   = "LEGO_ACCOUNT_ID"
 	envPath        = "LEGO_PATH"
 	envPFX         = "LEGO_PFX"
 	envPFXFormat   = "LEGO_PFX_FORMAT"
@@ -342,6 +344,12 @@ func CreateAccountFlags() []cli.Flag {
 			Aliases: []string{"m"},
 			Sources: cli.EnvVars(envEmail),
 			Usage:   "Email used for registration and recovery contact.",
+		},
+		&cli.StringFlag{
+			Name:    flgAccountID,
+			Aliases: []string{"a"},
+			Sources: cli.EnvVars(envAccountID),
+			Usage:   "Account identifier (The email is used if there is account ID is undefined).",
 		},
 		&cli.BoolFlag{
 			Name:    flgEAB,

--- a/cmd/internal/hook/hook.go
+++ b/cmd/internal/hook/hook.go
@@ -87,7 +87,7 @@ func metaToEnv(meta map[string]string) []string {
 }
 
 // AddPathToMetadata adds information about the certificate to the metadata map.
-func AddPathToMetadata(meta map[string]string, domain string, certRes *certificate.Resource, certsStorage *storage.CertificatesStorage) {
+func AddPathToMetadata(meta map[string]string, domain string, certRes *certificate.Resource, certsStorage *storage.CertificatesStorage, options *storage.SaveOptions) {
 	meta[EnvCertDomain] = domain
 	meta[EnvCertPath] = certsStorage.GetFileName(domain, storage.ExtCert)
 	meta[EnvCertKeyPath] = certsStorage.GetFileName(domain, storage.ExtKey)
@@ -96,11 +96,11 @@ func AddPathToMetadata(meta map[string]string, domain string, certRes *certifica
 		meta[EnvIssuerCertKeyPath] = certsStorage.GetFileName(domain, storage.ExtIssuer)
 	}
 
-	if certsStorage.IsPEM() {
+	if options.PEM {
 		meta[EnvCertPEMPath] = certsStorage.GetFileName(domain, storage.ExtPEM)
 	}
 
-	if certsStorage.IsPFX() {
+	if options.PFX {
 		meta[EnvCertPFXPath] = certsStorage.GetFileName(domain, storage.ExtPFX)
 	}
 }

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -6,19 +6,27 @@ import (
 	"github.com/go-acme/lego/v5/registration"
 )
 
+const accountIDPlaceholder = "noemail@example.com"
+
 // Account represents a users local saved credentials.
 type Account struct {
+	ID           string                 `json:"id"`
 	Email        string                 `json:"email"`
 	Registration *registration.Resource `json:"registration"`
 
 	key crypto.PrivateKey
 }
 
-func NewAccount(email string, key crypto.PrivateKey) *Account {
-	return &Account{Email: email, key: key}
+func NewAccount(email, id string, key crypto.PrivateKey) *Account {
+	return &Account{Email: email, ID: id, key: key}
 }
 
 /** Implementation of the registration.User interface **/
+
+// GetID returns the effective account ID.
+func (a *Account) GetID() string {
+	return getEffectiveAccountID(a.Email, a.ID)
+}
 
 // GetEmail returns the email address for the account.
 func (a *Account) GetEmail() string {
@@ -33,4 +41,16 @@ func (a *Account) GetPrivateKey() crypto.PrivateKey {
 // GetRegistration returns the server registration.
 func (a *Account) GetRegistration() *registration.Resource {
 	return a.Registration
+}
+
+func getEffectiveAccountID(email, id string) string {
+	if id != "" {
+		return id
+	}
+
+	if email != "" {
+		return email
+	}
+
+	return accountIDPlaceholder
 }

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-acme/lego/v5/registration"
 )
 
-const accountIDPlaceholder = "noemail@example.com"
+const AccountIDPlaceholder = "noemail@example.com"
 
 // Account represents a users local saved credentials.
 type Account struct {
@@ -52,5 +52,5 @@ func getEffectiveAccountID(email, id string) string {
 		return email
 	}
 
-	return accountIDPlaceholder
+	return AccountIDPlaceholder
 }

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -23,6 +24,14 @@ const (
 	baseKeysFolderName         = "keys"
 	accountFileName            = "account.json"
 )
+
+type PrivateKeyNotFound struct {
+	AccountID string
+}
+
+func (e *PrivateKeyNotFound) Error() string {
+	return fmt.Sprintf("no private key found for account %q", e.AccountID)
+}
 
 type AccountsStorageConfig struct {
 	BasePath string
@@ -85,11 +94,17 @@ func NewAccountsStorage(config AccountsStorageConfig) (*AccountsStorage, error) 
 	}, nil
 }
 
+// GetRootPath returns the root path of the storage of the accounts.
 func (s *AccountsStorage) GetRootPath() string {
 	return s.rootPath
 }
 
+// Save saves the account to a file.
 func (s *AccountsStorage) Save(account *Account) error {
+	if account.ID == "" {
+		account.ID = account.GetID()
+	}
+
 	jsonBytes, err := json.MarshalIndent(account, "", "\t")
 	if err != nil {
 		return err
@@ -98,26 +113,33 @@ func (s *AccountsStorage) Save(account *Account) error {
 	return os.WriteFile(s.getAccountFilePath(account.GetID()), jsonBytes, filePerm)
 }
 
+// Get gets an account from a file or creates a new one (the account is not saved).
 func (s *AccountsStorage) Get(ctx context.Context, keyType certcrypto.KeyType, email, accountID string) (*Account, error) {
 	effectiveAccountID := getEffectiveAccountID(email, accountID)
 
 	if !s.existsAccountFile(effectiveAccountID) {
-		return s.newAccount(keyType, email, accountID)
+		return s.createAccount(keyType, email, accountID)
 	}
 
-	return s.readAccount(ctx, keyType, effectiveAccountID)
+	return s.getAccount(ctx, keyType, effectiveAccountID)
 }
 
-func (s *AccountsStorage) newAccount(keyType certcrypto.KeyType, email, accountID string) (*Account, error) {
-	privateKey, err := s.getPrivateKey(keyType, getEffectiveAccountID(email, accountID))
+// createAccount creates a new account.
+func (s *AccountsStorage) createAccount(keyType certcrypto.KeyType, email, accountID string) (*Account, error) {
+	effectiveAccountID := getEffectiveAccountID(email, accountID)
+
+	privateKey, err := s.createPrivateKey(keyType, effectiveAccountID)
 	if err != nil {
-		return nil, fmt.Errorf("get private key: %w", err)
+		return nil, err
 	}
 
-	return NewAccount(email, accountID, privateKey), nil
+	return NewAccount(email, effectiveAccountID, privateKey), nil
 }
 
-func (s *AccountsStorage) readAccount(ctx context.Context, keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
+// getAccount gets the account from a file.
+// It will also try to recover the registration if it's missing (and save the account file).
+// And it will also create a new private key if it doesn't exist (and save the private key file).
+func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
 	accountFilePath := s.getAccountFilePath(effectiveAccountID)
 
 	fileBytes, err := os.ReadFile(accountFilePath)
@@ -132,57 +154,96 @@ func (s *AccountsStorage) readAccount(ctx context.Context, keyType certcrypto.Ke
 		return nil, fmt.Errorf("could not parse the account file %s: %w", accountFilePath, err)
 	}
 
-	account.key, err = s.getPrivateKey(keyType, effectiveAccountID)
-	if err != nil {
-		return nil, fmt.Errorf("get private key: %w", err)
-	}
+	account.key, err = s.readPrivateKey(effectiveAccountID)
+	if err == nil {
+		if account.Registration != nil && account.Registration.Body.Status != "" {
+			return account, nil
+		}
 
-	if account.Registration == nil || account.Registration.Body.Status == "" {
-		reg, err := s.tryRecoverRegistration(ctx, account.key)
+		account.Registration, err = s.tryRecoverRegistration(ctx, account.key)
 		if err != nil {
 			return nil, fmt.Errorf("could not load the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
 		}
-
-		account.Registration = reg
 
 		err = s.Save(account)
 		if err != nil {
 			return nil, fmt.Errorf("could not save the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
 		}
+
+		return account, nil
+	}
+
+	var privateKeyNotFound *PrivateKeyNotFound
+
+	if !errors.As(err, &privateKeyNotFound) {
+		return nil, err
+	}
+
+	// TODO(ldez): debug level?
+	log.Info("No key found for the account. Generating a new private key.",
+		slog.String("accountID", effectiveAccountID),
+		slog.Any("keyType", keyType),
+	)
+
+	account.key, err = s.createPrivateKey(keyType, effectiveAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("new private key creation: %w", err)
 	}
 
 	return account, nil
 }
 
-func (s *AccountsStorage) getPrivateKey(keyType certcrypto.KeyType, accountID string) (crypto.PrivateKey, error) {
-	keysPath := s.getKeysPath(accountID)
+// createPrivateKey generates a new private key and saves it to a file.
+func (s *AccountsStorage) createPrivateKey(keyType certcrypto.KeyType, effectiveAccountID string) (crypto.PrivateKey, error) {
+	keysPath := s.getKeysPath(effectiveAccountID)
 
-	accKeyPath := filepath.Join(keysPath, accountID+".key")
+	accKeyPath := filepath.Join(keysPath, effectiveAccountID+".key")
 
-	if _, err := os.Stat(accKeyPath); os.IsNotExist(err) {
-		// TODO(ldez): debug level?
-		log.Info("No key found for the account. Generating a new private key.",
-			slog.String("accountID", accountID),
-			slog.Any("keyType", keyType),
-		)
-
-		err := CreateNonExistingFolder(keysPath)
-		if err != nil {
-			return nil, fmt.Errorf("could not check/create the directory %q for the account (accountID: %s): %w", keysPath, accountID, err)
-		}
-
-		privateKey, err := generatePrivateKey(accKeyPath, keyType)
-		if err != nil {
-			return nil, fmt.Errorf("could not generate the private account key (accountID: %s): %w", accountID, err)
-		}
-
-		// TODO(ldez): debug level?
-		log.Info("Saved key.", slog.String("filepath", accKeyPath))
-
-		return privateKey, nil
+	err := CreateNonExistingFolder(keysPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not check/create the directory %q for the account (accountID: %s): %w", keysPath, effectiveAccountID, err)
 	}
 
-	privateKey, err := LoadPrivateKey(accKeyPath)
+	privateKey, err := certcrypto.GeneratePrivateKey(keyType)
+	if err != nil {
+		return nil, fmt.Errorf("private key generation (accountID: %s): %w", effectiveAccountID, err)
+	}
+
+	certOut, err := os.Create(accKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("private key file creation: (accountID: %s): %w", effectiveAccountID, err)
+	}
+
+	defer func() {
+		_ = certOut.Close()
+
+		// TODO(ldez): debug level?
+		log.Info("Private key saved.", slog.String("filepath", accKeyPath))
+	}()
+
+	pemKey := certcrypto.PEMBlock(privateKey)
+
+	err = pem.Encode(certOut, pemKey)
+	if err != nil {
+		return nil, fmt.Errorf("private key PEM encoding: (accountID: %s): %w", effectiveAccountID, err)
+	}
+
+	return privateKey, nil
+}
+
+// readPrivateKey reads the private key from a file.
+func (s *AccountsStorage) readPrivateKey(effectiveAccountID string) (crypto.PrivateKey, error) {
+	keysPath := s.getKeysPath(effectiveAccountID)
+
+	accKeyPath := filepath.Join(keysPath, effectiveAccountID+".key")
+
+	if _, err := os.Stat(accKeyPath); os.IsNotExist(err) {
+		return nil, &PrivateKeyNotFound{AccountID: effectiveAccountID}
+	} else if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := ReadPrivateKeyFile(accKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not load the private key from the file %q: %w", accKeyPath, err)
 	}
@@ -190,6 +251,7 @@ func (s *AccountsStorage) getPrivateKey(keyType certcrypto.KeyType, accountID st
 	return privateKey, nil
 }
 
+// existsAccountFile checks if the account file exists.
 func (s *AccountsStorage) existsAccountFile(effectiveAccountID string) bool {
 	accountFilePath := s.getAccountFilePath(effectiveAccountID)
 
@@ -205,20 +267,24 @@ func (s *AccountsStorage) existsAccountFile(effectiveAccountID string) bool {
 	return true
 }
 
-func (s *AccountsStorage) getAccountFilePath(accountID string) string {
-	return filepath.Join(s.getRootUserPath(accountID), accountFileName)
+// getAccountFilePath returns the account file path.
+func (s *AccountsStorage) getAccountFilePath(effectiveAccountID string) string {
+	return filepath.Join(s.getRootUserPath(effectiveAccountID), accountFileName)
 }
 
-func (s *AccountsStorage) getKeysPath(accountID string) string {
-	return filepath.Join(s.getRootUserPath(accountID), baseKeysFolderName)
+// getKeysPath returns the path to the folder that contains the private keys for an account.
+func (s *AccountsStorage) getKeysPath(effectiveAccountID string) string {
+	return filepath.Join(s.getRootUserPath(effectiveAccountID), baseKeysFolderName)
 }
 
-func (s *AccountsStorage) getRootUserPath(accountID string) string {
+// getRootUserPath returns the path to the root folder for an account.
+func (s *AccountsStorage) getRootUserPath(effectiveAccountID string) string {
 	serverPath := strings.NewReplacer(":", "_", "/", string(os.PathSeparator)).Replace(s.server.Host)
 
-	return filepath.Join(s.rootPath, serverPath, accountID)
+	return filepath.Join(s.rootPath, serverPath, effectiveAccountID)
 }
 
+// tryRecoverRegistration tries to recover the registration from the private key.
 func (s *AccountsStorage) tryRecoverRegistration(ctx context.Context, privateKey crypto.PrivateKey) (*registration.Resource, error) {
 	// couldn't load account but got a key. Try to look the account up.
 	config := lego.NewConfig(&Account{key: privateKey})
@@ -238,35 +304,14 @@ func (s *AccountsStorage) tryRecoverRegistration(ctx context.Context, privateKey
 	return reg, nil
 }
 
-func LoadPrivateKey(file string) (crypto.PrivateKey, error) {
-	keyBytes, err := os.ReadFile(file)
+// ReadPrivateKeyFile reads a private key file.
+func ReadPrivateKeyFile(filename string) (crypto.PrivateKey, error) {
+	keyBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	privateKey, err := certcrypto.ParsePEMPrivateKey(keyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return privateKey, nil
-}
-
-func generatePrivateKey(file string, keyType certcrypto.KeyType) (crypto.PrivateKey, error) {
-	privateKey, err := certcrypto.GeneratePrivateKey(keyType)
-	if err != nil {
-		return nil, err
-	}
-
-	certOut, err := os.Create(file)
-	if err != nil {
-		return nil, err
-	}
-	defer certOut.Close()
-
-	pemKey := certcrypto.PEMBlock(privateKey)
-
-	err = pem.Encode(certOut, pemKey)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"crypto"
-	"crypto/rsa"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,43 +123,4 @@ func TestAccountsStorage_Get_existingAccount(t *testing.T) {
 	assert.Equal(t, expectedRegistration, account.GetRegistration())
 
 	assert.NotNil(t, account.GetPrivateKey())
-}
-
-func TestAccountsStorage_getPrivateKey(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		basePath string
-	}{
-		{
-			desc: "create a new private key",
-		},
-		{
-			desc:     "existing private key",
-			basePath: "testdata",
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.desc, func(t *testing.T) {
-			if test.basePath == "" {
-				test.basePath = t.TempDir()
-			}
-
-			storage, err := NewAccountsStorage(AccountsStorageConfig{
-				BasePath: test.basePath,
-			})
-			require.NoError(t, err)
-
-			accountID := "test@example.com"
-
-			expectedPath := filepath.Join(test.basePath, baseAccountsRootFolderName, accountID, baseKeysFolderName, "test@example.com.key")
-
-			privateKey, err := storage.getPrivateKey(certcrypto.RSA4096, accountID)
-			require.NoError(t, err)
-
-			assert.FileExists(t, expectedPath)
-
-			assert.IsType(t, &rsa.PrivateKey{}, privateKey)
-		})
-	}
 }

--- a/cmd/internal/storage/certificates.go
+++ b/cmd/internal/storage/certificates.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,22 +24,29 @@ const (
 )
 
 // CertificatesStorage a certificates' storage.
+//
+// rootPath:
+//
+//	./.lego/certificates/
+//	     │      └── root certificates directory
+//	     └── "path" option
+//
+// archivePath:
+//
+//	./.lego/archives/
+//	     │      └── archived certificates directory
+//	     └── "path" option
 type CertificatesStorage struct {
-	*CertificatesWriter
-	*CertificatesReader
+	rootPath    string
+	archivePath string
 }
 
 // NewCertificatesStorage create a new certificates storage.
-func NewCertificatesStorage(config CertificatesWriterConfig) (*CertificatesStorage, error) {
-	writer, err := NewCertificatesWriter(config)
-	if err != nil {
-		return nil, fmt.Errorf("certificates storage writer: %w", err)
-	}
-
+func NewCertificatesStorage(basePath string) *CertificatesStorage {
 	return &CertificatesStorage{
-		CertificatesWriter: writer,
-		CertificatesReader: NewCertificatesReader(config.BasePath),
-	}, nil
+		rootPath:    getCertificatesRootPath(basePath),
+		archivePath: getCertificatesArchivePath(basePath),
+	}
 }
 
 func CreateNonExistingFolder(path string) error {

--- a/cmd/internal/storage/certificates_reader.go
+++ b/cmd/internal/storage/certificates_reader.go
@@ -13,17 +13,7 @@ import (
 	"github.com/go-acme/lego/v5/log"
 )
 
-type CertificatesReader struct {
-	rootPath string
-}
-
-func NewCertificatesReader(basePath string) *CertificatesReader {
-	return &CertificatesReader{
-		rootPath: getCertificatesRootPath(basePath),
-	}
-}
-
-func (s *CertificatesReader) ReadResource(domain string) (certificate.Resource, error) {
+func (s *CertificatesStorage) ReadResource(domain string) (certificate.Resource, error) {
 	raw, err := s.ReadFile(domain, ExtResource)
 	if err != nil {
 		return certificate.Resource{}, fmt.Errorf("unable to load resource for domain %q: %w", domain, err)
@@ -37,7 +27,7 @@ func (s *CertificatesReader) ReadResource(domain string) (certificate.Resource, 
 	return resource, nil
 }
 
-func (s *CertificatesReader) ExistsFile(domain, extension string) bool {
+func (s *CertificatesStorage) ExistsFile(domain, extension string) bool {
 	filePath := s.GetFileName(domain, extension)
 
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
@@ -49,20 +39,20 @@ func (s *CertificatesReader) ExistsFile(domain, extension string) bool {
 	return true
 }
 
-func (s *CertificatesReader) ReadFile(domain, extension string) ([]byte, error) {
+func (s *CertificatesStorage) ReadFile(domain, extension string) ([]byte, error) {
 	return os.ReadFile(s.GetFileName(domain, extension))
 }
 
-func (s *CertificatesReader) GetRootPath() string {
+func (s *CertificatesStorage) GetRootPath() string {
 	return s.rootPath
 }
 
-func (s *CertificatesReader) GetFileName(domain, extension string) string {
+func (s *CertificatesStorage) GetFileName(domain, extension string) string {
 	filename := sanitizedDomain(domain) + extension
 	return filepath.Join(s.rootPath, filename)
 }
 
-func (s *CertificatesReader) ReadCertificate(domain, extension string) ([]*x509.Certificate, error) {
+func (s *CertificatesStorage) ReadCertificate(domain, extension string) ([]*x509.Certificate, error) {
 	content, err := s.ReadFile(domain, extension)
 	if err != nil {
 		return nil, err

--- a/cmd/internal/storage/certificates_reader_test.go
+++ b/cmd/internal/storage/certificates_reader_test.go
@@ -77,14 +77,6 @@ func TestCertificatesStorage_GetRootPath(t *testing.T) {
 	assert.Equal(t, expected, rootPath)
 }
 
-func TestCertificatesStorage_GetArchivePath(t *testing.T) {
-	basePath := t.TempDir()
-
-	writer := NewCertificatesStorage(basePath)
-
-	assert.Equal(t, filepath.Join(basePath, baseArchivesFolderName), writer.archivePath)
-}
-
 func TestCertificatesStorage_GetFileName(t *testing.T) {
 	testCases := []struct {
 		desc      string

--- a/cmd/internal/storage/certificates_reader_test.go
+++ b/cmd/internal/storage/certificates_reader_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCertificatesWriter_ReadResource(t *testing.T) {
-	reader := NewCertificatesReader("testdata")
+func TestCertificatesStorage_ReadResource(t *testing.T) {
+	reader := NewCertificatesStorage("testdata")
 
 	resource, err := reader.ReadResource("example.com")
 	require.NoError(t, err)
@@ -24,8 +24,8 @@ func TestNewCertificatesWriter_ReadResource(t *testing.T) {
 	assert.Equal(t, expected, resource)
 }
 
-func TestNewCertificatesWriter_ExistsFile(t *testing.T) {
-	reader := NewCertificatesReader("testdata")
+func TestCertificatesStorage_ExistsFile(t *testing.T) {
+	reader := NewCertificatesStorage("testdata")
 
 	testCases := []struct {
 		desc      string
@@ -56,8 +56,8 @@ func TestNewCertificatesWriter_ExistsFile(t *testing.T) {
 	}
 }
 
-func TestNewCertificatesWriter_ReadFile(t *testing.T) {
-	reader := NewCertificatesReader("testdata")
+func TestCertificatesStorage_ReadFile(t *testing.T) {
+	reader := NewCertificatesStorage("testdata")
 
 	data, err := reader.ReadFile("example.com", ExtResource)
 	assert.NoError(t, err)
@@ -65,10 +65,10 @@ func TestNewCertificatesWriter_ReadFile(t *testing.T) {
 	assert.NotEmpty(t, data)
 }
 
-func TestNewCertificatesWriter_GetRootPath(t *testing.T) {
+func TestCertificatesStorage_GetRootPath(t *testing.T) {
 	basePath := t.TempDir()
 
-	reader := NewCertificatesReader(basePath)
+	reader := NewCertificatesStorage(basePath)
 
 	rootPath := reader.GetRootPath()
 
@@ -77,7 +77,15 @@ func TestNewCertificatesWriter_GetRootPath(t *testing.T) {
 	assert.Equal(t, expected, rootPath)
 }
 
-func TestNewCertificatesWriter_GetFileName(t *testing.T) {
+func TestCertificatesStorage_GetArchivePath(t *testing.T) {
+	basePath := t.TempDir()
+
+	writer := NewCertificatesStorage(basePath)
+
+	assert.Equal(t, filepath.Join(basePath, baseArchivesFolderName), writer.archivePath)
+}
+
+func TestCertificatesStorage_GetFileName(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		domain    string
@@ -122,7 +130,7 @@ func TestNewCertificatesWriter_GetFileName(t *testing.T) {
 
 			basePath := t.TempDir()
 
-			reader := NewCertificatesReader(basePath)
+			reader := NewCertificatesStorage(basePath)
 
 			filename := reader.GetFileName(test.domain, test.extension)
 
@@ -133,8 +141,8 @@ func TestNewCertificatesWriter_GetFileName(t *testing.T) {
 	}
 }
 
-func TestNewCertificatesWriter_ReadCertificate(t *testing.T) {
-	reader := NewCertificatesReader("testdata")
+func TestCertificatesStorage_ReadCertificate(t *testing.T) {
+	reader := NewCertificatesStorage("testdata")
 
 	cert, err := reader.ReadCertificate("example.org", ExtCert)
 	assert.NoError(t, err)

--- a/cmd/internal/storage/testdata/account.json
+++ b/cmd/internal/storage/testdata/account.json
@@ -1,4 +1,5 @@
 {
+  "id": "test@example.com",
   "email": "account@example.com",
   "registration": {
     "body": {

--- a/cmd/internal/storage/testdata/accounts/test@example.com/account.json
+++ b/cmd/internal/storage/testdata/accounts/test@example.com/account.json
@@ -1,5 +1,6 @@
 {
-	"email": "test@example.com",
+	"id": "test@example.com",
+	"email": "account@example.com",
 	"registration": {
 		"body": {
 			"status": "valid"

--- a/cmd/storages.go
+++ b/cmd/storages.go
@@ -7,7 +7,6 @@ import (
 
 func newAccountsStorageConfig(cmd *cli.Command) storage.AccountsStorageConfig {
 	return storage.AccountsStorageConfig{
-		Email:     cmd.String(flgEmail),
 		BasePath:  cmd.String(flgPath),
 		Server:    cmd.String(flgServer),
 		UserAgent: getUserAgent(cmd),

--- a/cmd/storages.go
+++ b/cmd/storages.go
@@ -5,21 +5,20 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func newCertificatesWriterConfig(cmd *cli.Command) storage.CertificatesWriterConfig {
-	return storage.CertificatesWriterConfig{
-		BasePath:    cmd.String(flgPath),
-		PEM:         cmd.Bool(flgPEM),
-		PFX:         cmd.Bool(flgPFX),
-		PFXFormat:   cmd.String(flgPFXPass),
-		PFXPassword: cmd.String(flgPFXFormat),
-	}
-}
-
 func newAccountsStorageConfig(cmd *cli.Command) storage.AccountsStorageConfig {
 	return storage.AccountsStorageConfig{
 		Email:     cmd.String(flgEmail),
 		BasePath:  cmd.String(flgPath),
 		Server:    cmd.String(flgServer),
 		UserAgent: getUserAgent(cmd),
+	}
+}
+
+func newSaveOptions(cmd *cli.Command) *storage.SaveOptions {
+	return &storage.SaveOptions{
+		PEM:         cmd.Bool(flgPEM),
+		PFX:         cmd.Bool(flgPFX),
+		PFXFormat:   cmd.String(flgPFXPass),
+		PFXPassword: cmd.String(flgPFXFormat),
 	}
 }

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -36,6 +36,7 @@ OPTIONS:
    --domains string, -d string [ --domains string, -d string ]    Add a domain to the process. Can be specified multiple times or use comma as a separator.
    --accept-tos, -a                                               By setting this flag to true you indicate that you accept the current Let's Encrypt terms of service.
    --email string, -m string                                      Email used for registration and recovery contact. [$LEGO_EMAIL]
+   --account-id string, -a string                                 Account identifier (The email is used if there is account ID is undefined). [$LEGO_ACCOUNT_ID]
    --eab                                                          Use External Account Binding for account registration. Requires --kid and --hmac. [$LEGO_EAB]
    --kid string                                                   Key identifier from External CA. Used for External Account Binding. [$LEGO_EAB_KID]
    --hmac string                                                  MAC key from External CA. Should be in Base64 URL Encoding without padding format. Used for External Account Binding. [$LEGO_EAB_HMAC]
@@ -98,6 +99,7 @@ OPTIONS:
    --domains string, -d string [ --domains string, -d string ]    Add a domain to the process. Can be specified multiple times or use comma as a separator.
    --accept-tos, -a                                               By setting this flag to true you indicate that you accept the current Let's Encrypt terms of service.
    --email string, -m string                                      Email used for registration and recovery contact. [$LEGO_EMAIL]
+   --account-id string, -a string                                 Account identifier (The email is used if there is account ID is undefined). [$LEGO_ACCOUNT_ID]
    --eab                                                          Use External Account Binding for account registration. Requires --kid and --hmac. [$LEGO_EAB]
    --kid string                                                   Key identifier from External CA. Used for External Account Binding. [$LEGO_EAB_KID]
    --hmac string                                                  MAC key from External CA. Should be in Base64 URL Encoding without padding format. Used for External Account Binding. [$LEGO_EAB_HMAC]
@@ -163,9 +165,13 @@ USAGE:
    lego revoke
 
 OPTIONS:
+   --path string                                                Directory to use for storing the data. [$LEGO_PATH]
+   --keep, -k                                                   Keep the certificates after the revocation instead of archiving them.
+   --reason uint                                                Identifies the reason for the certificate revocation. See https://www.rfc-editor.org/rfc/rfc5280.html#section-5.3.1. Valid values are: 0 (unspecified), 1 (keyCompromise), 2 (cACompromise), 3 (affiliationChanged), 4 (superseded), 5 (cessationOfOperation), 6 (certificateHold), 8 (removeFromCRL), 9 (privilegeWithdrawn), or 10 (aACompromise). (default: 0)
    --domains string, -d string [ --domains string, -d string ]  Add a domain to the process. Can be specified multiple times or use comma as a separator.
    --accept-tos, -a                                             By setting this flag to true you indicate that you accept the current Let's Encrypt terms of service.
    --email string, -m string                                    Email used for registration and recovery contact. [$LEGO_EMAIL]
+   --account-id string, -a string                               Account identifier (The email is used if there is account ID is undefined). [$LEGO_ACCOUNT_ID]
    --eab                                                        Use External Account Binding for account registration. Requires --kid and --hmac. [$LEGO_EAB]
    --kid string                                                 Key identifier from External CA. Used for External Account Binding. [$LEGO_EAB_KID]
    --hmac string                                                MAC key from External CA. Should be in Base64 URL Encoding without padding format. Used for External Account Binding. [$LEGO_EAB_HMAC]
@@ -177,13 +183,6 @@ OPTIONS:
    --cert.timeout int                                           Set the certificate timeout value to a specific value in seconds. Only used when obtaining certificates. (default: 30)
    --overall-request-limit int                                  ACME overall requests limit. (default: 18)
    --user-agent string                                          Add to the user-agent sent to the CA to identify an application embedding lego-cli
-   --path string                                                Directory to use for storing the data. [$LEGO_PATH]
-   --pem                                                        Generate an additional .pem (base64) file by concatenating the .key and .crt files together.
-   --pfx                                                        Generate an additional .pfx (PKCS#12) file by concatenating the .key and .crt and issuer .crt files together. [$LEGO_PFX]
-   --pfx.pass string                                            The password used to encrypt the .pfx (PCKS#12) file. (default: "changeit") [$LEGO_PFX_PASSWORD]
-   --pfx.format string                                          The encoding format to use when encrypting the .pfx (PCKS#12) file. Supported: RC2, DES, SHA256. (default: "RC2") [$LEGO_PFX_FORMAT]
-   --keep, -k                                                   Keep the certificates after the revocation instead of archiving them.
-   --reason uint                                                Identifies the reason for the certificate revocation. See https://www.rfc-editor.org/rfc/rfc5280.html#section-5.3.1. Valid values are: 0 (unspecified), 1 (keyCompromise), 2 (cACompromise), 3 (affiliationChanged), 4 (superseded), 5 (cessationOfOperation), 6 (certificateHold), 8 (removeFromCRL), 9 (privilegeWithdrawn), or 10 (aACompromise). (default: 0)
    --help, -h                                                   show help
 """
 


### PR DESCRIPTION
### CertificatesStorage

The options related to PEM and PFX don't need to be passed to the constructor because only the `SaveResource` method needs them.

This allows the removal of these unused related flags for the `revoke` command, and some simplifications.

### AccountStorage

The email is removed from the AccountStorage constructor but passed to methods instead.

An account ID is added (and the flag `--account-id`) to override the email to save the account.

This allows using the same email for multiple private keys (ex: RSA and ECDSA).

Fixes #2793

Related to #838
Related to #346
Related to #2614