### PR TITLE
feat: revert accounts by key type

### DIFF
--- a/cmd/internal/migrate/accounts.go
+++ b/cmd/internal/migrate/accounts.go
@@ -55,38 +55,36 @@ func Accounts(root string) error {
 			},
 		}
 
+		accountDir := filepath.Dir(srcAccountFilePath)
+
 		if account.ID == "" {
-			account.ID = filepath.Base(filepath.Dir(srcAccountFilePath))
+			account.ID = filepath.Base(accountDir)
 		}
 
-		accountsDir := filepath.Dir(srcAccountFilePath)
-
-		srcKeyPath := filepath.Join(accountsDir, "keys", account.GetID()+storage.ExtKey)
+		srcKeyPath := filepath.Join(accountDir, "keys", account.GetID()+storage.ExtKey)
 
 		account.KeyType, err = getKeyType(srcKeyPath)
 		if err != nil {
 			return fmt.Errorf("could not guess the account key type: %w", err)
 		}
 
-		newAccountDir := filepath.Join(accountsDir, string(account.GetKeyType()))
+		// Move the private key file.
 
-		err = os.MkdirAll(newAccountDir, 0o700)
-		if err != nil {
-			return fmt.Errorf("could not create the directory %q: %w", newAccountDir, err)
-		}
-
-		// Rename the private key file.
-
-		dstKeyPath := filepath.Join(newAccountDir, account.GetID()+storage.ExtKey)
+		dstKeyPath := filepath.Join(accountDir, account.GetID()+storage.ExtKey)
 
 		err = os.Rename(srcKeyPath, dstKeyPath)
 		if err != nil {
 			return fmt.Errorf("could not rename the private key file %q to %q: %w", srcKeyPath, dstKeyPath, err)
 		}
 
+		err = os.RemoveAll(filepath.Join(accountDir, "keys"))
+		if err != nil {
+			return fmt.Errorf("could not remove the old keys directory: %w", err)
+		}
+
 		// Create the new account file.
 
-		newAccountFile, err := os.Create(filepath.Join(newAccountDir, "account.json"))
+		newAccountFile, err := os.Create(filepath.Join(accountDir, "account.json"))
 		if err != nil {
 			return fmt.Errorf("could not create the new account file: %w", err)
 		}
