### PR TITLE
fix: migration without email

### DIFF
--- a/cmd/internal/migrate/accounts.go
+++ b/cmd/internal/migrate/accounts.go
@@ -55,6 +55,10 @@ func Accounts(root string) error {
 			},
 		}
 
+		if account.ID == "" {
+			account.ID = filepath.Base(filepath.Dir(srcAccountFilePath))
+		}
+
 		accountsDir := filepath.Dir(srcAccountFilePath)
 
 		srcKeyPath := filepath.Join(accountsDir, "keys", account.GetID()+storage.ExtKey)


### PR DESCRIPTION
When the account is migrated, and the email is not set, the account ID must be created with name of the folder (the default account placeholder).
