### PR TITLE
refactor: remove dependency on the ACME client from the account storage.

### DIFF
--- a/cmd/cmd_register.go
+++ b/cmd/cmd_register.go
@@ -39,12 +39,29 @@ func register(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
+	account, err := accountsStorage.Get(keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
-	if account.Registration == nil {
+	if account.NeedsRecovery {
+		client, err := newClient(cmd, account)
+		if err != nil {
+			return fmt.Errorf("new client: %w", err)
+		}
+
+		reg, err := client.Registration.ResolveAccountByKey(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve account by key: %w", err)
+		}
+
+		account.Registration = reg
+
+		err = accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	} else if account.Registration == nil || account.Registration.Status == "" {
 		client, err := newClient(cmd, account)
 		if err != nil {
 			return fmt.Errorf("new client: %w", err)

--- a/cmd/cmd_register.go
+++ b/cmd/cmd_register.go
@@ -56,7 +56,7 @@ func register(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		account.Registration = reg
-		if err = accountsStorage.Save(keyType, account); err != nil {
+		if err = accountsStorage.Save(account); err != nil {
 			return fmt.Errorf("could not save the account file: %w", err)
 		}
 

--- a/cmd/cmd_register.go
+++ b/cmd/cmd_register.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
@@ -44,10 +45,23 @@ func register(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
+	lazyClient := sync.OnceValues(func() (*lego.Client, error) {
+		return newClient(cmd, account)
+	})
+
+	err = handleRegistration(ctx, cmd, lazyClient, accountsStorage, account, true)
+	if err != nil {
+		return fmt.Errorf("registration: %w", err)
+	}
+
+	return nil
+}
+
+func handleRegistration(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, accountsStorage *storage.AccountsStorage, account *storage.Account, allowRegister bool) error {
 	if account.NeedsRecovery {
-		client, err := newClient(cmd, account)
+		client, err := lazyClient()
 		if err != nil {
-			return fmt.Errorf("new client: %w", err)
+			return fmt.Errorf("set up client: %w", err)
 		}
 
 		reg, err := client.Registration.ResolveAccountByKey(ctx)
@@ -61,25 +75,34 @@ func register(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return fmt.Errorf("could not save the account file: %w", err)
 		}
-	} else if account.Registration == nil || account.Registration.Status == "" {
-		client, err := newClient(cmd, account)
-		if err != nil {
-			return fmt.Errorf("new client: %w", err)
-		}
 
-		reg, err := registerAccount(ctx, cmd, client)
-		if err != nil {
-			return fmt.Errorf("could not complete registration: %w", err)
-		}
+		return nil
+	}
 
-		account.Registration = reg
-		if err = accountsStorage.Save(account); err != nil {
-			return fmt.Errorf("could not save the account file: %w", err)
-		}
+	if allowRegister {
+		if account.Registration == nil {
+			client, err := lazyClient()
+			if err != nil {
+				return fmt.Errorf("set up client: %w", err)
+			}
 
-		log.Warnf(log.LazySprintf(storage.RootPathWarningMessage, accountsStorage.GetRootPath()))
-	} else {
-		log.Info("Account already registered, skipping.")
+			reg, err := registerAccount(ctx, cmd, client)
+			if err != nil {
+				return fmt.Errorf("could not complete registration: %w", err)
+			}
+
+			account.Registration = reg
+
+			if err = accountsStorage.Save(account); err != nil {
+				return fmt.Errorf("could not save the account file: %w", err)
+			}
+
+			log.Warnf(log.LazySprintf(storage.RootPathWarningMessage, accountsStorage.GetRootPath()))
+		} else {
+			log.Debug("Account already registered, skipping.", slog.String("account", account.GetID()))
+		}
+	} else if account.Registration == nil {
+		return fmt.Errorf("the account %s is not registered", account.GetID())
 	}
 
 	return nil

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -28,8 +28,6 @@ import (
 
 const noDays = -math.MaxInt
 
-type lzSetUp func() (*lego.Client, error)
-
 func createRenew() *cli.Command {
 	return &cli.Command{
 		Name:   "renew",
@@ -51,16 +49,10 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
+	account, err := accountsStorage.Get(keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
-
-	if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.GetID())
-	}
-
-	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))
 
 	lazyClient := sync.OnceValues(func() (*lego.Client, error) {
 		client, err := newClient(cmd, account)
@@ -75,6 +67,29 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 
 		return client, nil
 	})
+
+	if account.NeedsRecovery {
+		client, err := lazyClient()
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
+
+		reg, err := client.Registration.ResolveAccountByKey(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve account by key: %w", err)
+		}
+
+		account.Registration = reg
+
+		err = accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	} else if account.Registration == nil {
+		return fmt.Errorf("the account %s is not registered", account.GetID())
+	}
+
+	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))
 
 	hookManager := newHookManager(cmd, certsStorage, account)
 

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -55,38 +55,22 @@ func renew(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	lazyClient := sync.OnceValues(func() (*lego.Client, error) {
-		client, err := newClient(cmd, account)
-		if err != nil {
-			return nil, fmt.Errorf("new client: %w", err)
+		client, errC := newClient(cmd, account)
+		if errC != nil {
+			return nil, fmt.Errorf("new client: %w", errC)
 		}
 
-		err = setupChallenges(cmd, client)
-		if err != nil {
-			return nil, fmt.Errorf("setup challenges: %w", err)
+		errC = setupChallenges(cmd, client)
+		if errC != nil {
+			return nil, fmt.Errorf("setup challenges: %w", errC)
 		}
 
 		return client, nil
 	})
 
-	if account.NeedsRecovery {
-		client, err := lazyClient()
-		if err != nil {
-			return fmt.Errorf("set up client: %w", err)
-		}
-
-		reg, err := client.Registration.ResolveAccountByKey(ctx)
-		if err != nil {
-			return fmt.Errorf("resolve account by key: %w", err)
-		}
-
-		account.Registration = reg
-
-		err = accountsStorage.Save(account)
-		if err != nil {
-			return fmt.Errorf("could not save the account file: %w", err)
-		}
-	} else if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.GetID())
+	err = handleRegistration(ctx, cmd, lazyClient, accountsStorage, account, false)
+	if err != nil {
+		return fmt.Errorf("registration: %w", err)
 	}
 
 	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
@@ -37,25 +38,18 @@ func revoke(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("set up account: %w", err)
 	}
 
-	client, err := newClient(cmd, account)
+	lazyClient := sync.OnceValues(func() (*lego.Client, error) {
+		return newClient(cmd, account)
+	})
+
+	err = handleRegistration(ctx, cmd, lazyClient, accountsStorage, account, false)
 	if err != nil {
-		return fmt.Errorf("new client: %w", err)
+		return fmt.Errorf("registration: %w", err)
 	}
 
-	if account.NeedsRecovery {
-		reg, err := client.Registration.ResolveAccountByKey(ctx)
-		if err != nil {
-			return fmt.Errorf("resolve account by key: %w", err)
-		}
-
-		account.Registration = reg
-
-		err = accountsStorage.Save(account)
-		if err != nil {
-			return fmt.Errorf("could not save the account file: %w", err)
-		}
-	} else if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.GetID())
+	client, err := lazyClient()
+	if err != nil {
+		return fmt.Errorf("new client: %w", err)
 	}
 
 	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))

--- a/cmd/cmd_revoke.go
+++ b/cmd/cmd_revoke.go
@@ -32,18 +32,30 @@ func revoke(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
+	account, err := accountsStorage.Get(keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
-	}
-
-	if account.Registration == nil {
-		return fmt.Errorf("the account %s is not registered", account.GetID())
 	}
 
 	client, err := newClient(cmd, account)
 	if err != nil {
 		return fmt.Errorf("new client: %w", err)
+	}
+
+	if account.NeedsRecovery {
+		reg, err := client.Registration.ResolveAccountByKey(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve account by key: %w", err)
+		}
+
+		account.Registration = reg
+
+		err = accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	} else if account.Registration == nil {
+		return fmt.Errorf("the account %s is not registered", account.GetID())
 	}
 
 	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -36,7 +36,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("accounts storage initialization: %w", err)
 	}
 
-	account, err := accountsStorage.Get(ctx, keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
+	account, err := accountsStorage.Get(keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
 	}
@@ -50,7 +50,21 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("new client: %w", err)
 	}
 
-	if account.Registration == nil {
+	if account.NeedsRecovery {
+		var reg *acme.ExtendedAccount
+
+		reg, err = client.Registration.ResolveAccountByKey(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve account by key: %w", err)
+		}
+
+		account.Registration = reg
+
+		err = accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	} else if account.Registration == nil {
 		var reg *acme.ExtendedAccount
 
 		reg, err = registerAccount(ctx, cmd, client)

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -59,7 +59,8 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		account.Registration = reg
-		if err = accountsStorage.Save(keyType, account); err != nil {
+
+		if err = accountsStorage.Save(account); err != nil {
 			return fmt.Errorf("could not save the account file: %w", err)
 		}
 

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -3,15 +3,14 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sync"
 
-	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
-	"github.com/go-acme/lego/v5/log"
 	"github.com/urfave/cli/v3"
 )
 
@@ -45,40 +44,18 @@ func run(ctx context.Context, cmd *cli.Command) error {
 
 	hookManager := newHookManager(cmd, certsStorage, account)
 
-	client, err := newClient(cmd, account)
+	lazyClient := sync.OnceValues(func() (*lego.Client, error) {
+		return newClient(cmd, account)
+	})
+
+	err = handleRegistration(ctx, cmd, lazyClient, accountsStorage, account, true)
 	if err != nil {
-		return fmt.Errorf("new client: %w", err)
+		return fmt.Errorf("registration: %w", err)
 	}
 
-	if account.NeedsRecovery {
-		var reg *acme.ExtendedAccount
-
-		reg, err = client.Registration.ResolveAccountByKey(ctx)
-		if err != nil {
-			return fmt.Errorf("resolve account by key: %w", err)
-		}
-
-		account.Registration = reg
-
-		err = accountsStorage.Save(account)
-		if err != nil {
-			return fmt.Errorf("could not save the account file: %w", err)
-		}
-	} else if account.Registration == nil {
-		var reg *acme.ExtendedAccount
-
-		reg, err = registerAccount(ctx, cmd, client)
-		if err != nil {
-			return fmt.Errorf("could not complete registration: %w", err)
-		}
-
-		account.Registration = reg
-
-		if err = accountsStorage.Save(account); err != nil {
-			return fmt.Errorf("could not save the account file: %w", err)
-		}
-
-		log.Warnf(log.LazySprintf(storage.RootPathWarningMessage, accountsStorage.GetRootPath()))
+	client, err := lazyClient()
+	if err != nil {
+		return fmt.Errorf("new client: %w", err)
 	}
 
 	err = setupChallenges(cmd, client)

--- a/cmd/internal/root/process_obtain.go
+++ b/cmd/internal/root/process_obtain.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/cmd/internal"
@@ -40,7 +39,7 @@ func obtain(ctx context.Context, cfg *configuration.Configuration) error {
 			return err
 		}
 
-		account, err := accountsStorage.Get(ctx, keyType, accountConfig.Email, accountID)
+		account, err := accountsStorage.Get(keyType, accountConfig.Email, accountID)
 		if err != nil {
 			return err
 		}
@@ -58,22 +57,38 @@ func obtain(ctx context.Context, cfg *configuration.Configuration) error {
 			return client, nil
 		})
 
-		if account.Registration == nil {
+		if account.NeedsRecovery {
 			client, errC := lazyClient()
 			if errC != nil {
 				return fmt.Errorf("set up client: %w", errC)
 			}
 
-			var reg *acme.ExtendedAccount
+			reg, errC := client.Registration.ResolveAccountByKey(ctx)
+			if errC != nil {
+				return fmt.Errorf("resolve account by key: %w", errC)
+			}
 
-			reg, errC = registerAccount(ctx, client, accountConfig)
+			account.Registration = reg
+
+			errC = accountsStorage.Save(account)
+			if errC != nil {
+				return fmt.Errorf("could not save the account file: %w", errC)
+			}
+		} else if account.Registration == nil || account.Registration.Status == "" {
+			client, errC := lazyClient()
+			if errC != nil {
+				return fmt.Errorf("set up client: %w", errC)
+			}
+
+			reg, errC := registerAccount(ctx, client, accountConfig)
 			if errC != nil {
 				return fmt.Errorf("could not complete registration: %w", errC)
 			}
 
 			account.Registration = reg
 
-			if errC = accountsStorage.Save(account); errC != nil {
+			errC = accountsStorage.Save(account)
+			if errC != nil {
 				return fmt.Errorf("could not save the account file: %w", errC)
 			}
 

--- a/cmd/internal/root/process_obtain.go
+++ b/cmd/internal/root/process_obtain.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
-	"github.com/go-acme/lego/v5/log"
 	"github.com/go-acme/lego/v5/registration"
 )
 
@@ -57,42 +56,9 @@ func obtain(ctx context.Context, cfg *configuration.Configuration) error {
 			return client, nil
 		})
 
-		if account.NeedsRecovery {
-			client, errC := lazyClient()
-			if errC != nil {
-				return fmt.Errorf("set up client: %w", errC)
-			}
-
-			reg, errC := client.Registration.ResolveAccountByKey(ctx)
-			if errC != nil {
-				return fmt.Errorf("resolve account by key: %w", errC)
-			}
-
-			account.Registration = reg
-
-			errC = accountsStorage.Save(account)
-			if errC != nil {
-				return fmt.Errorf("could not save the account file: %w", errC)
-			}
-		} else if account.Registration == nil || account.Registration.Status == "" {
-			client, errC := lazyClient()
-			if errC != nil {
-				return fmt.Errorf("set up client: %w", errC)
-			}
-
-			reg, errC := registerAccount(ctx, client, accountConfig)
-			if errC != nil {
-				return fmt.Errorf("could not complete registration: %w", errC)
-			}
-
-			account.Registration = reg
-
-			errC = accountsStorage.Save(account)
-			if errC != nil {
-				return fmt.Errorf("could not save the account file: %w", errC)
-			}
-
-			log.Warnf(log.LazySprintf(storage.RootPathWarningMessage, accountsStorage.GetRootPath()))
+		err = handleRegistration(ctx, lazyClient, accountConfig, accountsStorage, account)
+		if err != nil {
+			return fmt.Errorf("registration: %w", err)
 		}
 
 		certsStorage := storage.NewCertificatesStorage(cfg.Storage)

--- a/cmd/internal/root/process_obtain.go
+++ b/cmd/internal/root/process_obtain.go
@@ -73,7 +73,7 @@ func obtain(ctx context.Context, cfg *configuration.Configuration) error {
 
 			account.Registration = reg
 
-			if errC = accountsStorage.Save(keyType, account); errC != nil {
+			if errC = accountsStorage.Save(account); errC != nil {
 				return fmt.Errorf("could not save the account file: %w", errC)
 			}
 

--- a/cmd/internal/root/process_register.go
+++ b/cmd/internal/root/process_register.go
@@ -11,11 +11,59 @@ import (
 
 	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 	"github.com/go-acme/lego/v5/registration"
 	"github.com/go-acme/lego/v5/registration/zerossl"
 )
+
+func handleRegistration(ctx context.Context, lazyClient lzSetUp, accountConfig *configuration.Account, accountsStorage *storage.AccountsStorage, account *storage.Account) error {
+	if account.NeedsRecovery {
+		client, err := lazyClient()
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
+
+		reg, err := client.Registration.ResolveAccountByKey(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve account by key: %w", err)
+		}
+
+		account.Registration = reg
+
+		err = accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+
+		return nil
+	}
+
+	if account.Registration == nil {
+		client, err := lazyClient()
+		if err != nil {
+			return fmt.Errorf("set up client: %w", err)
+		}
+
+		reg, err := registerAccount(ctx, client, accountConfig)
+		if err != nil {
+			return fmt.Errorf("could not complete registration: %w", err)
+		}
+
+		account.Registration = reg
+
+		if err = accountsStorage.Save(account); err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+
+		log.Warnf(log.LazySprintf(storage.RootPathWarningMessage, accountsStorage.GetRootPath()))
+	} else {
+		log.Debug("Account already registered, skipping.", slog.String("account", account.GetID()))
+	}
+
+	return nil
+}
 
 func registerAccount(ctx context.Context, client *lego.Client, accountConfig *configuration.Account) (*acme.ExtendedAccount, error) {
 	accepted := handleTOS(client, accountConfig)

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -10,10 +10,11 @@ import (
 
 // Account represents a users local saved credentials.
 type Account struct {
-	ID           string                `json:"id"`
-	Email        string                `json:"email"`
-	KeyType      certcrypto.KeyType    `json:"keyType"`
-	Registration *acme.ExtendedAccount `json:"registration"`
+	ID            string                `json:"id"`
+	Email         string                `json:"email"`
+	KeyType       certcrypto.KeyType    `json:"keyType"`
+	Registration  *acme.ExtendedAccount `json:"registration"`
+	NeedsRecovery bool                  `json:"-"`
 
 	key crypto.Signer
 }

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -18,10 +18,6 @@ type Account struct {
 	key crypto.Signer
 }
 
-func NewAccount(email, id string, keyType certcrypto.KeyType, key crypto.Signer) *Account {
-	return &Account{Email: email, ID: id, KeyType: keyType, key: key}
-}
-
 /** Implementation of the registration.User interface **/
 
 // GetID returns the effective account ID.

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -181,39 +181,39 @@ func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.Key
 	}
 
 	account.key, err = s.readPrivateKey(keyType, effectiveAccountID)
-	if err == nil {
-		if account.Registration != nil && account.Registration.Status != "" {
-			return account, nil
+	if err != nil {
+		var privateKeyNotFound *PrivateKeyNotFound
+
+		if !errors.As(err, &privateKeyNotFound) {
+			return nil, err
 		}
 
-		account.Registration, err = s.tryRecoverRegistration(ctx, account.key)
-		if err != nil {
-			return nil, fmt.Errorf("could not load the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
-		}
+		// TODO(ldez): debug level?
+		log.Info("No key found for the account. Generating a new private key.",
+			slog.String("accountID", effectiveAccountID),
+			slog.Any("keyType", keyType),
+		)
 
-		err = s.Save(keyType, account)
+		account.key, err = s.createPrivateKey(keyType, effectiveAccountID)
 		if err != nil {
-			return nil, fmt.Errorf("could not save the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
+			return nil, fmt.Errorf("new private key creation: %w", err)
 		}
 
 		return account, nil
 	}
 
-	var privateKeyNotFound *PrivateKeyNotFound
-
-	if !errors.As(err, &privateKeyNotFound) {
-		return nil, err
+	if account.Registration != nil && account.Registration.Status != "" {
+		return account, nil
 	}
 
-	// TODO(ldez): debug level?
-	log.Info("No key found for the account. Generating a new private key.",
-		slog.String("accountID", effectiveAccountID),
-		slog.Any("keyType", keyType),
-	)
-
-	account.key, err = s.createPrivateKey(keyType, effectiveAccountID)
+	account.Registration, err = s.tryRecoverRegistration(ctx, account.key)
 	if err != nil {
-		return nil, fmt.Errorf("new private key creation: %w", err)
+		return nil, fmt.Errorf("could not load the account file, registration cannot be resolved on the server (accountID: %s): %w", effectiveAccountID, err)
+	}
+
+	err = s.Save(keyType, account)
+	if err != nil {
+		return nil, fmt.Errorf("could not save the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
 	}
 
 	return account, nil

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -154,7 +154,12 @@ func (s *AccountsStorage) createAccount(keyType certcrypto.KeyType, email, accou
 		return nil, err
 	}
 
-	return NewAccount(email, effectiveAccountID, keyType, privateKey), nil
+	return &Account{
+		ID:      effectiveAccountID,
+		Email:   email,
+		KeyType: keyType,
+		key:     privateKey,
+	}, nil
 }
 
 // getAccount gets the account from a file.

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -111,7 +111,7 @@ func (s *AccountsStorage) GetRootPath() string {
 }
 
 // Save saves the account to a file (only the JSON file).
-func (s *AccountsStorage) Save(keyType certcrypto.KeyType, account *Account) error {
+func (s *AccountsStorage) Save(account *Account) error {
 	if account.ID == "" {
 		account.ID = account.GetID()
 	}
@@ -121,7 +121,7 @@ func (s *AccountsStorage) Save(keyType certcrypto.KeyType, account *Account) err
 		return err
 	}
 
-	return os.WriteFile(s.getAccountFilePath(keyType, account.GetID()), jsonBytes, filePerm)
+	return os.WriteFile(s.getAccountFilePath(account.GetKeyType(), account.GetID()), jsonBytes, filePerm)
 }
 
 // Get gets an account from a file or creates a new one (the files are saved).
@@ -134,7 +134,7 @@ func (s *AccountsStorage) Get(ctx context.Context, keyType certcrypto.KeyType, e
 			return nil, err
 		}
 
-		err = s.Save(keyType, account)
+		err = s.Save(account)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +211,7 @@ func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.Key
 		return nil, fmt.Errorf("could not load the account file, registration cannot be resolved on the server (accountID: %s): %w", effectiveAccountID, err)
 	}
 
-	err = s.Save(keyType, account)
+	err = s.Save(account)
 	if err != nil {
 		return nil, fmt.Errorf("could not save the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
 	}

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"crypto"
 	"encoding/json"
 	"encoding/pem"
@@ -13,9 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
-	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 )
 
@@ -46,8 +43,7 @@ func (e *PrivateKeyNotFound) Error() string {
 type AccountsStorageConfig struct {
 	BasePath string
 
-	Server    string
-	UserAgent string
+	Server string
 }
 
 // AccountsStorage A storage for account data.
@@ -87,8 +83,7 @@ type AccountsStorageConfig struct {
 type AccountsStorage struct {
 	rootPath string
 
-	server    *url.URL
-	userAgent string
+	server *url.URL
 }
 
 // NewAccountsStorage Creates a new AccountsStorage.
@@ -99,9 +94,8 @@ func NewAccountsStorage(config AccountsStorageConfig) (*AccountsStorage, error) 
 	}
 
 	return &AccountsStorage{
-		rootPath:  filepath.Join(config.BasePath, baseAccountsRootFolderName),
-		server:    serverURL,
-		userAgent: config.UserAgent,
+		rootPath: filepath.Join(config.BasePath, baseAccountsRootFolderName),
+		server:   serverURL,
 	}, nil
 }
 
@@ -125,7 +119,7 @@ func (s *AccountsStorage) Save(account *Account) error {
 }
 
 // Get gets an account from a file or creates a new one (the files are saved).
-func (s *AccountsStorage) Get(ctx context.Context, keyType certcrypto.KeyType, email, accountID string) (*Account, error) {
+func (s *AccountsStorage) Get(keyType certcrypto.KeyType, email, accountID string) (*Account, error) {
 	effectiveAccountID := getEffectiveAccountID(email, accountID)
 
 	if !s.existsAccountFile(keyType, effectiveAccountID) {
@@ -142,7 +136,7 @@ func (s *AccountsStorage) Get(ctx context.Context, keyType certcrypto.KeyType, e
 		return account, nil
 	}
 
-	return s.getAccount(ctx, keyType, effectiveAccountID)
+	return s.getAccount(keyType, effectiveAccountID)
 }
 
 // createAccount creates a new account.
@@ -163,9 +157,9 @@ func (s *AccountsStorage) createAccount(keyType certcrypto.KeyType, email, accou
 }
 
 // getAccount gets the account from a file.
-// It will also try to recover the registration if it's missing (and save the account file).
+// It will flag the account as needing recovery if the registration is missing.
 // And it will also create a new private key if it doesn't exist (and save the private key file).
-func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
+func (s *AccountsStorage) getAccount(keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
 	accountFilePath := s.getAccountFilePath(keyType, effectiveAccountID)
 
 	fileBytes, err := os.ReadFile(accountFilePath)
@@ -202,6 +196,11 @@ func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.Key
 			return nil, fmt.Errorf("new private key creation: %w", err)
 		}
 
+		err := s.Save(account)
+		if err != nil {
+			return nil, fmt.Errorf("could not save the account file: %w", err)
+		}
+
 		return account, nil
 	}
 
@@ -209,15 +208,8 @@ func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.Key
 		return account, nil
 	}
 
-	account.Registration, err = s.tryRecoverRegistration(ctx, account.key)
-	if err != nil {
-		return nil, fmt.Errorf("could not load the account file, registration cannot be resolved on the server (accountID: %s): %w", effectiveAccountID, err)
-	}
-
-	err = s.Save(account)
-	if err != nil {
-		return nil, fmt.Errorf("could not save the account file, registration is nil (accountID: %s): %w", effectiveAccountID, err)
-	}
+	// The registration is missing, but there is an existing private key, so the account needs recovery.
+	account.NeedsRecovery = true
 
 	return account, nil
 }
@@ -309,26 +301,6 @@ func (s *AccountsStorage) getKeyPath(keyType certcrypto.KeyType, effectiveAccoun
 // getRootUserPath returns the path to the root folder for an account.
 func (s *AccountsStorage) getRootUserPath(effectiveAccountID string) string {
 	return filepath.Join(s.rootPath, sanitizeHost(s.server), effectiveAccountID)
-}
-
-// tryRecoverRegistration tries to recover the registration from the private key.
-func (s *AccountsStorage) tryRecoverRegistration(ctx context.Context, privateKey crypto.Signer) (*acme.ExtendedAccount, error) {
-	// couldn't load account but got a key. Try to look the account up.
-	config := lego.NewConfig(&Account{key: privateKey})
-	config.CADirURL = s.server.String()
-	config.UserAgent = s.userAgent
-
-	client, err := lego.NewClient(config)
-	if err != nil {
-		return nil, err
-	}
-
-	reg, err := client.Registration.ResolveAccountByKey(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return reg, nil
 }
 
 func sanitizeHost(uri *url.URL) string {

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -194,6 +194,9 @@ func (s *AccountsStorage) getAccount(ctx context.Context, keyType certcrypto.Key
 			slog.Any("keyType", keyType),
 		)
 
+		// The private key was regenerated, so the registration is no longer valid.
+		account.Registration = nil
+
 		account.key, err = s.createPrivateKey(keyType, effectiveAccountID)
 		if err != nil {
 			return nil, fmt.Errorf("new private key creation: %w", err)

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -90,7 +90,7 @@ func TestAccountsStorage_Get_newAccount(t *testing.T) {
 	email := "test@example.com"
 	keyType := certcrypto.RSA4096
 
-	account, err := storage.Get(t.Context(), keyType, email, "")
+	account, err := storage.Get(keyType, email, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "test@example.com", account.GetEmail())
@@ -110,7 +110,7 @@ func TestAccountsStorage_Get_existingAccount(t *testing.T) {
 
 	accountID := "test@example.com"
 
-	account, err := storage.Get(t.Context(), certcrypto.RSA4096, "", accountID)
+	account, err := storage.Get(certcrypto.RSA4096, "", accountID)
 	require.NoError(t, err)
 
 	assert.Equal(t, "account@example.com", account.GetEmail())

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -66,7 +66,7 @@ func TestAccountsStorage_Save(t *testing.T) {
 	err = os.MkdirAll(filepath.Dir(accountFilePath), 0o755)
 	require.NoError(t, err)
 
-	err = storage.Save(keyType, account)
+	err = storage.Save(account)
 	require.NoError(t, err)
 
 	require.FileExists(t, accountFilePath)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -20,6 +20,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+type lzSetUp func() (*lego.Client, error)
+
 func newClient(cmd *cli.Command, account registration.User) (*lego.Client, error) {
 	client, err := lego.NewClient(newClientConfig(cmd, account))
 	if err != nil {
@@ -104,9 +106,8 @@ func newObtainForCSRRequest(cmd *cli.Command, csr *x509.CertificateRequest) cert
 
 func newAccountsStorageConfig(cmd *cli.Command) storage.AccountsStorageConfig {
 	return storage.AccountsStorageConfig{
-		BasePath:  cmd.String(flags.FlgPath),
-		Server:    cmd.String(flags.FlgServer),
-		UserAgent: getUserAgentFromFlag(cmd),
+		BasePath: cmd.String(flags.FlgPath),
+		Server:   cmd.String(flags.FlgServer),
 	}
 }
 


### PR DESCRIPTION
It is complex to explain, so I created two schemas: one after, one before.

Before:

![lego-account-storage-registration](https://github.com/user-attachments/assets/61afe415-9a3f-4fb4-ba12-2d9fbe1cf628)

After:

![lego-account-storage-registration-new](https://github.com/user-attachments/assets/26616790-934a-4e48-a4f0-1d58f68601be)


The second schema seems more complex, but the design is more simple:
- the account storage is focused on the account data and the storage of the files.
- the other part is focused on the ACME client: the registration.
- the separation of concerns is respected.
- only one ACME client is used.

Also, in the first schema, we can see a bug when the account file exists but without a private key.
In this case, the registration from the file should not be kept because, as we are using a new private key, we have a new account.