### PR TITLE
chore: use memcache Docker image directly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: go install github.com/letsencrypt/pebble/v2/cmd/pebble-challtestsrv@v2.9.0
 
       - name: Set up a Memcached server
-        uses: niden/actions-memcached@v7
+        run: docker run -d --rm -p 11211:11211 memcached:1.6-alpine
 
       - name: Make
         run: |


### PR DESCRIPTION
The action `niden/actions-memcached` only run a Docker image, so we don't need it.

https://github.com/niden/actions-memcached/blob/3b3ecd9d0d035ea92db716dc1540a7dbe9e56349/entrypoint.sh#L4

This fix the CI failure:
> docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.

https://github.com/go-acme/lego/actions/runs/21955281520/job/63417642065?pr=2845#step:10:12