### PR TITLE
feat: add command related to archives management

### DIFF
--- a/cmd/cmd_archives.go
+++ b/cmd/cmd_archives.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-acme/lego/v5/cmd/internal/flags"
+	"github.com/go-acme/lego/v5/cmd/internal/storage"
+	"github.com/go-acme/lego/v5/log"
+	"github.com/urfave/cli/v3"
+)
+
+func createArchives() *cli.Command {
+	return &cli.Command{
+		Name:  "archives",
+		Usage: "Archives management.",
+		Commands: []*cli.Command{
+			{
+				Name:   "list",
+				Usage:  "List all archives.",
+				Action: listArchives,
+				Flags: []cli.Flag{
+					flags.CreatePathFlag(false),
+				},
+			},
+			{
+				Name:   "restore",
+				Usage:  "Restore an archive.",
+				Action: restoreArchive,
+				Flags: []cli.Flag{
+					flags.CreatePathFlag(false),
+				},
+			},
+		},
+	}
+}
+
+func restoreArchive(_ context.Context, cmd *cli.Command) error {
+	archiver := storage.NewArchiver(cmd.String(flags.FlgPath))
+
+	accountPaths, err := archiver.ListArchivedAccounts()
+	if err != nil {
+		return err
+	}
+
+	certificatePaths, err := archiver.ListArchivedCertificates()
+	if err != nil {
+		return err
+	}
+
+	all := slices.Concat(accountPaths, certificatePaths)
+
+	if len(all) == 0 {
+		log.Info("No archives were found.")
+		return nil
+	}
+
+	var options []string
+
+	for i, filename := range all {
+		date, errP := parseArchiveDate(filename)
+		if errP != nil {
+			return errP
+		}
+
+		fmt.Printf("%d: %s - %s - %s\n", i+1, filepath.Base(filepath.Dir(filename)), date, filepath.Base(filename))
+
+		options = append(options, strconv.Itoa(i+1))
+	}
+
+	fmt.Println()
+
+	choice := choose("Choose the archive to restore:", options)
+
+	index, err := strconv.Atoi(choice)
+	if err != nil {
+		return err
+	}
+
+	err = archiver.Restore(all[index-1])
+	if err != nil {
+		return fmt.Errorf("restore archive: %w", err)
+	}
+
+	log.Info("Account restored.")
+
+	return nil
+}
+
+func listArchives(_ context.Context, cmd *cli.Command) error {
+	archiver := storage.NewArchiver(cmd.String(flags.FlgPath))
+
+	accountPaths, err := archiver.ListArchivedAccounts()
+	if err != nil {
+		return err
+	}
+
+	displayArchivePaths("Account", accountPaths)
+
+	certificatePaths, err := archiver.ListArchivedCertificates()
+	if err != nil {
+		return err
+	}
+
+	displayArchivePaths("Certificate", certificatePaths)
+
+	if len(accountPaths) == 0 && len(certificatePaths) == 0 {
+		log.Info("No archives were found.")
+	}
+
+	return nil
+}
+
+func displayArchivePaths(kind string, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+
+	slices.Sort(paths)
+
+	fmt.Println(kind + " archives:")
+
+	prefix := "├──"
+
+	for i, filename := range paths {
+		if i == len(paths)-1 {
+			prefix = "└──"
+		}
+
+		date, _ := parseArchiveDate(filename)
+
+		fmt.Println(prefix, filepath.Base(filename), "("+date.String()+")")
+	}
+
+	fmt.Println()
+}
+
+func parseArchiveDate(filename string) (time.Time, error) {
+	lastIndex := strings.LastIndex(filename, "_")
+
+	unixRaw, err := strconv.ParseInt(strings.TrimSuffix(filename[lastIndex+1:], ".zip"), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(unixRaw, 0), nil
+}

--- a/cmd/cmd_migrate.go
+++ b/cmd/cmd_migrate.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
@@ -22,7 +20,11 @@ func createMigrate() *cli.Command {
 		Name:  "migrate",
 		Usage: "Migrate certificates and accounts.",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if !confirmMigration(cmd) {
+			log.Warnf(log.LazySprintf("The migration will not work if the certificates have been generated with the '--filename' flag."+
+				" Use the flag '--%s' to only migrate accounts.", flags.FlgAccountOnly))
+			log.Warnf(log.LazySprintf("Please create a backup of %q before the migration.", cmd.String(flags.FlgPath)))
+
+			if !confirm("Continue?") {
 				return nil
 			}
 
@@ -48,33 +50,6 @@ func createMigrate() *cli.Command {
 			return createConfigurationFile(cfg)
 		},
 		Flags: flags.CreateMigrateFlags(),
-	}
-}
-
-func confirmMigration(cmd *cli.Command) bool {
-	reader := bufio.NewReader(os.Stdin)
-
-	log.Warnf(log.LazySprintf("The migration will not work if the certificates have been generated with the '--filename' flag."+
-		" Use the flag '--%s' to only migrate accounts.", flags.FlgAccountOnly))
-	log.Warnf(log.LazySprintf("Please create a backup of %q before the migration.", cmd.String(flags.FlgPath)))
-
-	for {
-		fmt.Println("Continue? Y/n")
-
-		text, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatal("Could not read from the console", log.ErrorAttr(err))
-		}
-
-		text = strings.Trim(text, "\r\n")
-		switch strings.ToUpper(text) {
-		case "", "Y":
-			return true
-		case "N":
-			return false
-		default:
-			log.Warn("Your input was invalid. Please answer with one of Y/y, n/N or by pressing enter.")
-		}
 	}
 }
 

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -32,6 +32,7 @@ func CreateCommands() []*cli.Command {
 		createRun(),
 		createRevoke(),
 		createAccounts(),
+		createArchives(),
 		createDNSHelp(),
 		createList(),
 		createMigrate(),

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -115,7 +115,7 @@ func CreateRenewFlags() []cli.Flag {
 
 func CreateRevokeFlags() []cli.Flag {
 	flags := []cli.Flag{
-		createPathFlag(false),
+		CreatePathFlag(false),
 		createCertNamesFlag(),
 		&cli.BoolFlag{
 			Name:    FlgKeep,
@@ -143,7 +143,7 @@ func CreateRevokeFlags() []cli.Flag {
 
 func CreateRegisterFlags() []cli.Flag {
 	flags := []cli.Flag{
-		createPathFlag(true),
+		CreatePathFlag(true),
 		createAcceptFlag(),
 	}
 
@@ -155,7 +155,7 @@ func CreateRegisterFlags() []cli.Flag {
 
 func CreateRecoverFlags() []cli.Flag {
 	flags := []cli.Flag{
-		createPathFlag(true),
+		CreatePathFlag(true),
 		&cli.StringFlag{
 			Name:     FlgPrivateKey,
 			Sources:  cli.EnvVars(toEnvName(FlgPrivateKey)),
@@ -172,7 +172,7 @@ func CreateRecoverFlags() []cli.Flag {
 
 func CreateListFlags() []cli.Flag {
 	return []cli.Flag{
-		createPathFlag(false),
+		CreatePathFlag(false),
 		&cli.BoolFlag{
 			Name:  FlgFormatJSON,
 			Usage: "Format the output as JSON.",
@@ -182,7 +182,7 @@ func CreateListFlags() []cli.Flag {
 
 func CreateMigrateFlags() []cli.Flag {
 	return []cli.Flag{
-		createPathFlag(false),
+		CreatePathFlag(false),
 		&cli.BoolFlag{
 			Name:    FlgAccountOnly,
 			Sources: cli.EnvVars(toEnvName(FlgAccountOnly)),
@@ -487,7 +487,7 @@ func createDNSPersistChallengeFlags() []cli.Flag {
 
 func createStorageFlags() []cli.Flag {
 	return []cli.Flag{
-		createPathFlag(true),
+		CreatePathFlag(true),
 		&cli.BoolFlag{
 			Category: categoryStorage,
 			Name:     FlgPEM,
@@ -704,7 +704,7 @@ func createCertNamesFlag() cli.Flag {
 	}
 }
 
-func createPathFlag(forceCreation bool) cli.Flag {
+func CreatePathFlag(forceCreation bool) cli.Flag {
 	return &cli.StringFlag{
 		Category: categoryStorage,
 		Name:     FlgPath,

--- a/cmd/internal/storage/archiver.go
+++ b/cmd/internal/storage/archiver.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"archive/zip"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -46,6 +48,31 @@ func NewArchiver(basePath string) *Archiver {
 	}
 }
 
+func (m *Archiver) Restore(archivePath string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("could not open archive %q: %w", archivePath, err)
+	}
+
+	defer func() { _ = reader.Close() }()
+
+	baseDir := filepath.Join(m.basePath, reader.Comment)
+
+	for _, file := range reader.File {
+		err = extractZipFile(baseDir, file)
+		if err != nil {
+			return fmt.Errorf("extract file %q: %w", file.Name, err)
+		}
+	}
+
+	err = os.RemoveAll(archivePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *Archiver) cleanArchives(pattern string) error {
 	matches, err := zglob.Glob(pattern)
 	if err != nil {
@@ -75,6 +102,24 @@ func (m *Archiver) cleanArchives(pattern string) error {
 	}
 
 	return nil
+}
+
+func listArchives(archivePath string) ([]string, error) {
+	_, err := os.Stat(archivePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	matches, err := zglob.Glob(filepath.Join(archivePath, "**", "*.zip"))
+	if err != nil {
+		return nil, err
+	}
+
+	return matches, nil
 }
 
 func parseArchiveDate(filename string) (time.Time, error) {

--- a/cmd/internal/storage/archiver.go
+++ b/cmd/internal/storage/archiver.go
@@ -49,6 +49,20 @@ func NewArchiver(basePath string) *Archiver {
 }
 
 func (m *Archiver) Restore(archivePath string) error {
+	err := m.restore(archivePath)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(archivePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Archiver) restore(archivePath string) error {
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return fmt.Errorf("could not open archive %q: %w", archivePath, err)
@@ -63,11 +77,6 @@ func (m *Archiver) Restore(archivePath string) error {
 		if err != nil {
 			return fmt.Errorf("extract file %q: %w", file.Name, err)
 		}
-	}
-
-	err = os.RemoveAll(archivePath)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/cmd/internal/storage/archiver.go
+++ b/cmd/internal/storage/archiver.go
@@ -53,16 +53,17 @@ func (m *Archiver) cleanArchives(pattern string) error {
 	}
 
 	for _, filename := range matches {
-		li := strings.LastIndex(filename, "_")
-
-		v := strings.TrimSuffix(filename[li+1:], ".zip")
-
-		s, err := strconv.ParseInt(v, 10, 64)
+		date, err := parseArchiveDate(filename)
 		if err != nil {
-			return err
+			log.Error("The date of the archive cannot be parsed: the file is ignored.",
+				slog.String("filename", filename),
+				log.ErrorAttr(err),
+			)
+
+			continue
 		}
 
-		if time.Unix(s, 0).Add(m.maxTimeBeforeCleaning).After(time.Now()) {
+		if date.Add(m.maxTimeBeforeCleaning).After(time.Now()) {
 			log.Debug("The archive is not old enough to be cleaned.", slog.String("filename", filename))
 			continue
 		}
@@ -74,4 +75,15 @@ func (m *Archiver) cleanArchives(pattern string) error {
 	}
 
 	return nil
+}
+
+func parseArchiveDate(filename string) (time.Time, error) {
+	lastIndex := strings.LastIndex(filename, "_")
+
+	unixRaw, err := strconv.ParseInt(strings.TrimSuffix(filename[lastIndex+1:], ".zip"), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(unixRaw, 0), nil
 }

--- a/cmd/internal/storage/archiver_accounts.go
+++ b/cmd/internal/storage/archiver_accounts.go
@@ -29,6 +29,10 @@ func (m *Archiver) Accounts(cfg *configuration.Configuration) error {
 	return nil
 }
 
+func (m *Archiver) ListArchivedAccounts() ([]string, error) {
+	return listArchives(m.accountsArchivePath)
+}
+
 func (m *Archiver) archiveAccounts(cfg *configuration.Configuration) error {
 	_, err := os.Stat(m.accountsBasePath)
 	if os.IsNotExist(err) {

--- a/cmd/internal/storage/archiver_accounts_test.go
+++ b/cmd/internal/storage/archiver_accounts_test.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"github.com/mattn/go-zglob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,20 +38,68 @@ func TestArchiver_Accounts(t *testing.T) {
 	err = archiver.Accounts(cfg)
 	require.NoError(t, err)
 
-	entries, err := os.ReadDir(archiver.accountsArchivePath)
-	require.NoError(t, err)
+	accounts, err := archiver.ListArchivedAccounts()
+	assert.NoError(t, err)
 
-	assert.Len(t, entries, 1)
+	require.Len(t, accounts, 1)
+	assert.Regexp(t, `.+_\d+\.zip`, accounts[0])
 
 	// clean
 
 	err = archiver.Accounts(cfg)
 	require.NoError(t, err)
 
-	entries, err = os.ReadDir(archiver.accountsArchivePath)
+	accounts, err = archiver.ListArchivedAccounts()
 	require.NoError(t, err)
 
-	assert.Empty(t, entries)
+	require.Empty(t, accounts)
+}
+
+func TestArchiver_Restore_accounts(t *testing.T) {
+	cfg := &configuration.Configuration{
+		Storage: t.TempDir(),
+		Accounts: map[string]*configuration.Account{
+			"foo": {
+				Server:  "https://ca.example.org/dir",
+				KeyType: "EC256",
+			},
+		},
+	}
+
+	archiver := NewArchiver(cfg.Storage)
+	archiver.maxTimeBeforeCleaning = 0
+
+	err := os.MkdirAll(archiver.accountsBasePath, 0o700)
+	require.NoError(t, err)
+
+	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.org", "foo")
+	generateFakeAccountFiles(t, archiver.accountsBasePath, "ca.example.org", "bar")
+
+	// archive
+
+	err = archiver.Accounts(cfg)
+	require.NoError(t, err)
+
+	accounts, err := archiver.ListArchivedAccounts()
+	assert.NoError(t, err)
+
+	require.Len(t, accounts, 1)
+	assert.Regexp(t, `.+_\d+\.zip`, accounts[0])
+
+	// restore
+
+	err = archiver.Restore(accounts[0])
+	require.NoError(t, err)
+
+	matches, err := zglob.Glob(filepath.Join(archiver.accountsBasePath, "**", "*.json"))
+	require.NoError(t, err)
+
+	assert.Len(t, matches, 2)
+
+	accounts, err = archiver.ListArchivedAccounts()
+	require.NoError(t, err)
+
+	require.Empty(t, accounts)
 }
 
 func generateFakeAccountFiles(t *testing.T, accountsBasePath, server, accountID string) {
@@ -65,7 +115,11 @@ func generateFakeAccountFiles(t *testing.T, accountsBasePath, server, accountID 
 
 	defer func() { _ = file.Close() }()
 
-	r := Account{ID: accountID}
+	r := Account{
+		ID:      accountID,
+		KeyType: certcrypto.EC256,
+		Server:  "https://ca.example.com/dir",
+	}
 
 	err = json.NewEncoder(file).Encode(r)
 	require.NoError(t, err)

--- a/cmd/internal/storage/archiver_certificates.go
+++ b/cmd/internal/storage/archiver_certificates.go
@@ -36,6 +36,10 @@ func (m *Archiver) Certificate(certID string) error {
 	})
 }
 
+func (m *Archiver) ListArchivedCertificates() ([]string, error) {
+	return listArchives(m.certificatesArchivePath)
+}
+
 func (m *Archiver) archiveRemovedCertificates(certificates map[string]*configuration.Certificate) error {
 	// Only archive the certificates that are not in the configuration.
 	return m.archiveCertificates(func(resourceID string) bool {

--- a/cmd/internal/storage/archiver_certificates_test.go
+++ b/cmd/internal/storage/archiver_certificates_test.go
@@ -39,21 +39,68 @@ func TestArchiver_Certificates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, root, len(domainFiles))
 
-	archive, err := os.ReadDir(archiver.certificatesArchivePath)
+	archives, err := archiver.ListArchivedCertificates()
 	require.NoError(t, err)
 
-	require.Len(t, archive, 1)
-	assert.Regexp(t, regexp.QuoteMeta(archiveDomain)+`_\d+\.zip`, archive[0].Name())
+	require.Len(t, archives, 1)
+	assert.Regexp(t, regexp.QuoteMeta(archiveDomain)+`_\d+\.zip`, archives[0])
 
 	// clean
 
 	err = archiver.Certificates(cfg.Certificates)
 	require.NoError(t, err)
 
-	archive, err = os.ReadDir(archiver.certificatesArchivePath)
+	archives, err = archiver.ListArchivedCertificates()
 	require.NoError(t, err)
 
-	require.Empty(t, archive)
+	require.Empty(t, archives)
+}
+
+func TestArchiver_Restore_certificates(t *testing.T) {
+	domain := "example.com"
+	archiveDomain := "example.org"
+
+	cfg := &configuration.Configuration{
+		Storage: t.TempDir(),
+		Certificates: map[string]*configuration.Certificate{
+			domain: {},
+		},
+	}
+
+	archiver := NewArchiver(cfg.Storage)
+	archiver.maxTimeBeforeCleaning = 0
+
+	domainFiles := generateFakeCertificateFiles(t, archiver.certificatesBasePath, domain)
+	_ = generateFakeCertificateFiles(t, archiver.certificatesBasePath, archiveDomain)
+
+	// archive
+
+	err := archiver.Certificates(cfg.Certificates)
+	require.NoError(t, err)
+
+	root, err := os.ReadDir(archiver.certificatesBasePath)
+	require.NoError(t, err)
+	assert.Len(t, root, len(domainFiles))
+
+	archives, err := archiver.ListArchivedCertificates()
+	require.NoError(t, err)
+
+	require.Len(t, archives, 1)
+	assert.Regexp(t, regexp.QuoteMeta(archiveDomain)+`_\d+\.zip`, archives[0])
+
+	// restore
+
+	err = archiver.Restore(archives[0])
+	require.NoError(t, err)
+
+	root, err = os.ReadDir(archiver.certificatesBasePath)
+	require.NoError(t, err)
+	assert.Len(t, root, len(domainFiles)*2)
+
+	archives, err = archiver.ListArchivedCertificates()
+	require.NoError(t, err)
+
+	require.Empty(t, archives)
 }
 
 func TestArchiver_Certificate(t *testing.T) {

--- a/cmd/internal/storage/archiver_compress.go
+++ b/cmd/internal/storage/archiver_compress.go
@@ -81,3 +81,37 @@ func addFileToZip(f io.Writer, file string) error {
 
 	return nil
 }
+
+func extractZipFile(dst string, file *zip.File) error {
+	outputPath := filepath.Join(dst, file.Name)
+
+	if file.FileInfo().IsDir() {
+		return os.MkdirAll(outputPath, 0o700)
+	}
+
+	err := os.MkdirAll(filepath.Dir(outputPath), 0o700)
+	if err != nil {
+		return err
+	}
+
+	data, err := file.Open()
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = data.Close() }()
+
+	output, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = output.Close() }()
+
+	_, err = io.Copy(output, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -162,5 +163,29 @@ func confirm(message string) bool {
 		default:
 			log.Warn("Your input was invalid. Please answer with one of Y/y, N/n or by pressing enter.")
 		}
+	}
+}
+
+func choose(message string, options []string) string {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Println(message + " " + strings.Join(options, ", "))
+
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal("Could not read from the console", log.ErrorAttr(err))
+		}
+
+		text = strings.ToUpper(strings.Trim(text, "\r\n"))
+
+		if slices.Contains(options, text) {
+			return text
+		}
+
+		log.Warnf(log.LazySprintf(
+			"Your input was invalid. Please answer with one of %s or by pressing enter.",
+			strings.Join(options, ", "),
+		))
 	}
 }

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -14,6 +14,7 @@ COMMANDS:
    run       Get or renew a certificate
    revoke    Revoke a certificate
    accounts  Accounts management.
+   archives  Archives management.
    dnshelp   Shows additional help for the '--dns' global option
    list      Display information about certificates.
    migrate   Migrate certificates and accounts.


### PR DESCRIPTION
This PR adds 2 subcommands:
- `archives list`: to list all the archived elements (accounts and certificates)
- `archives restore`: to restore an archived elements (accounts or certificates)

