### PR TITLE
refactor: PFX formats management

### DIFF
--- a/certcrypto/pkcs12.go
+++ b/certcrypto/pkcs12.go
@@ -1,0 +1,50 @@
+package certcrypto
+
+import (
+	"fmt"
+	"slices"
+
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// Constants for all PKCS#12 encryption format we support.
+const (
+	PKCS12LegacyDES  = "DES"
+	PKCS12LegacyRC2  = "RC2"
+	PKCS12Modern2023 = "SHA256"
+	PKCS12Modern2026 = "PBMAC1"
+)
+
+func AllPKCS12Formats() []string {
+	return []string{
+		PKCS12LegacyDES,
+		PKCS12LegacyRC2,
+		PKCS12Modern2023,
+		PKCS12Modern2026,
+	}
+}
+
+// IsPKCS12Supported checks if the provided format is a supported PKCS#12 encryption format.
+func IsPKCS12Supported(format string) bool {
+	return slices.Contains(AllPKCS12Formats(), format)
+}
+
+// GetPKCS12Encoder returns a PKCS12 encoder based on the provided format.
+func GetPKCS12Encoder(format string) (*pkcs12.Encoder, error) {
+	var encoder *pkcs12.Encoder
+
+	switch format {
+	case PKCS12Modern2026:
+		encoder = pkcs12.Modern2026
+	case PKCS12Modern2023:
+		encoder = pkcs12.Modern2023
+	case PKCS12LegacyDES:
+		encoder = pkcs12.LegacyDES
+	case PKCS12LegacyRC2:
+		encoder = pkcs12.LegacyRC2
+	default:
+		return nil, fmt.Errorf("invalid PKCS12 format: %s", format)
+	}
+
+	return encoder, nil
+}

--- a/cmd/internal/configuration/configuration_validation.go
+++ b/cmd/internal/configuration/configuration_validation.go
@@ -60,6 +60,10 @@ func validateCertificates(cfg *Configuration) error {
 		if err != nil {
 			return fmt.Errorf("%s: challenge: %w", name, err)
 		}
+
+		if cert.PFX != nil && !certcrypto.IsPKCS12Supported(cert.PFX.Format) {
+			return fmt.Errorf("%s: invalid PFX format: %s", name, cert.PFX.Format)
+		}
 	}
 
 	return nil

--- a/cmd/internal/configuration/lego.jsonschema.json
+++ b/cmd/internal/configuration/lego.jsonschema.json
@@ -7,6 +7,9 @@
     "keyType": {
       "enum": ["EC256", "EC384", "RSA2048", "RSA4096", "RSA8192"]
     },
+    "pkcs12Formats": {
+      "enum": ["DES", "RC2", "SHA256", "PBMAC1"]
+    },
     "serversSettings": {
       "type": "object",
       "additionalProperties": false,
@@ -261,7 +264,7 @@
       "additionalProperties": false,
       "properties": {
         "format": {
-          "enum": ["DES", "RC2", "SHA256"]
+          "$ref": "#/definitions/pkcs12Formats"
         },
         "password": {
           "type": "string"

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-acme/lego/v5/acme"
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/lego"
@@ -511,8 +512,17 @@ func createStorageFlags() []cli.Flag {
 			Category: categoryStorage,
 			Name:     FlgPFXFormat,
 			Sources:  cli.EnvVars(toEnvName(FlgPFXFormat)),
-			Usage:    "The encoding format to use when encrypting the .pfx (PCKS#12) file. Supported: RC2, DES, SHA256.",
-			Value:    "RC2",
+			Usage: fmt.Sprintf("The encoding format to use when encrypting the .pfx (PCKS#12) file. Supported: %s.",
+				strings.Join(certcrypto.AllPKCS12Formats(), ", "),
+			),
+			Value: certcrypto.PKCS12LegacyRC2,
+			Validator: func(s string) error {
+				if !certcrypto.IsPKCS12Supported(s) {
+					return fmt.Errorf("invalid PFX format: %s", s)
+				}
+
+				return nil
+			},
 		},
 	}
 }

--- a/cmd/internal/flags/names.go
+++ b/cmd/internal/flags/names.go
@@ -60,7 +60,7 @@ const (
 	FlgPath      = "path"
 	FlgPEM       = "pem"
 	FlgPFX       = "pfx"
-	FlgPFXPass   = "pfx.pass"
+	FlgPFXPass   = "pfx.password"
 	FlgPFXFormat = "pfx.format"
 )
 

--- a/cmd/internal/storage/storage_certificates_writer.go
+++ b/cmd/internal/storage/storage_certificates_writer.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/log"
-	"software.sslmate.com/src/go-pkcs12"
 )
 
 const filePerm os.FileMode = 0o600
@@ -25,23 +24,6 @@ type SaveOptions struct {
 	PFXPassword string
 }
 
-// Validate validates the options.
-func (o *SaveOptions) Validate() error {
-	if o == nil {
-		return nil
-	}
-
-	if o.PFX {
-		switch o.PFXFormat {
-		case "DES", "RC2", "SHA256":
-		default:
-			return fmt.Errorf("invalid PFX format: %s", o.PFXFormat)
-		}
-	}
-
-	return nil
-}
-
 // Save saves the certificate and related files.
 // - the resource file (JSON)
 // - the certificate file
@@ -50,12 +32,7 @@ func (o *SaveOptions) Validate() error {
 // - the PFX file (if needed)
 // - the PEM file (if needed).
 func (s *CertificatesStorage) Save(certRes *Certificate, opts *SaveOptions) error {
-	err := opts.Validate()
-	if err != nil {
-		return err
-	}
-
-	err = CreateNonExistingFolder(s.rootPath)
+	err := CreateNonExistingFolder(s.rootPath)
 	if err != nil {
 		return fmt.Errorf("root folder creation: %w", err)
 	}
@@ -148,7 +125,7 @@ func (s *CertificatesStorage) writePFXFile(certRes *Certificate, password, forma
 		return fmt.Errorf("unable to parse private ky %q: %w", certRes.ID, err)
 	}
 
-	encoder, err := getPFXEncoder(format)
+	encoder, err := certcrypto.GetPKCS12Encoder(format)
 	if err != nil {
 		return fmt.Errorf("PFX encoder: %w", err)
 	}
@@ -189,21 +166,4 @@ func getCertificateChain(certRes *Certificate) ([]*x509.Certificate, error) {
 	}
 
 	return certChain, nil
-}
-
-func getPFXEncoder(pfxFormat string) (*pkcs12.Encoder, error) {
-	var encoder *pkcs12.Encoder
-
-	switch pfxFormat {
-	case "SHA256":
-		encoder = pkcs12.Modern2023
-	case "DES":
-		encoder = pkcs12.LegacyDES
-	case "RC2":
-		encoder = pkcs12.LegacyRC2
-	default:
-		return nil, fmt.Errorf("invalid PFX format: %s", pfxFormat)
-	}
-
-	return encoder, nil
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -110,10 +110,11 @@ func newObtainForCSRRequest(cmd *cli.Command, csr *x509.CertificateRequest) cert
 
 func newSaveOptions(cmd *cli.Command) *storage.SaveOptions {
 	return &storage.SaveOptions{
-		PEM:         cmd.Bool(flags.FlgPEM),
+		PEM: cmd.Bool(flags.FlgPEM),
+
 		PFX:         cmd.Bool(flags.FlgPFX),
-		PFXFormat:   cmd.String(flags.FlgPFXPass),
-		PFXPassword: cmd.String(flags.FlgPFXFormat),
+		PFXPassword: cmd.String(flags.FlgPFXPass),
+		PFXFormat:   cmd.String(flags.FlgPFXFormat),
 	}
 }
 

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -140,8 +140,8 @@ OPTIONS:
    --path string                  Directory to use for storing the data. [$LEGO_PATH]
    --pem                          Generate an additional .pem (base64) file by concatenating the .key and .crt files together. [$LEGO_PEM]
    --pfx                          Generate an additional .pfx (PKCS#12) file by concatenating the .key and .crt and issuer .crt files together. [$LEGO_PFX]
-   --pfx.format string            The encoding format to use when encrypting the .pfx (PCKS#12) file. Supported: RC2, DES, SHA256. (default: "RC2") [$LEGO_PFX_FORMAT]
-   --pfx.pass string              The password used to encrypt the .pfx (PCKS#12) file. (default: "changeit") [$LEGO_PFX_PASS]
+   --pfx.format string            The encoding format to use when encrypting the .pfx (PCKS#12) file. Supported: DES, RC2, SHA256, PBMAC1. (default: "RC2") [$LEGO_PFX_FORMAT]
+   --pfx.password string          The password used to encrypt the .pfx (PCKS#12) file. (default: "changeit") [$LEGO_PFX_PASSWORD]
 """
 
 [[command]]


### PR DESCRIPTION
- fix inversion of CLI flags parsing: password and format.
- rename `pfx.pass` to `pfx.password`
- move code related to PKCS12 into `certcrypto` package.