### PR TITLE
feat: move enableCommonName option to Request

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -75,10 +75,11 @@ type ObtainRequest struct {
 	MustStaple     bool
 	EmailAddresses []string
 
-	NotBefore      time.Time
-	NotAfter       time.Time
-	Bundle         bool
-	PreferredChain string
+	NotBefore        time.Time
+	NotAfter         time.Time
+	Bundle           bool
+	PreferredChain   string
+	EnableCommonName bool
 
 	// A string uniquely identifying the profile
 	// which will be used to affect issuance of the certificate requested by this Order.
@@ -104,10 +105,11 @@ type ObtainForCSRRequest struct {
 
 	PrivateKey crypto.PrivateKey
 
-	NotBefore      time.Time
-	NotAfter       time.Time
-	Bundle         bool
-	PreferredChain string
+	NotBefore        time.Time
+	NotAfter         time.Time
+	Bundle           bool
+	PreferredChain   string
+	EnableCommonName bool
 
 	// A string uniquely identifying the profile
 	// which will be used to affect issuance of the certificate requested by this Order.
@@ -130,7 +132,6 @@ type CertifierOptions struct {
 	KeyType             certcrypto.KeyType
 	Timeout             time.Duration
 	OverallRequestLimit int
-	EnableCommonName    bool
 }
 
 // Certifier A service to obtain/renew/revoke certificates.
@@ -309,7 +310,7 @@ func (c *Certifier) getForOrder(ctx context.Context, domains []string, order acm
 	}
 
 	commonName := ""
-	if len(domains[0]) <= 64 && c.options.EnableCommonName {
+	if len(domains[0]) <= 64 && request.EnableCommonName {
 		commonName = domains[0]
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -46,7 +46,6 @@ func newClientConfig(cmd *cli.Command, account registration.User, keyType certcr
 		KeyType:             keyType,
 		Timeout:             time.Duration(cmd.Int(flgCertTimeout)) * time.Second,
 		OverallRequestLimit: cmd.Int(flgOverallRequestLimit),
-		EnableCommonName:    cmd.Bool(flgEnableCommonName),
 	}
 
 	if cmd.IsSet(flgHTTPTimeout) {
@@ -168,6 +167,7 @@ func newObtainRequest(cmd *cli.Command, domains []string) certificate.ObtainRequ
 		NotAfter:                       cmd.Timestamp(flgNotAfter),
 		Bundle:                         !cmd.Bool(flgNoBundle),
 		PreferredChain:                 cmd.String(flgPreferredChain),
+		EnableCommonName:               cmd.Bool(flgEnableCommonName),
 		Profile:                        cmd.String(flgProfile),
 		AlwaysDeactivateAuthorizations: cmd.Bool(flgAlwaysDeactivateAuthorizations),
 	}
@@ -180,6 +180,7 @@ func newObtainForCSRRequest(cmd *cli.Command, csr *x509.CertificateRequest) cert
 		NotAfter:                       cmd.Timestamp(flgNotAfter),
 		Bundle:                         !cmd.Bool(flgNoBundle),
 		PreferredChain:                 cmd.String(flgPreferredChain),
+		EnableCommonName:               cmd.Bool(flgEnableCommonName),
 		Profile:                        cmd.String(flgProfile),
 		AlwaysDeactivateAuthorizations: cmd.Bool(flgAlwaysDeactivateAuthorizations),
 	}

--- a/lego/client.go
+++ b/lego/client.go
@@ -58,7 +58,6 @@ func NewClient(config *Config) (*Client, error) {
 		KeyType:             config.Certificate.KeyType,
 		Timeout:             config.Certificate.Timeout,
 		OverallRequestLimit: config.Certificate.OverallRequestLimit,
-		EnableCommonName:    config.Certificate.EnableCommonName,
 	}
 
 	certifier := certificate.NewCertifier(core, prober, options)

--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -58,7 +58,6 @@ type CertificateConfig struct {
 	KeyType             certcrypto.KeyType
 	Timeout             time.Duration
 	OverallRequestLimit int
-	EnableCommonName    bool
 }
 
 // createDefaultHTTPClient Creates an HTTP client with a reasonable timeout value


### PR DESCRIPTION
This allows controlling this option per certificate.
