### PR TITLE
feat: restrict archive process to only accounts and certificates related to the configuration

### DIFF
--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -49,6 +49,9 @@ type Resource struct {
 
 	KeyType certcrypto.KeyType `json:"keyType"`
 
+	PreferredChain string `json:"preferredChain,omitempty"`
+	Profile        string `json:"profile,omitempty"`
+
 	CertURL       string `json:"certUrl"`
 	CertStableURL string `json:"certStableUrl"`
 
@@ -224,6 +227,9 @@ func (c *Certifier) Obtain(ctx context.Context, request ObtainRequest) (*Resourc
 		if err != nil {
 			return nil, err
 		}
+
+		cert.PreferredChain = request.PreferredChain
+		cert.Profile = request.Profile
 	}
 
 	return cert, failures.Join()
@@ -311,6 +317,9 @@ func (c *Certifier) ObtainForCSR(ctx context.Context, request ObtainForCSRReques
 		if err != nil {
 			return nil, err
 		}
+
+		cert.PreferredChain = request.PreferredChain
+		cert.Profile = request.Profile
 	}
 
 	return cert, failures.Join()

--- a/cmd/cmd_accounts_register.go
+++ b/cmd/cmd_accounts_register.go
@@ -52,6 +52,11 @@ func register(ctx context.Context, cmd *cli.Command) error {
 }
 
 func handleRegistration(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, accountsStorage *storage.AccountsStorage, account *storage.Account, allowRegister bool) error {
+	err := updateAccountOrigin(accountsStorage, account)
+	if err != nil {
+		return err
+	}
+
 	if account.NeedsRecovery {
 		client, err := lazyClient()
 		if err != nil {
@@ -143,4 +148,17 @@ func handleTOS(cmd *cli.Command, client *lego.Client) bool {
 	log.Warn("Please review the TOS.", slog.String("url", urlTOS))
 
 	return confirm("Do you accept the TOS?")
+}
+
+func updateAccountOrigin(accountsStorage *storage.AccountsStorage, account *storage.Account) error {
+	if account.Origin == "" || account.Origin == storage.OriginMigration {
+		account.Origin = storage.OriginCommand
+
+		err := accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/cmd_migrate.go
+++ b/cmd/cmd_migrate.go
@@ -73,7 +73,7 @@ func createConfigurationFile(cfg *configuration.Configuration) error {
 		return fmt.Errorf("could not encode the configuration file: %w", err)
 	}
 
-	log.Warn("Please review the configuration file to handle the FIXME.", slog.String("filepath", filename))
+	log.Warn("Please rename and review the configuration file to handle the FIXME.", slog.String("filepath", filename))
 
 	return nil
 }

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/go-acme/lego/v5/certcrypto"
-	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
@@ -108,7 +107,7 @@ func obtain(ctx context.Context, cmd *cli.Command, certID string, lazyClient lzS
 	return obtainForDomains(ctx, cmd, client, certID, certsStorage, hookManager)
 }
 
-func renew(ctx context.Context, cmd *cli.Command, certID string, resource *certificate.Resource, lazyClient lzSetUp, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
+func renew(ctx context.Context, cmd *cli.Command, certID string, resource *storage.Certificate, lazyClient lzSetUp, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	if cmd.IsSet(flags.FlgCSR) {
 		return renewForCSR(ctx, cmd, lazyClient, certID, certsStorage, hookManager)
 	}

--- a/cmd/cmd_run_obtain.go
+++ b/cmd/cmd_run_obtain.go
@@ -46,7 +46,7 @@ func obtainForDomains(ctx context.Context, cmd *cli.Command, client *lego.Client
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(certRes, options)
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -90,7 +90,7 @@ func obtainForCSR(ctx context.Context, cmd *cli.Command, client *lego.Client, ce
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(certRes, options)
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}

--- a/cmd/cmd_run_obtain.go
+++ b/cmd/cmd_run_obtain.go
@@ -46,7 +46,13 @@ func obtainForDomains(ctx context.Context, cmd *cli.Command, client *lego.Client
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginCommand,
+		},
+		options,
+	)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -90,7 +96,13 @@ func obtainForCSR(ctx context.Context, cmd *cli.Command, client *lego.Client, ce
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginCommand,
+		},
+		options,
+	)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}

--- a/cmd/cmd_run_renew.go
+++ b/cmd/cmd_run_renew.go
@@ -101,7 +101,7 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, 
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(certRes, options)
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -170,7 +170,7 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, cert
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(certRes, options)
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
 	if err != nil {
 		return fmt.Errorf("CSR: could not save the resource: %w", err)
 	}

--- a/cmd/cmd_run_renew.go
+++ b/cmd/cmd_run_renew.go
@@ -101,7 +101,13 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, 
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginCommand,
+		},
+		options,
+	)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -170,7 +176,13 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, cert
 
 	options := newSaveOptions(cmd)
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, options)
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginCommand,
+		},
+		options,
+	)
 	if err != nil {
 		return fmt.Errorf("CSR: could not save the resource: %w", err)
 	}

