### PR TITLE
feat: handle account URI inside the challenge

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -16,11 +16,10 @@ func (a *AccountService) New(ctx context.Context, req acme.Account) (acme.Extend
 	var account acme.Account
 
 	resp, err := a.core.post(ctx, a.core.GetDirectory().NewAccountURL, req, &account)
+
 	location := getLocation(resp)
 
-	if location != "" {
-		a.core.jws.SetKid(location)
-	}
+	a.core.setKid(location)
 
 	if err != nil {
 		return acme.ExtendedAccount{Location: location}, err

--- a/acme/api/internal/secure/jws.go
+++ b/acme/api/internal/secure/jws.go
@@ -29,11 +29,6 @@ func NewJWS(privateKey crypto.PrivateKey, kid string, nonceManager *nonces.Manag
 	}
 }
 
-// SetKid Sets a key identifier.
-func (j *JWS) SetKid(kid string) {
-	j.kid = kid
-}
-
 // SignContent Signs a content with the JWS.
 func (j *JWS) SignContent(ctx context.Context, url string, content []byte) (*jose.JSONWebSignature, error) {
 	var alg jose.SignatureAlgorithm

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -121,12 +121,12 @@ func (c *Challenge) Solve(ctx context.Context, authz acme.Authorization) error {
 	time.Sleep(interval)
 
 	err = wait.For("propagation", timeout, interval, func() (bool, error) {
-		stop, errP := c.preCheck.call(ctx, domain, info.EffectiveFQDN, info.Value)
-		if !stop || errP != nil {
+		stop, callErr := c.preCheck.call(ctx, domain, info.EffectiveFQDN, info.Value)
+		if !stop || callErr != nil {
 			log.Info("dns01: waiting for record propagation.", log.DomainAttr(domain))
 		}
 
-		return stop, errP
+		return stop, callErr
 	})
 	if err != nil {
 		return err

--- a/challenge/dnspersist01/dns_persist_challenge_options.go
+++ b/challenge/dnspersist01/dns_persist_challenge_options.go
@@ -33,21 +33,6 @@ func CondOptions(condition bool, opt ...ChallengeOption) ChallengeOption {
 	}
 }
 
-// WithAccountURI sets the ACME account URI bound to dns-persist-01 records.
-// It is required both to construct the `accounturi=` parameter and
-// to match already-provisioned TXT records that should be updated.
-func WithAccountURI(accountURI string) ChallengeOption {
-	return func(chlg *Challenge) error {
-		if accountURI == "" {
-			return errors.New("ACME account URI cannot be empty")
-		}
-
-		chlg.accountURI = accountURI
-
-		return nil
-	}
-}
-
 // WithIssuerDomainName forces the issuer-domain-name used for dns-persist-01.
 // When set, it overrides automatic issuer selection and
 // must match one of the issuer-domain-names offered in the ACME challenge.

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -90,7 +90,7 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 			return nil, fmt.Errorf("new client: %w", err)
 		}
 
-		setupChallenges(cmd, client, account.GetRegistration())
+		setupChallenges(cmd, client)
 
 		return client, nil
 	})

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -75,7 +75,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf(rootPathWarningMessage, accountsStorage.GetRootPath())
 	}
 
-	setupChallenges(cmd, client, account.GetRegistration())
+	setupChallenges(cmd, client)
 
 	certRes, err := obtainCertificate(ctx, cmd, client)
 	if err != nil {

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/challenge/dns01"
 	"github.com/go-acme/lego/v5/challenge/dnspersist01"
@@ -23,7 +22,7 @@ import (
 )
 
 //nolint:gocyclo // challenge setup dispatch is expected to branch by enabled challenge type.
-func setupChallenges(cmd *cli.Command, client *lego.Client, account *acme.ExtendedAccount) {
+func setupChallenges(cmd *cli.Command, client *lego.Client) {
 	if !cmd.Bool(flgHTTP) && !cmd.Bool(flgTLS) && !cmd.IsSet(flgDNS) && !cmd.Bool(flgDNSPersist) {
 		log.Fatal(fmt.Sprintf("No challenge selected. You must specify at least one challenge: `--%s`, `--%s`, `--%s`, `--%s`.",
 			flgHTTP, flgTLS, flgDNS, flgDNSPersist))
@@ -51,7 +50,7 @@ func setupChallenges(cmd *cli.Command, client *lego.Client, account *acme.Extend
 	}
 
 	if cmd.Bool(flgDNSPersist) {
-		err := setupDNSPersist(cmd, client, account)
+		err := setupDNSPersist(cmd, client)
 		if err != nil {
 			log.Fatal("Could not set DNS-PERSIST-01 challenge provider.", log.ErrorAttr(err))
 		}
@@ -212,7 +211,7 @@ func setupDNS(cmd *cli.Command, client *lego.Client) error {
 	return err
 }
 
-func setupDNSPersist(cmd *cli.Command, client *lego.Client, account *acme.ExtendedAccount) error {
+func setupDNSPersist(cmd *cli.Command, client *lego.Client) error {
 	err := validatePropagationExclusiveOptions(cmd, flgDNSPersistPropagationWait, flgDNSPersistPropagationDisableANS, flgDNSPersistIssuerDomainName)
 	if err != nil {
 		return err
@@ -231,7 +230,6 @@ func setupDNSPersist(cmd *cli.Command, client *lego.Client, account *acme.Extend
 	shouldWait := cmd.IsSet(flgDNSPersistPropagationWait)
 
 	return client.Challenge.SetDNSPersist01(
-		dnspersist01.WithAccountURI(account.Location),
 		dnspersist01.WithIssuerDomainName(cmd.String(flgDNSPersistIssuerDomainName)),
 		dnspersist01.CondOptions(cmd.IsSet(flgDNSPersistPersistUntil),
 			dnspersist01.WithPersistUntil(cmd.Timestamp(flgDNSPersistPersistUntil)),

--- a/e2e/dnschallenge/dns_persist_challenges_test.go
+++ b/e2e/dnschallenge/dns_persist_challenges_test.go
@@ -64,7 +64,6 @@ func TestChallengeDNSPersist_Client_Obtain(t *testing.T) {
 	mockDefaultPersist(t)
 
 	err = client.Challenge.SetDNSPersist01(
-		dnspersist01.WithAccountURI(reg.Location),
 		dnspersist01.DisableAuthoritativeNssPropagationRequirement(),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Instead of creating the challenge a with the account URI (account/registration), the account URI is get from the `core` KID.