### PR TITLE
refactor: lazy setup of the client inside the renew command

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -54,10 +54,12 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
-	client, err := setupClient(cmd, account, keyType)
+	client, err := newClient(cmd, account, keyType)
 	if err != nil {
-		return fmt.Errorf("set up client: %w", err)
+		return fmt.Errorf("new client: %w", err)
 	}
+
+	setupChallenges(cmd, client)
 
 	if account.Registration == nil {
 		var reg *registration.Resource

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -22,18 +22,6 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// setupClient creates a new client with challenge settings.
-func setupClient(cmd *cli.Command, account registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
-	client, err := newClient(cmd, account, keyType)
-	if err != nil {
-		return nil, fmt.Errorf("new client: %w", err)
-	}
-
-	setupChallenges(cmd, client)
-
-	return client, nil
-}
-
 func newClient(cmd *cli.Command, account registration.User, keyType certcrypto.KeyType) (*lego.Client, error) {
 	client, err := lego.NewClient(newClientConfig(cmd, account, keyType))
 	if err != nil {


### PR DESCRIPTION
Instead of repeating the setup of the client inside the renew command, it can be done lazily when the client is needed and has only one setup.
