### PR TITLE
feat(cfg): add hooks

### DIFF
--- a/cmd/cmd_run_renew.go
+++ b/cmd/cmd_run_renew.go
@@ -72,7 +72,10 @@ func renewForDomains(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, 
 	// This is just meant to be informal for the user.
 	log.Info("Trying renewal.",
 		log.CertNameAttr(certID),
-		slog.Any("time-remaining", log.FormattableDuration(cert.NotAfter.Sub(time.Now().UTC()))),
+		slog.Any(
+			"time-remaining",
+			log.FormattableDuration(cert.NotAfter.Sub(time.Now().UTC())),
+		),
 	)
 
 	request, err := newObtainRequest(cmd, renewalDomains)
@@ -159,7 +162,10 @@ func renewForCSR(ctx context.Context, cmd *cli.Command, lazyClient lzSetUp, cert
 	// This is just meant to be informal for the user.
 	log.Info("Trying renewal.",
 		log.CertNameAttr(certID),
-		slog.Any("time-remaining", log.FormattableDuration(cert.NotAfter.Sub(time.Now().UTC()))),
+		slog.Any(
+			"time-remaining",
+			log.FormattableDuration(cert.NotAfter.Sub(time.Now().UTC())),
+		),
 	)
 
 	request := newObtainForCSRRequest(cmd, csr)

--- a/cmd/internal/configuration/configuration.go
+++ b/cmd/internal/configuration/configuration.go
@@ -14,6 +14,7 @@ type Configuration struct {
 	Accounts     map[string]*Account     `yaml:"accounts,omitempty"`
 	Challenges   map[string]*Challenge   `yaml:"challenges,omitempty"`
 	Certificates map[string]*Certificate `yaml:"certificates,omitempty"`
+	Hooks        *Hooks                  `yaml:"hooks,omitempty"`
 	Log          *Log                    `yaml:"log,omitempty"`
 }
 
@@ -126,6 +127,17 @@ type ARIConfiguration struct {
 type PFX struct {
 	Password string `json:"password,omitempty"`
 	Format   string `json:"format,omitempty"`
+}
+
+type Hooks struct {
+	Pre    *Hook `yaml:"pre,omitempty"`
+	Deploy *Hook `yaml:"deploy,omitempty"`
+	Post   *Hook `yaml:"post,omitempty"`
+}
+
+type Hook struct {
+	Cmd     string        `json:"command,omitempty"`
+	Timeout time.Duration `json:"timeout,omitempty"`
 }
 
 type Log struct {

--- a/cmd/internal/configuration/lego.jsonschema.json
+++ b/cmd/internal/configuration/lego.jsonschema.json
@@ -262,6 +262,33 @@
         }
       }
     },
+    "hooksSettings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pre": {
+          "$ref": "#/definitions/hookSettings"
+        },
+        "deploy": {
+          "$ref": "#/definitions/hookSettings"
+        },
+        "post": {
+          "$ref": "#/definitions/hookSettings"
+        }
+      }
+    },
+    "hookSettings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        }
+      }
+    },
     "logSettings": {
       "type": "object",
       "additionalProperties": false,
@@ -325,6 +352,9 @@
           "$ref": "#/definitions/certificatesSettings"
         }
       }
+    },
+    "hooks": {
+      "$ref": "#/definitions/hooksSettings"
     },
     "log": {
       "$ref": "#/definitions/logSettings"

--- a/cmd/internal/configuration/testdata/reference.yml
+++ b/cmd/internal/configuration/testdata/reference.yml
@@ -84,6 +84,17 @@ certificates:
       password: xxx
       format: pkcs12
 
+hooks:
+  pre:
+    command: "./my-pre-hook.sh"
+    timeout: 3s
+  deploy:
+    command: "./my-deploy-hook.sh"
+    timeout: 3s
+  post:
+    command: "./my-post-hook.sh"
+    timeout: 3s
+
 log:
   level: debug
   format: text

--- a/cmd/internal/hook/manager.go
+++ b/cmd/internal/hook/manager.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/go-acme/lego/v5/certcrypto"
@@ -40,6 +41,18 @@ func NewManager(certsStorage *storage.CertificatesStorage, options ...Option) *M
 	}
 
 	return m
+}
+
+// Clone creates a new hook Manager.
+// The metadata is cloned too.
+func (h *Manager) Clone() *Manager {
+	return &Manager{
+		certsStorage: h.certsStorage,
+		metadata:     maps.Clone(h.metadata),
+		pre:          h.pre,
+		deploy:       h.deploy,
+		post:         h.post,
+	}
 }
 
 // PreForDomains runs the pre-hook if defined.

