### PR TITLE
conoha,conohav3: remove get token from the constructor

### DIFF
--- a/providers/dns/conoha/conoha.go
+++ b/providers/dns/conoha/conoha.go
@@ -59,8 +59,9 @@ func NewDefaultConfig() *Config {
 
 // DNSProvider implements the challenge.Provider interface.
 type DNSProvider struct {
-	config *Config
-	client *internal.Client
+	config     *Config
+	client     *internal.Client
+	identifier *internal.Identifier
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for ConoHa DNS.
@@ -101,20 +102,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	identifier.HTTPClient = clientdebug.Wrap(identifier.HTTPClient)
 
-	auth := internal.Auth{
-		TenantID: config.TenantID,
-		PasswordCredentials: internal.PasswordCredentials{
-			Username: config.Username,
-			Password: config.Password,
-		},
-	}
-
-	tokens, err := identifier.GetToken(context.TODO(), auth)
-	if err != nil {
-		return nil, fmt.Errorf("conoha: failed to log in: %w", err)
-	}
-
-	client, err := internal.NewClient(config.Region, tokens.Access.Token.ID)
+	client, err := internal.NewClient(config.Region)
 	if err != nil {
 		return nil, fmt.Errorf("conoha: failed to create client: %w", err)
 	}
@@ -125,19 +113,30 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client.HTTPClient = clientdebug.Wrap(client.HTTPClient)
 
-	return &DNSProvider{config: config, client: client}, nil
+	return &DNSProvider{
+		config:     config,
+		client:     client,
+		identifier: identifier,
+	}, nil
 }
 
 // Present creates a TXT record to fulfill the dns-01 challenge.
 func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string) error {
-	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+	tok, err := d.getToken(ctx)
+	if err != nil {
+		return fmt.Errorf("conoha: failed to log in: %w", err)
+	}
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	ctxAuth := internal.WithContext(ctx, tok)
+
+	info := dns01.GetChallengeInfo(ctxAuth, domain, keyAuth)
+
+	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctxAuth, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("conoha: could not find zone for domain %q: %w", domain, err)
 	}
 
-	id, err := d.client.GetDomainID(ctx, authZone)
+	id, err := d.client.GetDomainID(ctxAuth, authZone)
 	if err != nil {
 		return fmt.Errorf("conoha: failed to get domain ID: %w", err)
 	}
@@ -149,7 +148,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		TTL:  d.config.TTL,
 	}
 
-	err = d.client.CreateRecord(ctx, id, record)
+	err = d.client.CreateRecord(ctxAuth, id, record)
 	if err != nil {
 		return fmt.Errorf("conoha: failed to create record: %w", err)
 	}
@@ -159,24 +158,31 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 
 // CleanUp clears ConoHa DNS TXT record.
 func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
-	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+	tok, err := d.getToken(ctx)
+	if err != nil {
+		return fmt.Errorf("conoha: failed to log in: %w", err)
+	}
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	ctxAuth := internal.WithContext(ctx, tok)
+
+	info := dns01.GetChallengeInfo(ctxAuth, domain, keyAuth)
+
+	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctxAuth, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("conoha: could not find zone for domain %q: %w", domain, err)
 	}
 
-	domID, err := d.client.GetDomainID(ctx, authZone)
+	domID, err := d.client.GetDomainID(ctxAuth, authZone)
 	if err != nil {
 		return fmt.Errorf("conoha: failed to get domain ID: %w", err)
 	}
 
-	recID, err := d.client.GetRecordID(ctx, domID, info.EffectiveFQDN, "TXT", info.Value)
+	recID, err := d.client.GetRecordID(ctxAuth, domID, info.EffectiveFQDN, "TXT", info.Value)
 	if err != nil {
 		return fmt.Errorf("conoha: failed to get record ID: %w", err)
 	}
 
-	err = d.client.DeleteRecord(ctx, domID, recID)
+	err = d.client.DeleteRecord(ctxAuth, domID, recID)
 	if err != nil {
 		return fmt.Errorf("conoha: failed to delete record: %w", err)
 	}