--- a/cmd/internal/migrate/accounts.go
+++ b/cmd/internal/migrate/accounts.go
@@ -19,6 +19,11 @@ import (
 	"github.com/mattn/go-zglob"
 )
 
+const (
+	accountFileName   = "account.json"
+	oldKeysFolderName = "keys"
+)
+
 type OldAccount struct {
 	Email        string       `json:"email"`
 	Registration *OldResource `json:"registration"`
@@ -31,7 +36,7 @@ type OldResource struct {
 
 // Accounts migrates the old accounts directory structure to the new one.
 func Accounts(root string, cfg *configuration.Configuration) error {
-	matches, err := zglob.Glob(filepath.Join(root, "**", "account.json"))
+	matches, err := zglob.Glob(filepath.Join(root, "**", accountFileName))
 	if err != nil {
 		return err
 	}
@@ -70,7 +75,7 @@ func Accounts(root string, cfg *configuration.Configuration) error {
 			},
 		}
 
-		srcKeyPath := filepath.Join(accountDir, "keys", account.GetID()+storage.ExtKey)
+		srcKeyPath := filepath.Join(accountDir, oldKeysFolderName, account.GetID()+storage.ExtKey)
 
 		account.KeyType, err = getKeyType(srcKeyPath)
 		if err != nil {
@@ -102,13 +107,13 @@ func migrateAccountFiles(accountDir, srcKeyPath string, account storage.Account)
 		return fmt.Errorf("could not rename the private key file %q to %q: %w", srcKeyPath, dstKeyPath, err)
 	}
 
-	err = os.RemoveAll(filepath.Join(accountDir, "keys"))
+	err = os.RemoveAll(filepath.Join(accountDir, oldKeysFolderName))
 	if err != nil {
 		return fmt.Errorf("could not remove the old keys directory: %w", err)
 	}
 
 	// Create the new account file.
-	newAccountFile, err := os.Create(filepath.Join(accountDir, "account.json"))
+	newAccountFile, err := os.Create(filepath.Join(accountDir, accountFileName))
 	if err != nil {
 		return fmt.Errorf("could not create the new account file: %w", err)
 	}

--- a/cmd/internal/migrate/accounts.go
+++ b/cmd/internal/migrate/accounts.go
@@ -65,10 +65,11 @@ func Accounts(root string, cfg *configuration.Configuration) error {
 
 		serverDir := filepath.Dir(accountDir)
 
-		account := storage.Account{
+		account := &storage.Account{
 			ID:     accountID,
 			Email:  oldAccount.Email,
 			Server: guessServer(serverDir),
+			Origin: storage.OriginMigration,
 			Registration: &acme.ExtendedAccount{
 				Account:  oldAccount.Registration.Body,
 				Location: oldAccount.Registration.URI,
@@ -98,7 +99,7 @@ func Accounts(root string, cfg *configuration.Configuration) error {
 	return nil
 }
 
-func migrateAccountFiles(accountDir, srcKeyPath string, account storage.Account) error {
+func migrateAccountFiles(accountDir, srcKeyPath string, account *storage.Account) error {
 	dstKeyPath := filepath.Join(accountDir, account.GetID()+storage.ExtKey)
 
 	// Move the private key file.

--- a/cmd/internal/migrate/certificates.go
+++ b/cmd/internal/migrate/certificates.go
@@ -18,6 +18,10 @@ import (
 	"github.com/mattn/go-zglob"
 )
 
+const (
+	baseCertificatesFolderName = "certificates"
+)
+
 type oldResource struct {
 	Domain        string `json:"domain"`
 	CertURL       string `json:"certUrl"`
@@ -25,7 +29,7 @@ type oldResource struct {
 }
 
 func Certificates(root string, cfg *configuration.Configuration) error {
-	matches, err := zglob.Glob(filepath.Join(root, "certificates", "**", "*.json"))
+	matches, err := zglob.Glob(filepath.Join(root, baseCertificatesFolderName, "**", "*.json"))
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/migrate/certificates.go
+++ b/cmd/internal/migrate/certificates.go
@@ -60,6 +60,7 @@ func Certificates(root string, cfg *configuration.Configuration) error {
 				CertURL:       oldCertRes.CertURL,
 				CertStableURL: oldCertRes.CertStableURL,
 			},
+			Origin: storage.OriginMigration,
 		}
 
 		baseName := strings.TrimSuffix(certResourceFilePath, filepath.Ext(certResourceFilePath))

--- a/cmd/internal/migrate/certificates.go
+++ b/cmd/internal/migrate/certificates.go
@@ -55,9 +55,11 @@ func Certificates(root string, cfg *configuration.Configuration) error {
 
 		log.Debug("Migrating a certificate.", slog.String("filepath", certResourceFilePath))
 
-		certRes := certificate.Resource{
-			CertURL:       oldCertRes.CertURL,
-			CertStableURL: oldCertRes.CertStableURL,
+		certRes := &storage.Certificate{
+			Resource: &certificate.Resource{
+				CertURL:       oldCertRes.CertURL,
+				CertStableURL: oldCertRes.CertStableURL,
+			},
 		}
 
 		baseName := strings.TrimSuffix(certResourceFilePath, filepath.Ext(certResourceFilePath))
@@ -109,8 +111,11 @@ func Certificates(root string, cfg *configuration.Configuration) error {
 	return nil
 }
 
-func migrateCertificate(certResourceFilePath string, certRes certificate.Resource) error {
-	log.Debug("Saving the certificate file.", slog.String("filepath", certResourceFilePath), slog.String("keyType", string(certRes.KeyType)))
+func migrateCertificate(certResourceFilePath string, certRes *storage.Certificate) error {
+	log.Debug("Saving the certificate file.",
+		slog.String("filepath", certResourceFilePath),
+		slog.String("keyType", string(certRes.KeyType)),
+	)
 
 	f, err := os.Create(certResourceFilePath)
 	if err != nil {

--- a/cmd/internal/root/process_register.go
+++ b/cmd/internal/root/process_register.go
@@ -19,6 +19,11 @@ import (
 )
 
 func handleRegistration(ctx context.Context, lazyClient lzSetUp, accountConfig *configuration.Account, accountsStorage *storage.AccountsStorage, account *storage.Account) error {
+	err := updateAccountOrigin(accountsStorage, account)
+	if err != nil {
+		return err
+	}
+
 	if account.NeedsRecovery {
 		client, err := lazyClient()
 		if err != nil {
@@ -118,4 +123,17 @@ func handleTOS(client *lego.Client, accountConfig *configuration.Account) bool {
 			fmt.Println("Your input was invalid. Please answer with one of Y/y, n/N or by pressing enter.")
 		}
 	}
+}
+
+func updateAccountOrigin(accountsStorage *storage.AccountsStorage, account *storage.Account) error {
+	if account.Origin != storage.OriginConfiguration {
+		account.Origin = storage.OriginConfiguration
+
+		err := accountsStorage.Save(account)
+		if err != nil {
+			return fmt.Errorf("could not save the account file: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/internal/root/process_renew.go
+++ b/cmd/internal/root/process_renew.go
@@ -113,7 +113,13 @@ func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, cer
 
 	certRes.ID = certID
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, &storage.SaveOptions{PEM: true})
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginConfiguration,
+		},
+		&storage.SaveOptions{PEM: true},
+	)
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -185,7 +191,13 @@ func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certCon
 
 	certRes.ID = certID
 
-	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, &storage.SaveOptions{PEM: true})
+	err = certsStorage.Save(
+		&storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginConfiguration,
+		},
+		&storage.SaveOptions{PEM: true},
+	)
 	if err != nil {
 		return fmt.Errorf("CSR: could not save the resource: %w", err)
 	}

--- a/cmd/internal/root/process_renew.go
+++ b/cmd/internal/root/process_renew.go
@@ -113,7 +113,7 @@ func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, cer
 
 	certRes.ID = certID
 
-	err = certsStorage.Save(certRes, &storage.SaveOptions{PEM: true})
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, &storage.SaveOptions{PEM: true})
 	if err != nil {
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
@@ -185,7 +185,7 @@ func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certCon
 
 	certRes.ID = certID
 
-	err = certsStorage.Save(certRes, &storage.SaveOptions{PEM: true})
+	err = certsStorage.Save(&storage.Certificate{Resource: certRes}, &storage.SaveOptions{PEM: true})
 	if err != nil {
 		return fmt.Errorf("CSR: could not save the resource: %w", err)
 	}

--- a/cmd/internal/root/process_run.go
+++ b/cmd/internal/root/process_run.go
@@ -30,7 +30,7 @@ func runCertificate(ctx context.Context, lazySetup lzSetUp, certConfig *configur
 	return nil
 }
 
-func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *configuration.Certificate) (*certificate.Resource, error) {
+func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *configuration.Certificate) (*storage.Certificate, error) {
 	if certConfig.CSR != "" {
 		csr, err := storage.ReadCSRFile(certConfig.CSR)
 		if err != nil {
@@ -53,7 +53,12 @@ func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *con
 		// I didn't find a use case for it when using the file configuration.
 		// Maybe this can be added in the future.
 
-		return client.Certificate.ObtainForCSR(ctx, request)
+		certRes, err := client.Certificate.ObtainForCSR(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		return &storage.Certificate{Resource: certRes}, nil
 	}
 
 	keyType, err := certcrypto.ToKeyType(certConfig.KeyType)
@@ -78,5 +83,10 @@ func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *con
 	// I didn't find a use case for it when using the file configuration.
 	// Maybe this can be added in the future.
 
-	return client.Certificate.Obtain(ctx, request)
+	certRes, err := client.Certificate.Obtain(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return &storage.Certificate{Resource: certRes}, nil
 }

--- a/cmd/internal/root/process_run.go
+++ b/cmd/internal/root/process_run.go
@@ -58,7 +58,10 @@ func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *con
 			return nil, err
 		}
 
-		return &storage.Certificate{Resource: certRes}, nil
+		return &storage.Certificate{
+			Resource: certRes,
+			Origin:   storage.OriginConfiguration,
+		}, nil
 	}
 
 	keyType, err := certcrypto.ToKeyType(certConfig.KeyType)
@@ -88,5 +91,8 @@ func obtainCertificate(ctx context.Context, client *lego.Client, certConfig *con
 		return nil, err
 	}
 
-	return &storage.Certificate{Resource: certRes}, nil
+	return &storage.Certificate{
+		Resource: certRes,
+		Origin:   storage.OriginConfiguration,
+	}, nil
 }

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"crypto"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/certcrypto"
@@ -73,4 +75,20 @@ func getEffectiveAccountID(email, id string) string {
 	}
 
 	return configuration.DefaultAccountID
+}
+
+func readAccountFile(filename string) (*Account, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	account := new(Account)
+
+	err = json.Unmarshal(data, account)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
 }

--- a/cmd/internal/storage/account.go
+++ b/cmd/internal/storage/account.go
@@ -11,12 +11,20 @@ import (
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 )
 
+const (
+	OriginConfiguration = "configuration"
+	OriginCommand       = "command"
+	OriginMigration     = "migration"
+)
+
 // Account represents a users local saved credentials.
 type Account struct {
 	ID      string             `json:"id"`
 	Email   string             `json:"email"`
 	KeyType certcrypto.KeyType `json:"keyType"`
 	Server  string             `json:"server"`
+
+	Origin string `json:"origin,omitempty"`
 
 	Registration  *acme.ExtendedAccount `json:"registration"`
 	NeedsRecovery bool                  `json:"-"`

--- a/cmd/internal/storage/archiver.go
+++ b/cmd/internal/storage/archiver.go
@@ -141,3 +141,7 @@ func parseArchiveDate(filename string) (time.Time, error) {
 
 	return time.Unix(unixRaw, 0), nil
 }
+
+func isManaged(origin string) bool {
+	return origin == OriginConfiguration || origin == OriginMigration
+}

--- a/cmd/internal/storage/archiver_accounts.go
+++ b/cmd/internal/storage/archiver_accounts.go
@@ -52,11 +52,22 @@ func (m *Archiver) archiveAccounts(cfg *configuration.Configuration) error {
 	date := strconv.FormatInt(time.Now().Unix(), 10)
 
 	for _, filename := range matches {
+		log.Debug("Found an account file", slog.String("filepath", filename))
+
 		dirAcc, _ := filepath.Split(filename)
 		dirSrv, accID := filepath.Split(filepath.Dir(dirAcc))
 		_, srv := filepath.Split(filepath.Dir(dirSrv))
 
 		if _, ok := accountTree[srv]; !ok {
+			if !isManagedAccount(filename) {
+				log.Warn(
+					"The account has been created by the command line and not defined in the configuration file: skipping the archive.",
+					slog.String("filepath", filename),
+				)
+
+				continue
+			}
+
 			err = m.archiveAccount("server", dirSrv, srv, date)
 			if err != nil {
 				return fmt.Errorf("archive account (server) %q: %w", srv, err)
@@ -66,6 +77,15 @@ func (m *Archiver) archiveAccounts(cfg *configuration.Configuration) error {
 		}
 
 		if _, ok := accountTree[srv][accID]; !ok {
+			if !isManagedAccount(filename) {
+				log.Warn(
+					"The account has been created by the command line and not defined in the configuration file: skipping the archive.",
+					slog.String("filepath", filename),
+				)
+
+				continue
+			}
+
 			err = m.archiveAccount("accountID", dirAcc, srv, accID, date)
 			if err != nil {
 				return fmt.Errorf("archive account (accountID) %q: %w", accID, err)
@@ -136,4 +156,14 @@ func accountMapping(cfg *configuration.Configuration) (map[string]map[string]str
 	}
 
 	return accountTree, nil
+}
+
+func isManagedAccount(filename string) bool {
+	account, err := readAccountFile(filename)
+	if err != nil {
+		log.Error("Could not read the account file", slog.String("filepath", filename))
+		return false
+	}
+
+	return account.Origin == OriginConfiguration || account.Origin == OriginMigration
 }

--- a/cmd/internal/storage/archiver_accounts.go
+++ b/cmd/internal/storage/archiver_accounts.go
@@ -165,5 +165,5 @@ func isManagedAccount(filename string) bool {
 		return false
 	}
 
-	return account.Origin == OriginConfiguration || account.Origin == OriginMigration
+	return isManaged(account.Origin)
 }

--- a/cmd/internal/storage/archiver_accounts_test.go
+++ b/cmd/internal/storage/archiver_accounts_test.go
@@ -119,6 +119,7 @@ func generateFakeAccountFiles(t *testing.T, accountsBasePath, server, accountID 
 		ID:      accountID,
 		KeyType: certcrypto.EC256,
 		Server:  "https://ca.example.com/dir",
+		Origin:  OriginConfiguration,
 	}
 
 	err = json.NewEncoder(file).Encode(r)

--- a/cmd/internal/storage/archiver_certificates.go
+++ b/cmd/internal/storage/archiver_certificates.go
@@ -32,7 +32,7 @@ func (m *Archiver) Certificates(certificates map[string]*configuration.Certifica
 func (m *Archiver) Certificate(certID string) error {
 	return m.archiveCertificates(func(resourceID string) bool {
 		return certID != resourceID
-	})
+	}, false)
 }
 
 func (m *Archiver) ListArchivedCertificates() ([]string, error) {
@@ -45,10 +45,10 @@ func (m *Archiver) archiveRemovedCertificates(certificates map[string]*configura
 		_, ok := certificates[resourceID]
 
 		return ok
-	})
+	}, true)
 }
 
-func (m *Archiver) archiveCertificates(skip func(resourceID string) bool) error {
+func (m *Archiver) archiveCertificates(skip func(resourceID string) bool, managedOnly bool) error {
 	_, err := os.Stat(m.certificatesBasePath)
 	if os.IsNotExist(err) {
 		return nil
@@ -75,6 +75,11 @@ func (m *Archiver) archiveCertificates(skip func(resourceID string) bool) error 
 		}
 
 		if skip(resource.ID) {
+			continue
+		}
+
+		// If managedOnly is true, only archive managed certificates (aka created from the configuration file or migrated).
+		if managedOnly && resource.Origin != OriginConfiguration && resource.Origin != OriginMigration {
 			continue
 		}
 

--- a/cmd/internal/storage/archiver_certificates.go
+++ b/cmd/internal/storage/archiver_certificates.go
@@ -79,7 +79,7 @@ func (m *Archiver) archiveCertificates(skip func(resourceID string) bool, manage
 		}
 
 		// If managedOnly is true, only archive managed certificates (aka created from the configuration file or migrated).
-		if managedOnly && resource.Origin != OriginConfiguration && resource.Origin != OriginMigration {
+		if managedOnly && !isManaged(resource.Origin) {
 			continue
 		}
 

--- a/cmd/internal/storage/archiver_certificates.go
+++ b/cmd/internal/storage/archiver_certificates.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/log"
 	"github.com/mattn/go-zglob"
@@ -68,7 +67,7 @@ func (m *Archiver) archiveCertificates(skip func(resourceID string) bool) error 
 			return fmt.Errorf("reading certificate file %q: %w", filename, err)
 		}
 
-		resource := new(certificate.Resource)
+		resource := new(Certificate)
 
 		err = json.Unmarshal(file, resource)
 		if err != nil {
@@ -88,7 +87,7 @@ func (m *Archiver) archiveCertificates(skip func(resourceID string) bool) error 
 	return nil
 }
 
-func (m *Archiver) archiveOneCertificate(filename, date string, resource *certificate.Resource) error {
+func (m *Archiver) archiveOneCertificate(filename, date string, resource *Certificate) error {
 	dest := filepath.Join(m.certificatesArchivePath, strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))+"_"+date+".zip")
 
 	log.Info("Archiving certificate", log.CertNameAttr(resource.ID), slog.String("archive", dest))

--- a/cmd/internal/storage/archiver_certificates_test.go
+++ b/cmd/internal/storage/archiver_certificates_test.go
@@ -215,7 +215,10 @@ func generateFakeCertificateFiles(t *testing.T, dir, domain string) []string {
 
 	defer func() { _ = file.Close() }()
 
-	r := Certificate{Resource: &certificate.Resource{ID: domain}}
+	r := Certificate{
+		Resource: &certificate.Resource{ID: domain},
+		Origin:   OriginConfiguration,
+	}
 
 	err = json.NewEncoder(file).Encode(r)
 	require.NoError(t, err)

--- a/cmd/internal/storage/archiver_certificates_test.go
+++ b/cmd/internal/storage/archiver_certificates_test.go
@@ -215,7 +215,7 @@ func generateFakeCertificateFiles(t *testing.T, dir, domain string) []string {
 
 	defer func() { _ = file.Close() }()
 
-	r := certificate.Resource{ID: domain}
+	r := Certificate{Resource: &certificate.Resource{ID: domain}}
 
 	err = json.NewEncoder(file).Encode(r)
 	require.NoError(t, err)

--- a/cmd/internal/storage/certificate.go
+++ b/cmd/internal/storage/certificate.go
@@ -1,0 +1,7 @@
+package storage
+
+import "github.com/go-acme/lego/v5/certificate"
+
+type Certificate struct {
+	*certificate.Resource
+}

--- a/cmd/internal/storage/certificate.go
+++ b/cmd/internal/storage/certificate.go
@@ -4,4 +4,6 @@ import "github.com/go-acme/lego/v5/certificate"
 
 type Certificate struct {
 	*certificate.Resource
+
+	Origin string `json:"origin,omitempty"`
 }

--- a/cmd/internal/storage/storage_accounts.go
+++ b/cmd/internal/storage/storage_accounts.go
@@ -189,16 +189,9 @@ func (s *AccountsStorage) createAccount(server *url.URL, keyType certcrypto.KeyT
 func (s *AccountsStorage) getAccount(server *url.URL, keyType certcrypto.KeyType, effectiveAccountID string) (*Account, error) {
 	accountFilePath := s.getAccountFilePath(server, effectiveAccountID)
 
-	fileBytes, err := os.ReadFile(accountFilePath)
+	account, err := readAccountFile(accountFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read the account file %q: %w", accountFilePath, err)
-	}
-
-	account := new(Account)
-
-	err = json.Unmarshal(fileBytes, account)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse the account file %s: %w", accountFilePath, err)
 	}
 
 	if fixIntegrity(account, server.String(), keyType) {

--- a/cmd/internal/storage/storage_certificates_reader.go
+++ b/cmd/internal/storage/storage_certificates_reader.go
@@ -9,17 +9,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/log"
 )
 
-func (s *CertificatesStorage) ReadResource(certID string) (*certificate.Resource, error) {
+func (s *CertificatesStorage) ReadResource(certID string) (*Certificate, error) {
 	raw, err := s.ReadFile(certID, ExtResource)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load resource for domain %q: %w", certID, err)
 	}
 
-	resource := new(certificate.Resource)
+	resource := new(Certificate)
+
 	if err = json.Unmarshal(raw, resource); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal resource for domain %q: %w", certID, err)
 	}

--- a/cmd/internal/storage/storage_certificates_reader_test.go
+++ b/cmd/internal/storage/storage_certificates_reader_test.go
@@ -15,12 +15,14 @@ func TestCertificatesStorage_ReadResource(t *testing.T) {
 	resource, err := reader.ReadResource("example.com")
 	require.NoError(t, err)
 
-	expected := &certificate.Resource{
-		ID:            "example.com",
-		Domains:       []string{"example.com"},
-		KeyType:       "EC256",
-		CertURL:       "https://acme.example.org/cert/123",
-		CertStableURL: "https://acme.example.org/cert/456",
+	expected := &Certificate{
+		Resource: &certificate.Resource{
+			ID:            "example.com",
+			Domains:       []string{"example.com"},
+			KeyType:       "EC256",
+			CertURL:       "https://acme.example.org/cert/123",
+			CertStableURL: "https://acme.example.org/cert/456",
+		},
 	}
 
 	assert.Equal(t, expected, resource)

--- a/cmd/internal/storage/storage_certificates_writer.go
+++ b/cmd/internal/storage/storage_certificates_writer.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/go-acme/lego/v5/certcrypto"
-	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/log"
 	"software.sslmate.com/src/go-pkcs12"
 )
@@ -50,7 +49,7 @@ func (o *SaveOptions) Validate() error {
 // - the issuer certificate file (if any)
 // - the PFX file (if needed)
 // - the PEM file (if needed).
-func (s *CertificatesStorage) Save(certRes *certificate.Resource, opts *SaveOptions) error {
+func (s *CertificatesStorage) Save(certRes *Certificate, opts *SaveOptions) error {
 	err := opts.Validate()
 	if err != nil {
 		return err
@@ -87,7 +86,7 @@ func (s *CertificatesStorage) Save(certRes *certificate.Resource, opts *SaveOpti
 	return s.saveResource(certRes)
 }
 
-func (s *CertificatesStorage) saveResource(certRes *certificate.Resource) error {
+func (s *CertificatesStorage) saveResource(certRes *Certificate) error {
 	jsonBytes, err := json.MarshalIndent(certRes, "", "\t")
 	if err != nil {
 		return fmt.Errorf("unable to marshal the resource for %q: %w", certRes.ID, err)
@@ -101,7 +100,7 @@ func (s *CertificatesStorage) saveResource(certRes *certificate.Resource) error 
 	return nil
 }
 
-func (s *CertificatesStorage) writeCertificateFiles(certRes *certificate.Resource, opts *SaveOptions) error {
+func (s *CertificatesStorage) writeCertificateFiles(certRes *Certificate, opts *SaveOptions) error {
 	err := s.writeFile(certRes.ID, ExtKey, certRes.PrivateKey)
 	if err != nil {
 		return fmt.Errorf("unable to save the key file: %w", err)
@@ -128,7 +127,7 @@ func (s *CertificatesStorage) writeCertificateFiles(certRes *certificate.Resourc
 	return nil
 }
 
-func (s *CertificatesStorage) writePFXFile(certRes *certificate.Resource, password, format string) error {
+func (s *CertificatesStorage) writePFXFile(certRes *Certificate, password, format string) error {
 	certPemBlock, _ := pem.Decode(certRes.Certificate)
 	if certPemBlock == nil {
 		return fmt.Errorf("unable to parse certificate %q", certRes.ID)
@@ -171,7 +170,7 @@ func (s *CertificatesStorage) writeFile(domain, extension string, data []byte) e
 	return os.WriteFile(filePath, data, filePerm)
 }
 
-func getCertificateChain(certRes *certificate.Resource) ([]*x509.Certificate, error) {
+func getCertificateChain(certRes *Certificate) ([]*x509.Certificate, error) {
 	chainCertPemBlock, rest := pem.Decode(certRes.IssuerCertificate)
 	if chainCertPemBlock == nil {
 		return nil, errors.New("unable to parse Issuer Certificate")

--- a/cmd/internal/storage/storage_certificates_writer_test.go
+++ b/cmd/internal/storage/storage_certificates_writer_test.go
@@ -23,16 +23,18 @@ func TestCertificatesStorage_Save(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.key"))
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.json"))
 
-	resource := &certificate.Resource{
-		ID:                "example.com",
-		Domains:           []string{"example.com"},
-		KeyType:           "EC256",
-		CertURL:           "https://acme.example.org/cert/123",
-		CertStableURL:     "https://acme.example.org/cert/456",
-		PrivateKey:        []byte("PrivateKey"),
-		Certificate:       []byte("Certificate"),
-		IssuerCertificate: []byte("IssuerCertificate"),
-		CSR:               []byte("CSR"),
+	resource := &Certificate{
+		Resource: &certificate.Resource{
+			ID:                "example.com",
+			Domains:           []string{"example.com"},
+			KeyType:           "EC256",
+			CertURL:           "https://acme.example.org/cert/123",
+			CertStableURL:     "https://acme.example.org/cert/456",
+			PrivateKey:        []byte("PrivateKey"),
+			Certificate:       []byte("Certificate"),
+			IssuerCertificate: []byte("IssuerCertificate"),
+			CSR:               []byte("CSR"),
+		},
 	}
 
 	err = writer.Save(resource, nil)
@@ -70,16 +72,18 @@ func TestCertificatesStorage_Save_pem(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.json"))
 	require.NoFileExists(t, filepath.Join(basePath, baseCertificatesFolderName, "example.com.pem"))
 
-	resource := &certificate.Resource{
-		ID:                "example.com",
-		Domains:           []string{"example.com"},
-		KeyType:           "EC256",
-		CertURL:           "https://acme.example.org/cert/123",
-		CertStableURL:     "https://acme.example.org/cert/456",
-		PrivateKey:        []byte("PrivateKey"),
-		Certificate:       []byte("Certificate"),
-		IssuerCertificate: []byte("IssuerCertificate"),
-		CSR:               []byte("CSR"),
+	resource := &Certificate{
+		Resource: &certificate.Resource{
+			ID:                "example.com",
+			Domains:           []string{"example.com"},
+			KeyType:           "EC256",
+			CertURL:           "https://acme.example.org/cert/123",
+			CertStableURL:     "https://acme.example.org/cert/456",
+			PrivateKey:        []byte("PrivateKey"),
+			Certificate:       []byte("Certificate"),
+			IssuerCertificate: []byte("IssuerCertificate"),
+			CSR:               []byte("CSR"),
+		},
 	}
 
 	err = writer.Save(resource, &SaveOptions{

--- a/e2e/dnschallenge/dns_challenge_test.go
+++ b/e2e/dnschallenge/dns_challenge_test.go
@@ -151,6 +151,7 @@ func TestChallengeDNS_Client_Obtain_profile(t *testing.T) {
 	require.NotNil(t, resource)
 	assert.Equal(t, "*.xn--lgo-bma.localhost", resource.ID)
 	assert.Equal(t, []string{"*.xn--lgo-bma.localhost", "xn--lgo-bma.localhost"}, resource.Domains)
+	assert.Equal(t, "shortlived", resource.Profile)
 	assert.Regexp(t, `https://localhost:15000/certZ/[\w\d]{14,}`, resource.CertURL)
 	assert.Regexp(t, `https://localhost:15000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)

--- a/e2e/http_challenge_test.go
+++ b/e2e/http_challenge_test.go
@@ -116,6 +116,7 @@ func TestChallengeHTTP_Client_Obtain_profile(t *testing.T) {
 	require.NotNil(t, resource)
 	assert.Equal(t, testDomain1, resource.ID)
 	assert.Equal(t, []string{testDomain1}, resource.Domains)
+	assert.Equal(t, "shortlived", resource.Profile)
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertURL)
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)

--- a/e2e/tls_challenge_test.go
+++ b/e2e/tls_challenge_test.go
@@ -264,6 +264,7 @@ func TestChallengeTLS_Client_ObtainForCSR_profile(t *testing.T) {
 	require.NotNil(t, resource)
 	assert.Equal(t, testDomain1, resource.ID)
 	assert.Equal(t, []string{testDomain1, testDomain2}, resource.Domains)
+	assert.Equal(t, "shortlived", resource.Profile)
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertURL)
 	assert.Regexp(t, `https://localhost:14000/certZ/[\w\d]{14,}`, resource.CertStableURL)
 	assert.NotEmpty(t, resource.Certificate)


### PR DESCRIPTION
The goal of `origin` is to restrict the archive process to only accounts and certificates related to the configuration.

To do that, the PR extended stored information:
- certificates: `preferredChain`, `profile`, `origin`
- accounts: `origin`