--- a/cmd/internal/hook/manager_options.go
+++ b/cmd/internal/hook/manager_options.go
@@ -8,6 +8,9 @@ import (
 
 type Option func(m *Manager)
 
+// Noop is a no-op option.
+func Noop(m *Manager) {}
+
 // WithPre sets the pre-hook.
 func WithPre(cmd string, timeout time.Duration) Option {
 	return func(m *Manager) {

--- a/cmd/internal/root/process.go
+++ b/cmd/internal/root/process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/cmd/internal"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/registration"
@@ -67,7 +68,17 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 			return fmt.Errorf("registration: %w", err)
 		}
 
+		hm := hook.NewManager(
+			store.Certificate,
+			withHooks(cfg.Hooks),
+			hook.WithAccountMetadata(account),
+		)
+
 		for challengeID, certIDs := range challengesInfo {
+			// Clone the hook manager for each certificate because:
+			// each certificate is different, so the metadata is different, except for the account information.
+			hookManager := hm.Clone()
+
 			chlgConfig := cfg.Challenges[challengeID]
 
 			lazySetup := sync.OnceValues(func() (*lego.Client, error) {
@@ -91,7 +102,7 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 
 				// Renew
 				if store.Certificate.ExistsFile(certID, storage.ExtResource) {
-					err = renew(ctx, lazySetup, certID, certConfig, store.Certificate)
+					err = renew(ctx, lazySetup, certID, certConfig, store.Certificate, hookManager)
 					if err != nil {
 						return err
 					}
@@ -100,7 +111,7 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 				}
 
 				// Run
-				err := obtain(ctx, lazySetup, certID, certConfig, store.Certificate)
+				err := obtain(ctx, lazySetup, certID, certConfig, store.Certificate, hookManager)
 				if err != nil {
 					return err
 				}
@@ -185,4 +196,24 @@ func parseAddress(address string) (string, string, error) {
 	}
 
 	return host, port, nil
+}
+
+func withHooks(hooks *configuration.Hooks) hook.Option {
+	if hooks == nil {
+		return hook.Noop
+	}
+
+	return func(m *hook.Manager) {
+		addHook(hooks.Pre, hook.WithPre)(m)
+		addHook(hooks.Deploy, hook.WithDeploy)(m)
+		addHook(hooks.Post, hook.WithPost)(m)
+	}
+}
+
+func addHook(h *configuration.Hook, optFn func(cmd string, timeout time.Duration) hook.Option) hook.Option {
+	if h == nil {
+		return hook.Noop
+	}
+
+	return optFn(h.Cmd, h.Timeout)
 }

--- a/cmd/internal/root/process_obtain.go
+++ b/cmd/internal/root/process_obtain.go
@@ -7,29 +7,37 @@ import (
 
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
 )
 
-func obtain(ctx context.Context, lazySetup lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func obtain(ctx context.Context, lazySetup lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	client, err := lazySetup()
 	if err != nil {
 		return fmt.Errorf("set up client: %w", err)
 	}
 
 	if certConfig.CSR != "" {
-		return obtainForCSR(ctx, client, certID, certConfig, certsStorage)
+		return obtainForCSR(ctx, client, certID, certConfig, certsStorage, hookManager)
 	}
 
-	return obtainForDomains(ctx, client, certID, certConfig, certsStorage)
+	return obtainForDomains(ctx, client, certID, certConfig, certsStorage, hookManager)
 }
 
-func obtainForDomains(ctx context.Context, client *lego.Client, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func obtainForDomains(ctx context.Context, client *lego.Client, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	request := newObtainRequest(certConfig, certConfig.Domains)
 
 	// NOTE(ldez): I didn't add an option to set a private key as the file.
 	// I didn't find a use case for it when using the file configuration.
 	// Maybe this can be added in the future.
+
+	err := hookManager.PreForDomains(ctx, certID, request)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = hookManager.Post(ctx) }()
 
 	certRes, err := client.Certificate.Obtain(ctx, request)
 	if err != nil {
@@ -53,10 +61,10 @@ func obtainForDomains(ctx context.Context, client *lego.Client, certID string, c
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
 
-	return nil
+	return hookManager.Deploy(ctx, certRes, options)
 }
 
-func obtainForCSR(ctx context.Context, client *lego.Client, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func obtainForCSR(ctx context.Context, client *lego.Client, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	csr, err := storage.ReadCSRFile(certConfig.CSR)
 	if err != nil {
 		return err
@@ -68,6 +76,13 @@ func obtainForCSR(ctx context.Context, client *lego.Client, certID string, certC
 	// NOTE(ldez): I didn't add an option to set a private key as the file.
 	// I didn't find a use case for it when using the file configuration.
 	// Maybe this can be added in the future.
+
+	err = hookManager.PreForCSR(ctx, certID, request)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = hookManager.Post(ctx) }()
 
 	certRes, err := client.Certificate.ObtainForCSR(ctx, request)
 	if err != nil {
@@ -91,7 +106,7 @@ func obtainForCSR(ctx context.Context, client *lego.Client, certID string, certC
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
 
-	return nil
+	return hookManager.Deploy(ctx, certRes, options)
 }
 
 func newObtainRequest(certConfig *configuration.Certificate, domains []string) certificate.ObtainRequest {

--- a/cmd/internal/root/process_renew.go
+++ b/cmd/internal/root/process_renew.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-acme/lego/v5/acme/api"
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
@@ -24,15 +25,15 @@ import (
 
 type lzSetUp func() (*lego.Client, error)
 
-func renew(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func renew(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	if certConfig.CSR != "" {
-		return renewForCSR(ctx, lazyClient, certID, certConfig, certsStorage)
+		return renewForCSR(ctx, lazyClient, certID, certConfig, certsStorage, hookManager)
 	}
 
-	return renewForDomains(ctx, lazyClient, certID, certConfig, certsStorage)
+	return renewForDomains(ctx, lazyClient, certID, certConfig, certsStorage, hookManager)
 }
 
-func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	certificates, err := certsStorage.ReadCertificate(certID)
 	if err != nil {
 		return fmt.Errorf("error while reading the certificate for %q: %w", certID, err)
@@ -67,13 +68,6 @@ func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, cer
 		),
 	)
 
-	client, err := lazyClient()
-	if err != nil {
-		return fmt.Errorf("set up client: %w", err)
-	}
-
-	randomSleep(certConfig)
-
 	request := newObtainRequest(certConfig, renewalDomains)
 
 	if certConfig.Renew != nil && certConfig.Renew.ReuseKey {
@@ -86,6 +80,20 @@ func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, cer
 	if replacesCertID != "" {
 		request.ReplacesCertID = replacesCertID
 	}
+
+	err = hookManager.PreForDomains(ctx, certID, request)
+	if err != nil {
+		return fmt.Errorf("pre-renew hook: %w", err)
+	}
+
+	defer func() { _ = hookManager.Post(ctx) }()
+
+	client, err := lazyClient()
+	if err != nil {
+		return fmt.Errorf("set up client: %w", err)
+	}
+
+	randomSleep(certConfig)
 
 	certRes, err := client.Certificate.Obtain(ctx, request)
 	if err != nil {
@@ -107,10 +115,10 @@ func renewForDomains(ctx context.Context, lazyClient lzSetUp, certID string, cer
 		return fmt.Errorf("could not save the resource: %w", err)
 	}
 
-	return nil
+	return hookManager.Deploy(ctx, certRes, options)
 }
 
-func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage) error {
+func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certConfig *configuration.Certificate, certsStorage *storage.CertificatesStorage, hookManager *hook.Manager) error {
 	csr, err := storage.ReadCSRFile(certConfig.CSR)
 	if err != nil {
 		return fmt.Errorf("CSR: could not read file %q: %w", certConfig.CSR, err)
@@ -147,15 +155,22 @@ func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certCon
 		),
 	)
 
-	client, err := lazyClient()
-	if err != nil {
-		return fmt.Errorf("CSR: set up client: %w", err)
-	}
-
 	request := newObtainForCSRRequest(certConfig, csr)
 
 	if replacesCertID != "" {
 		request.ReplacesCertID = replacesCertID
+	}
+
+	err = hookManager.PreForCSR(ctx, certID, request)
+	if err != nil {
+		return fmt.Errorf("CSR: pre-renew hook: %w", err)
+	}
+
+	defer func() { _ = hookManager.Post(ctx) }()
+
+	client, err := lazyClient()
+	if err != nil {
+		return fmt.Errorf("CSR: set up client: %w", err)
 	}
 
 	certRes, err := client.Certificate.ObtainForCSR(ctx, request)
@@ -178,10 +193,10 @@ func renewForCSR(ctx context.Context, lazyClient lzSetUp, certID string, certCon
 		return fmt.Errorf("CSR: could not save the resource: %w", err)
 	}
 
-	return nil
+	return hookManager.Deploy(ctx, certRes, options)
 }
 
-func isInRenewalPeriod(cert *x509.Certificate, domain string, days int, now time.Time) bool {
+func isInRenewalPeriod(cert *x509.Certificate, certID string, days int, now time.Time) bool {
 	dueDate := getDueDate(cert, days, now)
 
 	if dueDate.Before(now) || dueDate.Equal(now) {
@@ -193,7 +208,7 @@ func isInRenewalPeriod(cert *x509.Certificate, domain string, days int, now time
 			cert.NotAfter.Format(time.RFC3339),
 			log.FormattableDuration(dueDate.Sub(now)),
 		),
-		log.CertNameAttr(domain),
+		log.CertNameAttr(certID),
 	)
 
 	return false
@@ -255,20 +270,20 @@ func getARIInfo(ctx context.Context, lazyClient lzSetUp, certID string, renewCon
 }
 
 // getARIRenewalTime checks if the certificate needs to be renewed using the renewalInfo endpoint.
-func getARIRenewalTime(ctx context.Context, willingToSleep time.Duration, cert *x509.Certificate, domain string, client *lego.Client) *time.Time {
+func getARIRenewalTime(ctx context.Context, willingToSleep time.Duration, cert *x509.Certificate, certID string, client *lego.Client) *time.Time {
 	renewalInfo, err := client.Certificate.GetRenewalInfo(ctx, cert)
 	if err != nil {
 		if errors.Is(err, api.ErrNoARI) {
 			log.Warn("The server does not advertise a renewal info endpoint.",
-				log.CertNameAttr(domain),
+				log.CertNameAttr(certID),
 				log.ErrorAttr(err),
 			)
 
 			return nil
 		}
 
-		log.Warn("calling renewal info endpoint",
-			log.CertNameAttr(domain),
+		log.Warn("Calling renewal info endpoint",
+			log.CertNameAttr(certID),
 			log.ErrorAttr(err),
 		)
 
@@ -279,15 +294,15 @@ func getARIRenewalTime(ctx context.Context, willingToSleep time.Duration, cert *
 
 	renewalTime := renewalInfo.ShouldRenewAt(now, willingToSleep)
 	if renewalTime == nil {
-		log.Info("RenewalInfo endpoint indicates that renewal is not needed.", log.CertNameAttr(domain))
+		log.Info("RenewalInfo endpoint indicates that renewal is not needed.", log.CertNameAttr(certID))
 		return nil
 	}
 
-	log.Info("RenewalInfo endpoint indicates that renewal is needed.", log.CertNameAttr(domain))
+	log.Info("RenewalInfo endpoint indicates that renewal is needed.", log.CertNameAttr(certID))
 
 	if renewalInfo.ExplanationURL != "" {
 		log.Info("RenewalInfo endpoint provided an explanation.",
-			log.CertNameAttr(domain),
+			log.CertNameAttr(certID),
 			slog.String("explanationURL", renewalInfo.ExplanationURL),
 		)
 	}


### PR DESCRIPTION
To understand the PR, you need to understand the constraints with the hooks inside the configuration file.

For example, the pre-hook is executed only if a certificate needs to be renewed or created, with the "classic" CLI it's easy because there is only one certificate.
But with the configuration file, there are several certificates: some certificates need to be renewed, some other not, some other need to be created.

If there are several DNS providers, maybe the hook needs to be different for each provider or based on other criteria.

The need related to pre-hook can be to start/launch something once before all the creation/renewal of certificates.
The need related to pre-hook can be to start/launch something before each creation/renewal of certificates.

And this is non-exhaustive and only for one example: pre-hook.

The cases are as complex as the pre-hook for the other hooks (post-hook, deploy-hook).

Currently, I don't know how to manage all the cases, I don't even know if it's possible.

So, I implemented the "simplest" solution for now: the hooks will be executed per-certificate and defined in only one place (the same hook for all the certificates).
Basically, the same thing as for running the "classic" CLI several times.

I think this will cover most of the cases.

If there is a need for more complex behaviors:

1. I will wait for feedback from the community.
2. I think it's already possible to "hack" around the topic by using local files inside the hook scripts as "lock" or "storage".
3. It's possible to add more metadata in the future.