@@ -98,27 +96,6 @@ func Accounts(root string) error {
 		if err != nil {
 			return fmt.Errorf("could not encode the new account file: %w", err)
 		}
-
-		// Clean up.
-
-		err = accountsCleanUp(srcAccountFilePath)
-		if err != nil {
-			return fmt.Errorf("could not clean up: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func accountsCleanUp(srcAccountPath string) error {
-	err := os.Remove(srcAccountPath)
-	if err != nil {
-		return fmt.Errorf("could not remove the account file %q: %w", srcAccountPath, err)
-	}
-
-	err = os.Remove(filepath.Join(filepath.Dir(srcAccountPath), "keys"))
-	if err != nil {
-		return fmt.Errorf("could not remove the keys directory: %w", err)
 	}
 
 	return nil
@@ -132,7 +109,7 @@ func getKeyType(srcKeyPath string) (certcrypto.KeyType, error) {
 
 	kt, err := certcrypto.GetPrivateKeyType(pk)
 	if err != nil {
-		return "", fmt.Errorf("could not guess the private key type: %w", err)
+		return "", fmt.Errorf("could not get the private key type: %w", err)
 	}
 
 	return kt, nil

--- a/cmd/internal/storage/accounts.go
+++ b/cmd/internal/storage/accounts.go
@@ -56,10 +56,10 @@ func (e *PrivateKeyNotFound) Error() string {
 //	     │      └── root accounts directory
 //	     └── "path" option
 //
-// keysPath:
+// keyPath:
 //
-//	./.lego/accounts/localhost_14000/foo@example.com/RSA4096/
-//	     │      │             │             │          └── per key type directory
+//	./.lego/accounts/localhost_14000/foo@example.com/foo@example.com.key
+//	     │      │             │             │            └── private key
 //	     │      │             │             └── accountID
 //	     │      │             └── CA server ("server" option)
 //	     │      └── root accounts directory
@@ -67,9 +67,8 @@ func (e *PrivateKeyNotFound) Error() string {
 //
 // accountFilePath:
 //
-//	./.lego/accounts/localhost_14000/foo@example.com/RSA4096/account.json
-//	     │      │             │             │          │       └── account file
-//	     │      │             │             │          └── per key type directory
+//	./.lego/accounts/localhost_14000/foo@example.com/account.json
+//	     │      │             │             │            └── account file
 //	     │      │             │             └── accountID
 //	     │      │             └── CA server ("server" option)
 //	     │      └── root accounts directory
@@ -106,7 +105,7 @@ func (s *AccountsStorage) Save(account *Account) error {
 		return fmt.Errorf("invalid server URL %q: %w", account.Server, err)
 	}
 
-	accountFilePath := s.getAccountFilePath(server, account.GetKeyType(), account.GetID())
+	accountFilePath := s.getAccountFilePath(server, account.GetID())
 
 	return os.WriteFile(accountFilePath, jsonBytes, filePerm)
 }
@@ -120,7 +119,7 @@ func (s *AccountsStorage) Get(server string, keyType certcrypto.KeyType, email, 
 
 	effectiveAccountID := getEffectiveAccountID(email, accountID)
 
-	if !s.existsAccountFile(serverURL, keyType, effectiveAccountID) {
+	if !s.existsAccountFile(serverURL, effectiveAccountID) {
 		var account *Account
 
 		account, err = s.createAccount(serverURL, keyType, email, accountID)
@@ -166,7 +165,7 @@ func (s *AccountsStorage) createAccount(server *url.URL, keyType certcrypto.KeyT
 // It will flag the account as needing recovery if the registration is missing.
 // And it will also create a new private key if it doesn't exist (and save the private key file).
 func (s *AccountsStorage) getAccount(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
-	accountFilePath := s.getAccountFilePath(server, keyType, effectiveAccountID)
+	accountFilePath := s.getAccountFilePath(server, effectiveAccountID)
 
 	fileBytes, err := os.ReadFile(accountFilePath)
 	if err != nil {
@@ -187,7 +186,7 @@ func (s *AccountsStorage) getAccount(server *url.URL, keyType certcrypto.KeyType
 		}
 	}
 
-	account.key, err = s.readPrivateKey(server, keyType, effectiveAccountID)
+	account.key, err = s.readPrivateKey(server, effectiveAccountID)
 	if err != nil {
 		var privateKeyNotFound *PrivateKeyNotFound
 
@@ -229,7 +228,7 @@ func (s *AccountsStorage) getAccount(server *url.URL, keyType certcrypto.KeyType
 
 // createPrivateKey generates a new private key and saves it to a file.
 func (s *AccountsStorage) createPrivateKey(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) (crypto.Signer, error) {
-	accKeyPath := s.getAccountKeyPath(server, keyType, effectiveAccountID)
+	accKeyPath := s.getAccountKeyPath(server, effectiveAccountID)
 	keysPath := filepath.Dir(accKeyPath)
 
 	err := CreateNonExistingFolder(keysPath)
@@ -265,8 +264,8 @@ func (s *AccountsStorage) createPrivateKey(server *url.URL, keyType certcrypto.K
 }
 
 // readPrivateKey reads the private key from a file.
-func (s *AccountsStorage) readPrivateKey(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) (crypto.Signer, error) {
-	accKeyPath := s.getAccountKeyPath(server, keyType, effectiveAccountID)
+func (s *AccountsStorage) readPrivateKey(server *url.URL, effectiveAccountID string) (crypto.Signer, error) {
+	accKeyPath := s.getAccountKeyPath(server, effectiveAccountID)
 
 	if _, err := os.Stat(accKeyPath); os.IsNotExist(err) {
 		return nil, &PrivateKeyNotFound{AccountID: effectiveAccountID}
@@ -283,8 +282,8 @@ func (s *AccountsStorage) readPrivateKey(server *url.URL, keyType certcrypto.Key
 }
 
 // existsAccountFile checks if the account file exists.
-func (s *AccountsStorage) existsAccountFile(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) bool {
-	accountFilePath := s.getAccountFilePath(server, keyType, effectiveAccountID)
+func (s *AccountsStorage) existsAccountFile(server *url.URL, effectiveAccountID string) bool {
+	accountFilePath := s.getAccountFilePath(server, effectiveAccountID)
 
 	if _, err := os.Stat(accountFilePath); os.IsNotExist(err) {
 		return false
@@ -299,18 +298,13 @@ func (s *AccountsStorage) existsAccountFile(server *url.URL, keyType certcrypto.
 }
 
 // getAccountKeyPath returns the account private key path.
-func (s *AccountsStorage) getAccountKeyPath(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) string {
-	return filepath.Join(s.getKeyPath(server, keyType, effectiveAccountID), effectiveAccountID+".key")
+func (s *AccountsStorage) getAccountKeyPath(server *url.URL, effectiveAccountID string) string {
+	return filepath.Join(s.getRootUserPath(server, effectiveAccountID), effectiveAccountID+".key")
 }
 
 // getAccountFilePath returns the account file path.
-func (s *AccountsStorage) getAccountFilePath(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) string {
-	return filepath.Join(s.getKeyPath(server, keyType, effectiveAccountID), accountFileName)
-}
-
-// getKeyPath returns the path to the folder that contains the private key for an account.
-func (s *AccountsStorage) getKeyPath(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) string {
-	return filepath.Join(s.getRootUserPath(server, effectiveAccountID), string(keyType))
+func (s *AccountsStorage) getAccountFilePath(server *url.URL, effectiveAccountID string) string {
+	return filepath.Join(s.getRootUserPath(server, effectiveAccountID), accountFileName)
 }
 
 // getRootUserPath returns the path to the root folder for an account.

--- a/cmd/internal/storage/accounts_test.go
+++ b/cmd/internal/storage/accounts_test.go
@@ -61,7 +61,7 @@ func TestAccountsStorage_Save(t *testing.T) {
 	server, err := url.Parse(account.Server)
 	require.NoError(t, err)
 
-	accountFilePath := storage.getAccountFilePath(server, keyType, accountID)
+	accountFilePath := storage.getAccountFilePath(server, accountID)
 
 	err = os.MkdirAll(filepath.Dir(accountFilePath), 0o755)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestAccountsStorage_Save(t *testing.T) {
 	require.NoError(t, err)
 
 	require.FileExists(t, accountFilePath)
-	assert.NoFileExists(t, storage.getAccountKeyPath(server, keyType, accountID))
+	assert.NoFileExists(t, storage.getAccountKeyPath(server, accountID))
 
 	file, err := os.ReadFile(accountFilePath)
 	require.NoError(t, err)
@@ -99,8 +99,8 @@ func TestAccountsStorage_Get_newAccount(t *testing.T) {
 	assert.NotNil(t, account.GetPrivateKey())
 	assert.False(t, account.NeedsRecovery)
 
-	assert.FileExists(t, storage.getAccountFilePath(server, keyType, email))
-	assert.FileExists(t, storage.getAccountKeyPath(server, keyType, email))
+	assert.FileExists(t, storage.getAccountFilePath(server, email))
+	assert.FileExists(t, storage.getAccountKeyPath(server, email))
 }
 
 func TestAccountsStorage_Get_existingAccount(t *testing.T) {
@@ -126,12 +126,12 @@ func TestAccountsStorage_Get_existingAccount(t *testing.T) {
 		},
 	}
 
-	createFakeAccountFile(t, storage, server, keyType, accountID, existingAccount)
+	createFakeAccountFile(t, storage, server, accountID, existingAccount)
 
 	privateKey, err := certcrypto.GeneratePrivateKey(keyType)
 	require.NoError(t, err)
 
-	err = os.WriteFile(storage.getAccountKeyPath(server, keyType, accountID), certcrypto.PEMEncode(privateKey), 0o600)
+	err = os.WriteFile(storage.getAccountKeyPath(server, accountID), certcrypto.PEMEncode(privateKey), 0o600)
 	require.NoError(t, err)
 
 	account, err := storage.Get(server.String(), keyType, "", accountID)
@@ -178,7 +178,7 @@ func TestAccountsStorage_Get_existingAccount_withoutPrivateKey(t *testing.T) {
 		},
 	}
 
-	createFakeAccountFile(t, storage, server, keyType, accountID, existingAccount)
+	createFakeAccountFile(t, storage, server, accountID, existingAccount)
 
 	account, err := storage.Get(server.String(), keyType, "", accountID)
 	require.NoError(t, err)
@@ -210,12 +210,12 @@ func TestAccountsStorage_Get_existingAccount_withoutRegistration(t *testing.T) {
 		Server:  server.String(),
 	}
 
-	createFakeAccountFile(t, storage, server, keyType, accountID, existingAccount)
+	createFakeAccountFile(t, storage, server, accountID, existingAccount)
 
 	privateKey, err := certcrypto.GeneratePrivateKey(keyType)
 	require.NoError(t, err)
 
-	err = os.WriteFile(storage.getAccountKeyPath(server, keyType, accountID), certcrypto.PEMEncode(privateKey), 0o600)
+	err = os.WriteFile(storage.getAccountKeyPath(server, accountID), certcrypto.PEMEncode(privateKey), 0o600)
 	require.NoError(t, err)
 
 	account, err := storage.Get(server.String(), keyType, "", accountID)
@@ -231,10 +231,10 @@ func TestAccountsStorage_Get_existingAccount_withoutRegistration(t *testing.T) {
 	assert.NotNil(t, account.GetPrivateKey())
 }
 
-func createFakeAccountFile(t *testing.T, storage *AccountsStorage, server *url.URL, keyType certcrypto.KeyType, accountID string, existingAccount *Account) {
+func createFakeAccountFile(t *testing.T, storage *AccountsStorage, server *url.URL, accountID string, existingAccount *Account) {
 	t.Helper()
 
-	accountFilePath := storage.getAccountFilePath(server, keyType, accountID)
+	accountFilePath := storage.getAccountFilePath(server, accountID)
 
 	err := os.MkdirAll(filepath.Dir(accountFilePath), 0o700)
 	require.NoError(t, err)

--- a/cmd/internal/storage/archiver_accounts.go
+++ b/cmd/internal/storage/archiver_accounts.go
@@ -48,8 +48,7 @@ func (m *Archiver) archiveAccounts(cfg *configuration.Configuration) error {
 	date := strconv.FormatInt(time.Now().Unix(), 10)
 
 	for _, filename := range matches {
-		dirKt, _ := filepath.Split(filename)
-		dirAcc, kt := filepath.Split(filepath.Dir(dirKt))
+		dirAcc, _ := filepath.Split(filename)
 		dirSrv, accID := filepath.Split(filepath.Dir(dirAcc))
 		_, srv := filepath.Split(filepath.Dir(dirSrv))
 
@@ -66,15 +65,6 @@ func (m *Archiver) archiveAccounts(cfg *configuration.Configuration) error {
 			err = m.archiveAccount("accountID", dirAcc, srv, accID, date)
 			if err != nil {
 				return fmt.Errorf("archive account (accountID) %q: %w", accID, err)
-			}
-
-			continue
-		}
-
-		if _, ok := accountTree[srv][accID][kt]; !ok {
-			err := m.archiveAccount("keyType", dirKt, srv, accID, kt, date)
-			if err != nil {
-				return fmt.Errorf("archive account (keyType) %q: %w", kt, err)
 			}
 
 			continue
@@ -120,11 +110,11 @@ func (m *Archiver) cleanArchivedAccounts() error {
 	return m.cleanArchives(filepath.Join(m.accountsArchivePath, "**", "*.zip"))
 }
 
-func accountMapping(cfg *configuration.Configuration) (map[string]map[string]map[string]struct{}, error) {
-	// Server -> AccountID -> KeyType
-	accountTree := make(map[string]map[string]map[string]struct{})
+func accountMapping(cfg *configuration.Configuration) (map[string]map[string]struct{}, error) {
+	// Server -> AccountID
+	accountTree := make(map[string]map[string]struct{})
 
-	for accID, account := range cfg.Accounts {
+	for accID := range cfg.Accounts {
 		serverConfig := configuration.GetServerConfig(cfg, accID)
 
 		s, err := url.Parse(serverConfig.URL)
@@ -135,14 +125,10 @@ func accountMapping(cfg *configuration.Configuration) (map[string]map[string]map
 		server := sanitizeHost(s)
 
 		if _, ok := accountTree[server]; !ok {
-			accountTree[server] = make(map[string]map[string]struct{})
+			accountTree[server] = make(map[string]struct{})
 		}
 
-		if _, ok := accountTree[server][accID]; !ok {
-			accountTree[server][accID] = make(map[string]struct{})
-		}
-
-		accountTree[server][accID][account.KeyType] = struct{}{}
+		accountTree[server][accID] = struct{}{}
 	}
 
 	return accountTree, nil

--- a/cmd/internal/storage/archiver_accounts_test.go
+++ b/cmd/internal/storage/archiver_accounts_test.go
@@ -28,8 +28,8 @@ func TestArchiver_Accounts(t *testing.T) {
 	err := os.MkdirAll(archiver.accountsBasePath, 0o700)
 	require.NoError(t, err)
 
-	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.com", "EC256", "foo")
-	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.com", "EC256", "bar")
+	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.com", "foo")
+	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.com", "bar")
 
 	// archive
 
@@ -52,10 +52,10 @@ func TestArchiver_Accounts(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
-func generateFakeAccountFiles(t *testing.T, accountsBasePath, server, keyType, accountID string) {
+func generateFakeAccountFiles(t *testing.T, accountsBasePath, server, accountID string) {
 	t.Helper()
 
-	filename := filepath.Join(accountsBasePath, server, accountID, keyType, "account.json")
+	filename := filepath.Join(accountsBasePath, server, accountID, "account.json")
 
 	err := os.MkdirAll(filepath.Dir(filename), 0o700)
 	require.NoError(t, err)

--- a/e2e/dnschallenge/dns_persist_challenge_test.go
+++ b/e2e/dnschallenge/dns_persist_challenge_test.go
@@ -251,9 +251,7 @@ func createCLIAccountState(t *testing.T, email string) string {
 	require.NoError(t, err)
 	require.NotEmpty(t, reg.Location)
 
-	keyType := certcrypto.EC256
-
-	accountPathRoot := getAccountPath(email, keyType)
+	accountPathRoot := getAccountPath(email)
 
 	err = os.MkdirAll(accountPathRoot, 0o700)
 	require.NoError(t, err)
@@ -271,7 +269,7 @@ func createCLIAccountState(t *testing.T, email string) string {
 	}{
 		ID:           email,
 		Email:        email,
-		KeyType:      keyType,
+		KeyType:      certcrypto.EC256,
 		Registration: reg,
 	}, "", "\t")
 	require.NoError(t, err)
@@ -283,7 +281,7 @@ func createCLIAccountState(t *testing.T, email string) string {
 }
 
 func waitForAccountFile(ctx context.Context, email string) (string, error) {
-	accountPath := filepath.Join(getAccountPath(email, certcrypto.EC256), "account.json")
+	accountPath := filepath.Join(getAccountPath(email), "account.json")
 
 	type accountFile struct {
 		Registration *acme.ExtendedAccount `json:"registration"`
@@ -317,8 +315,8 @@ func waitForAccountFile(ctx context.Context, email string) (string, error) {
 		backoff.WithMaxElapsedTime(10*time.Second))
 }
 
-func getAccountPath(accountID string, keyType certcrypto.KeyType) string {
-	return filepath.Join(".lego", "accounts", "localhost_15000", accountID, string(keyType))
+func getAccountPath(accountID string) string {
+	return filepath.Join(".lego", "accounts", "localhost_15000", accountID)
 }
 
 func mockDefaultPersist(t *testing.T) {


### PR DESCRIPTION
I have been fooled by the lego v4 `run` command.

In the v4, there is no `register` command, so only the `run` command was able to register the account.
In this case, the account key type and the certificate key type are the same.

But once the account is registered, you can use the `run` command with another key type, different from the account key type.

In the v5:
1. There is a `register` command
2. The accounts have an ID (not only an optional email)

So an account is uniquely identified by its ID and not by its key type + email.

related to #2850