### PR TITLE
Add --no-solver flag for pre-authorized domains (EAB with out-of-band DCV)

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -24,6 +24,7 @@ const (
 	flgKeyType                  = "key-type"
 	flgFilename                 = "filename"
 	flgPath                     = "path"
+	flgNoSolver                 = "no-solver"
 	flgHTTP                     = "http"
 	flgHTTPPort                 = "http.port"
 	flgHTTPDelay                = "http.delay"
@@ -128,6 +129,10 @@ func CreateFlags(defaultPath string) []cli.Flag {
 			EnvVars: []string{envPath},
 			Usage:   "Directory to use for storing the data.",
 			Value:   defaultPath,
+		},
+		&cli.BoolFlag{
+			Name:  flgNoSolver,
+			Usage: "Disable the challenge solver. Cannot be mixed with other challenge types. Must be used together with `--eab`.",
 		},
 		&cli.BoolFlag{
 			Name:  flgHTTP,

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -20,8 +20,13 @@ import (
 )
 
 func setupChallenges(ctx *cli.Context, client *lego.Client) {
-	if !ctx.Bool(flgHTTP) && !ctx.Bool(flgTLS) && !ctx.IsSet(flgDNS) {
-		log.Fatalf("No challenge selected. You must specify at least one challenge: `--%s`, `--%s`, `--%s`.", flgHTTP, flgTLS, flgDNS)
+	if !ctx.Bool(flgHTTP) && !ctx.Bool(flgTLS) && !ctx.IsSet(flgDNS) && !ctx.Bool(flgNoSolver) {
+		log.Fatalf("No challenge selected. You must specify at least one challenge: `--%s`, `--%s`, `--%s`, `--%s`.", flgHTTP, flgTLS, flgDNS, flgNoSolver)
+	}
+
+	if ctx.Bool(flgNoSolver) {
+		setupNoSolver(ctx, client)
+		return
 	}
 
 	if ctx.Bool(flgHTTP) {
@@ -181,3 +186,29 @@ func checkPropagationExclusiveOptions(ctx *cli.Context) error {
 func isSetBool(ctx *cli.Context, name string) bool {
 	return ctx.IsSet(name) && ctx.Bool(name)
 }
+
+func setupNoSolver(ctx *cli.Context, client *lego.Client) {
+	if !ctx.Bool(flgEAB) {
+		log.Fatalf("The `--%s` flag requires `--%s`. It should only be used when the ACME server pre-authorizes domains via EAB.", flgNoSolver, flgEAB)
+	}
+
+	err := client.Challenge.SetHTTP01Provider(&noopProvider{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = client.Challenge.SetTLSALPN01Provider(&noopProvider{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = client.Challenge.SetDNS01Provider(&noopProvider{})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+type noopProvider struct{}
+
+func (n *noopProvider) Present(domain, token, keyAuth string) error { return nil }
+func (n *noopProvider) CleanUp(domain, token, keyAuth string) error { return nil }

--- a/docs/content/usage/cli/Obtain-a-Certificate.md
+++ b/docs/content/usage/cli/Obtain-a-Certificate.md
@@ -104,6 +104,28 @@ You should be able to run an existing webserver on port 80 and have lego write t
 lego --accept-tos --email you@example.com --http --http.webroot /path/to/webroot --domains example.com run
 ```
 
+## Using no challenge solver
+
+Some ACME servers (such as enterprise/private CAs and managed PKI platforms using EAB) pre-authorize domains out-of-band.
+Means no challenge validation is required to obtain a certificate.
+In this scenario, using `--no-solver` skips challenge setup entirely:
+
+```bash
+lego \
+  --accept-tos \
+  --email you@example.com \
+  --server https://acme-eab.example.com/directory \
+  --eab \
+  --kid "$ACME_KEY_ID" \
+  --hmac "$ACME_KEY" \
+  --no-solver \
+  --domains example.com \
+  run
+```
+
+Only use `--no-solver` together with `--eab` when your ACME server pre-authorizes domains and does not require challenge validation.
+If your ACME server does require challenge validation, the certificate request will fail.
+
 ## Running a script afterward
 
 You can easily hook into the certificate-obtaining process by providing the path to a script:

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -31,6 +31,7 @@ GLOBAL OPTIONS:
    --key-type value, -k value                                   Key type to use for private keys. Supported: rsa2048, rsa3072, rsa4096, rsa8192, ec256, ec384. (default: "ec256")
    --filename value                                             (deprecated) Filename of the generated certificate.
    --path value                                                 Directory to use for storing the data. (default: "./.lego") [$LEGO_PATH]
+   --no-solver                                                  Disable the challenge solver, if you not require challenge validation. Cannot be mixed with other challenge types. Must be used together with --eab. (default: false)
    --http                                                       Use the HTTP-01 challenge to solve challenges. Can be mixed with other types of challenges. (default: false)
    --http.port value                                            Set the port and interface to use for HTTP-01 based challenges to listen on. Supported: interface:port or :port. (default: ":80")
    --http.delay value                                           Delay between the starts of the HTTP server (use for HTTP-01 based challenges) and the validation of the challenge. (default: 0s)


### PR DESCRIPTION
- Implementation proposal for https://github.com/go-acme/lego/issues/2916
- My motivation for this PR is simple: 😅 I'm tired of having to keep explaining that the managed PKI platform used ([HydrantID](https://help.hydrantid.com/build/Roles/requestor/domains.html) in our case) doesn't require challenges to be solved, when requesting certificates via ACME-EAB. As the allowed domains are already DCV validated.
- This is my first contribution here, and I am not a go expert. (e.g. review careful in case this feature request is accepted)
---

Some ACME servers (enterprise/private CAs, managed PKI platforms when using EAB) pre-authorize domains out-of-band and return authorizations as already valid — means no challenge solving needed when requesting a certificate.
[RFC 8555 §7.4.1](https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.1) explicitly permits this. 

**Add a `--no-solver` flag, to handle EAB with out-of-band DCV:**

- `cmd/flags.go`: 
  - add `--no-solver` bool flag. Cannot be combined with other challenge flags, requires `--eab`.
- `cmd/setup_challenges.go`:
  - Add `--no-solver` to "no challenge selected" guard.
  - Add `setupNoSolver` helper - not touching `setupChallenges` to keep complexity low.
  - `setupNoSolver` enforces `--eab` co-requirement, registers a no-op provider for all three challenge types (HTTP-01, TLS-ALPN-01, DNS-01) and returns early.
- `docs/content/usage/cli/Obtain-a-Certificate.md`:
  - Add new section documenting usage with `--eab` example.

--- 

The usage tests I made below.
(real domain replaced with `example.com`, sensitive data `<redacted>`)

```bash
./dist/lego --version
lego version a37ad6d526c6360f0d7ee35cfec05dab1bead5ee darwin/arm64
```

```bash

./dist/lego \
  --server "$ACME_URL" \
  --email "$ACME_EMAIL_ADDRESS" \
  --accept-tos \
  --eab --kid "$ACME_KEY_ID" --hmac "$ACME_KEY" \
  --domains example.com \
  --no-solver \
  run
  
2026/03/18 21:17:40 No key found for account <redacted>. Generating a P256 key.
2026/03/18 21:17:40 Saved key to <redacted>.key
2026/03/18 21:17:40 [INFO] acme: Registering account for <redacted>
!!!! HEADS UP !!!!

Your account credentials have been saved in your
configuration directory at "<redacted>/.lego/accounts".

You should make a secure backup of this folder now. This
configuration directory will also contain private keys
generated by lego and certificates obtained from the ACME
server. Making regular backups of this folder is ideal.
2026/03/18 21:17:41 [INFO] [example.com] acme: Obtaining bundled SAN certificate
2026/03/18 21:17:44 [INFO] [example.com] AuthURL: https://acm.hydrantid.com:443/acme/<redacted>/authz/<redacted>
2026/03/18 21:17:44 [INFO] [example.com] acme: use http-01 solver
2026/03/18 21:17:44 [INFO] [example.com] acme: Trying to solve HTTP-01
2026/03/18 21:17:50 [INFO] [example.com] The server validated our request
2026/03/18 21:17:50 [INFO] [example.com] acme: Validations succeeded; requesting certificates
2026/03/18 21:17:52 [INFO] Wait for certificate [timeout: 30s, interval: 500ms]
2026/03/18 21:18:02 [INFO] [example.com] Server responded with a certificate.
```