@@ -188,4 +194,21 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 // Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+func (d *DNSProvider) getToken(ctx context.Context) (string, error) {
+	auth := internal.Auth{
+		TenantID: d.config.TenantID,
+		PasswordCredentials: internal.PasswordCredentials{
+			Username: d.config.Username,
+			Password: d.config.Password,
+		},
+	}
+
+	tokens, err := d.identifier.GetToken(ctx, auth)
+	if err != nil {
+		return "", fmt.Errorf("get token: %w", err)
+	}
+
+	return tokens.Access.Token.ID, nil
 }

--- a/providers/dns/conoha/conoha_test.go
+++ b/providers/dns/conoha/conoha_test.go
@@ -23,13 +23,12 @@ func TestNewDNSProvider(t *testing.T) {
 		expected string
 	}{
 		{
-			desc: "complete credentials, but login failed",
+			desc: "complete credentials",
 			envVars: map[string]string{
 				EnvTenantID:    "tenant_id",
 				EnvAPIUsername: "api_username",
 				EnvAPIPassword: "api_password",
 			},
-			expected: `conoha: failed to log in: unexpected status code: [status code: 401] body: {"unauthorized":{"message":"Invalid user: api_username","code":401}}`,
 		},
 		{
 			desc: "missing credentials",
@@ -99,8 +98,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		password string
 	}{
 		{
-			desc:     "complete credentials, but login failed",
-			expected: `conoha: failed to log in: unexpected status code: [status code: 401] body: {"unauthorized":{"message":"Invalid user: api_username","code":401}}`,
+			desc:     "complete credentials",
 			tenant:   "tenant_id",
 			username: "api_username",
 			password: "api_password",

--- a/providers/dns/conoha/internal/client.go
+++ b/providers/dns/conoha/internal/client.go
@@ -18,21 +18,18 @@ const dnsServiceBaseURL = "https://dns-service.%s.conoha.io"
 
 // Client is a ConoHa API client.
 type Client struct {
-	token string
-
 	baseURL    *url.URL
 	HTTPClient *http.Client
 }
 
 // NewClient returns a client instance logged into the ConoHa service.
-func NewClient(region, token string) (*Client, error) {
+func NewClient(region string) (*Client, error) {
 	baseURL, err := url.Parse(fmt.Sprintf(dnsServiceBaseURL, region))
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		token:      token,
 		baseURL:    baseURL,
 		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}, nil
@@ -147,10 +144,6 @@ func (c *Client) DeleteRecord(ctx context.Context, domainID, recordID string) er
 }
 
 func (c *Client) do(req *http.Request, result any) error {
-	if c.token != "" {
-		req.Header.Set("X-Auth-Token", c.token)
-	}
-
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return errutils.NewHTTPDoError(req, err)
@@ -192,6 +185,11 @@ func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, paylo
 	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), buf)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	tok := getToken(ctx)
+	if tok != "" {
+		req.Header.Set("X-Auth-Token", tok)
 	}
 
 	req.Header.Set("Accept", "application/json")

--- a/providers/dns/conoha/internal/client_test.go
+++ b/providers/dns/conoha/internal/client_test.go
@@ -19,7 +19,7 @@ import (
 func mockBuilder() *servermock.Builder[*Client] {
 	return servermock.NewBuilder[*Client](
 		func(server *httptest.Server) (*Client, error) {
-			client, err := NewClient("tyo1", "secret")
+			client, err := NewClient("tyo1")
 			if err != nil {
 				return nil, err
 			}
@@ -71,7 +71,9 @@ func TestClient_GetDomainID(t *testing.T) {
 				Route("GET /v1/domains", servermock.ResponseFromFixture(test.response)).
 				Build(t)
 
-			domainID, err := client.GetDomainID(t.Context(), test.domainName)
+			ctx := WithContext(t.Context(), "secret")
+
+			domainID, err := client.GetDomainID(ctx, test.domainName)
 
 			if test.expected.error {
 				require.Error(t, err)
@@ -141,7 +143,9 @@ func TestClient_CreateRecord(t *testing.T) {
 				TTL:  300,
 			}
 
-			err := client.CreateRecord(t.Context(), domainID, record)
+			ctx := WithContext(t.Context(), "secret")
+
+			err := client.CreateRecord(ctx, domainID, record)
 			test.assert(t, err)
 		})
 	}
@@ -153,7 +157,9 @@ func TestClient_GetRecordID(t *testing.T) {
 			servermock.ResponseFromFixture("domains-records_GET.json")).
 		Build(t)
 
-	recordID, err := client.GetRecordID(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
+	ctx := WithContext(t.Context(), "secret")
+
+	recordID, err := client.GetRecordID(ctx, "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
 	require.NoError(t, err)
 
 	assert.Equal(t, "2e32e609-3a4f-45ba-bdef-e50eacd345ad", recordID)
@@ -165,6 +171,8 @@ func TestClient_DeleteRecord(t *testing.T) {
 			servermock.ResponseFromFixture("domains-records_GET.json")).
 		Build(t)
 
-	err := client.DeleteRecord(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
+	ctx := WithContext(t.Context(), "secret")
+
+	err := client.DeleteRecord(ctx, "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
 	require.NoError(t, err)
 }

--- a/providers/dns/conoha/internal/identity.go
+++ b/providers/dns/conoha/internal/identity.go
@@ -14,6 +14,10 @@ import (
 
 const identityBaseURL = "https://identity.%s.conoha.io"
 
+type token string
+
+const tokenKey token = "token"
+
 type Identifier struct {
 	baseURL    *url.URL
 	HTTPClient *http.Client
@@ -79,4 +83,17 @@ func (c *Identifier) do(req *http.Request, result any) error {
 	}
 
 	return nil
+}
+
+func WithContext(ctx context.Context, credential string) context.Context {
+	return context.WithValue(ctx, tokenKey, credential)
+}
+
+func getToken(ctx context.Context) string {
+	credential, ok := ctx.Value(tokenKey).(string)
+	if !ok {
+		return ""
+	}
+
+	return credential
 }

--- a/providers/dns/conohav3/conohav3.go
+++ b/providers/dns/conohav3/conohav3.go
@@ -59,8 +59,9 @@ func NewDefaultConfig() *Config {
 
 // DNSProvider implements the challenge.Provider interface.
 type DNSProvider struct {
-	config *Config
-	client *internal.Client
+	config     *Config
+	client     *internal.Client
+	identifier *internal.Identifier
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for ConoHa DNS.
@@ -101,29 +102,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	identifier.HTTPClient = clientdebug.Wrap(identifier.HTTPClient)
 
-	auth := internal.Auth{
-		Identity: internal.Identity{
-			Methods: []string{"password"},
-			Password: internal.Password{
-				User: internal.User{
-					ID:       config.UserID,
-					Password: config.Password,
-				},
-			},
-		},
-		Scope: internal.Scope{
-			Project: internal.Project{
-				ID: config.TenantID,
-			},
-		},
-	}
-
-	token, err := identifier.GetToken(context.Background(), auth)
-	if err != nil {
-		return nil, fmt.Errorf("conohav3: failed to log in: %w", err)
-	}
-
-	client, err := internal.NewClient(config.Region, token)
+	client, err := internal.NewClient(config.Region)
 	if err != nil {
 		return nil, fmt.Errorf("conohav3: failed to create client: %w", err)
 	}
@@ -134,19 +113,30 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 
 	client.HTTPClient = clientdebug.Wrap(client.HTTPClient)
 
-	return &DNSProvider{config: config, client: client}, nil
+	return &DNSProvider{
+		config:     config,
+		client:     client,
+		identifier: identifier,
+	}, nil
 }
 
 // Present creates a TXT record to fulfill the dns-01 challenge.
 func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string) error {
-	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+	tok, err := d.getToken(ctx)
+	if err != nil {
+		return fmt.Errorf("conohav3: failed to log in: %w", err)
+	}
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	ctxAuth := internal.WithContext(ctx, tok)
+
+	info := dns01.GetChallengeInfo(ctxAuth, domain, keyAuth)
+
+	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctxAuth, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("conohav3: could not find zone for domain %q: %w", domain, err)
 	}
 
-	id, err := d.client.GetDomainID(ctx, authZone)
+	id, err := d.client.GetDomainID(ctxAuth, authZone)
 	if err != nil {
 		return fmt.Errorf("conohav3: failed to get domain ID: %w", err)
 	}
@@ -158,7 +148,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		TTL:  d.config.TTL,
 	}
 
-	err = d.client.CreateRecord(ctx, id, record)
+	err = d.client.CreateRecord(ctxAuth, id, record)
 	if err != nil {
 		return fmt.Errorf("conohav3: failed to create record: %w", err)
 	}
@@ -168,24 +158,31 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 
 // CleanUp clears ConoHa DNS TXT record.
 func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
-	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+	tok, err := d.getToken(ctx)
+	if err != nil {
+		return fmt.Errorf("conohav3: failed to log in: %w", err)
+	}
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	ctxAuth := internal.WithContext(ctx, tok)
+
+	info := dns01.GetChallengeInfo(ctxAuth, domain, keyAuth)
+
+	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctxAuth, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("conohav3: could not find zone for domain %q: %w", domain, err)
 	}
 
-	domID, err := d.client.GetDomainID(ctx, authZone)
+	domID, err := d.client.GetDomainID(ctxAuth, authZone)
 	if err != nil {
 		return fmt.Errorf("conohav3: failed to get domain ID: %w", err)
 	}
 
-	recID, err := d.client.GetRecordID(ctx, domID, info.EffectiveFQDN, "TXT", info.Value)
+	recID, err := d.client.GetRecordID(ctxAuth, domID, info.EffectiveFQDN, "TXT", info.Value)
 	if err != nil {
 		return fmt.Errorf("conohav3: failed to get record ID: %w", err)
 	}
 
-	err = d.client.DeleteRecord(ctx, domID, recID)
+	err = d.client.DeleteRecord(ctxAuth, domID, recID)
 	if err != nil {
 		return fmt.Errorf("conohav3: failed to delete record: %w", err)
 	}
@@ -196,4 +193,30 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 // Timeout returns the timeout and interval to use when checking for DNS propagation.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+func (d *DNSProvider) getToken(ctx context.Context) (string, error) {
+	auth := internal.Auth{
+		Identity: internal.Identity{
+			Methods: []string{"password"},
+			Password: internal.Password{
+				User: internal.User{
+					ID:       d.config.UserID,
+					Password: d.config.Password,
+				},
+			},
+		},
+		Scope: internal.Scope{
+			Project: internal.Project{
+				ID: d.config.TenantID,
+			},
+		},
+	}
+
+	tok, err := d.identifier.GetToken(ctx, auth)
+	if err != nil {
+		return "", fmt.Errorf("get token: %w", err)
+	}
+
+	return tok, nil
 }

--- a/providers/dns/conohav3/conohav3_test.go
+++ b/providers/dns/conohav3/conohav3_test.go
@@ -23,13 +23,12 @@ func TestNewDNSProvider(t *testing.T) {
 		expected string
 	}{
 		{
-			desc: "complete credentials, but login failed",
+			desc: "complete credentials",
 			envVars: map[string]string{
 				EnvTenantID:    "tenant_id",
 				EnvAPIUserID:   "api_user_id",
 				EnvAPIPassword: "api_password",
 			},
-			expected: `conohav3: failed to log in: unexpected status code: [status code: 400] body: {"code": 400, "error": "user does not exist"}`,
 		},
 		{
 			desc: "missing credentials",
@@ -99,8 +98,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 		password string
 	}{
 		{
-			desc:     "complete credentials, but login failed",
-			expected: `conohav3: failed to log in: unexpected status code: [status code: 400] body: {"code": 400, "error": "user does not exist"}`,
+			desc:     "complete credentials",
 			tenant:   "tenant_id",
 			userid:   "api_user_id",
 			password: "api_password",

--- a/providers/dns/conohav3/internal/client.go
+++ b/providers/dns/conohav3/internal/client.go
@@ -18,21 +18,18 @@ const dnsServiceBaseURL = "https://dns-service.%s.conoha.io"
 
 // Client is a ConoHa API client.
 type Client struct {
-	token string
-
 	baseURL    *url.URL
 	HTTPClient *http.Client
 }
 
 // NewClient returns a client instance logged into the ConoHa service.
-func NewClient(region, token string) (*Client, error) {
+func NewClient(region string) (*Client, error) {
 	baseURL, err := url.Parse(fmt.Sprintf(dnsServiceBaseURL, region))
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		token:      token,
 		baseURL:    baseURL,
 		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}, nil
@@ -147,10 +144,6 @@ func (c *Client) DeleteRecord(ctx context.Context, domainID, recordID string) er
 }
 
 func (c *Client) do(req *http.Request, result any) error {
-	if c.token != "" {
-		req.Header.Set("X-Auth-Token", c.token)
-	}
-
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return errutils.NewHTTPDoError(req, err)
@@ -192,6 +185,11 @@ func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, paylo
 	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), buf)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	tok := getToken(ctx)
+	if tok != "" {
+		req.Header.Set("X-Auth-Token", tok)
 	}
 
 	req.Header.Set("Accept", "application/json")

--- a/providers/dns/conohav3/internal/client_test.go
+++ b/providers/dns/conohav3/internal/client_test.go
@@ -19,7 +19,7 @@ import (
 func mockBuilder() *servermock.Builder[*Client] {
 	return servermock.NewBuilder[*Client](
 		func(server *httptest.Server) (*Client, error) {
-			client, err := NewClient("c3j1", "secret")
+			client, err := NewClient("c3j1")
 			if err != nil {
 				return nil, err
 			}
@@ -72,7 +72,9 @@ func TestClient_GetDomainID(t *testing.T) {
 				Route("GET /v1/domains", servermock.ResponseFromFixture(test.response)).
 				Build(t)
 
-			domainID, err := client.GetDomainID(t.Context(), test.domainName)
+			ctx := WithContext(t.Context(), "secret")
+
+			domainID, err := client.GetDomainID(ctx, test.domainName)
 
 			if test.expected.error {
 				require.Error(t, err)
@@ -133,6 +135,8 @@ func TestClient_CreateRecord(t *testing.T) {
 				Route("POST /v1/domains/lego/records", test.handler).
 				Build(t)
 
+			ctx := WithContext(t.Context(), "secret")
+
 			domainID := "lego"
 
 			record := Record{
@@ -142,7 +146,7 @@ func TestClient_CreateRecord(t *testing.T) {
 				TTL:  300,
 			}
 
-			err := client.CreateRecord(t.Context(), domainID, record)
+			err := client.CreateRecord(ctx, domainID, record)
 			test.assert(t, err)
 		})
 	}
@@ -154,7 +158,9 @@ func TestClient_GetRecordID(t *testing.T) {
 			servermock.ResponseFromFixture("domains-records_GET.json")).
 		Build(t)
 
-	recordID, err := client.GetRecordID(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
+	ctx := WithContext(t.Context(), "secret")
+
+	recordID, err := client.GetRecordID(ctx, "89acac79-38e7-497d-807c-a011e1310438", "www.example.com.", "A", "15.185.172.153")
 	require.NoError(t, err)
 
 	assert.Equal(t, "2e32e609-3a4f-45ba-bdef-e50eacd345ad", recordID)
@@ -166,6 +172,8 @@ func TestClient_DeleteRecord(t *testing.T) {
 			servermock.ResponseFromFixture("domains-records_GET.json")).
 		Build(t)
 
-	err := client.DeleteRecord(t.Context(), "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
+	ctx := WithContext(t.Context(), "secret")
+
+	err := client.DeleteRecord(ctx, "89acac79-38e7-497d-807c-a011e1310438", "2e32e609-3a4f-45ba-bdef-e50eacd345ad")
 	require.NoError(t, err)
 }

--- a/providers/dns/conohav3/internal/identity.go
+++ b/providers/dns/conohav3/internal/identity.go
@@ -16,6 +16,10 @@ import (
 
 const identityBaseURL = "https://identity.%s.conoha.io"
 
+type token string
+
+const tokenKey token = "token"
+
 type Identifier struct {
 	baseURL    *url.URL
 	HTTPClient *http.Client
@@ -68,4 +72,17 @@ func (c *Identifier) do(req *http.Request) (string, error) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return token, nil
+}
+
+func WithContext(ctx context.Context, credential string) context.Context {
+	return context.WithValue(ctx, tokenKey, credential)
+}
+
+func getToken(ctx context.Context) string {
+	credential, ok := ctx.Value(tokenKey).(string)
+	if !ok {
+		return ""
+	}
+
+	return credential
 }


### PR DESCRIPTION
Move the call to get the token outside the provider constructors.