### PR TITLE
feat: define default account only if needed

### DIFF
--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -105,7 +105,7 @@ func (c *SolverManager) chooseSolver(authz acme.Authorization) solver {
 			return solvr
 		}
 
-		log.Error("acme: Could not find the solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
+		log.Info("acme: Could not find the solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
 	}
 
 	return nil

--- a/cmd/internal/configuration/configuration.go
+++ b/cmd/internal/configuration/configuration.go
@@ -104,7 +104,7 @@ type Certificate struct {
 
 	Renew *RenewConfiguration `yaml:"renew,omitempty"`
 
-	PFX *PFX `json:"pfx,omitempty"`
+	PFX *PFX `yaml:"pfx,omitempty"`
 }
 
 type RenewConfiguration struct {
@@ -125,8 +125,8 @@ type ARIConfiguration struct {
 }
 
 type PFX struct {
-	Password string `json:"password,omitempty"`
-	Format   string `json:"format,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	Format   string `yaml:"format,omitempty"`
 }
 
 type Hooks struct {
@@ -136,8 +136,8 @@ type Hooks struct {
 }
 
 type Hook struct {
-	Cmd     string        `json:"command,omitempty"`
-	Timeout time.Duration `json:"timeout,omitempty"`
+	Cmd     string        `yaml:"command,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
 }
 
 type Log struct {

--- a/cmd/internal/configuration/configuration_defaults.go
+++ b/cmd/internal/configuration/configuration_defaults.go
@@ -46,12 +46,6 @@ func ApplyDefaults(cfg *Configuration) {
 	applyAccountsDefaults(cfg)
 	applyChallengesDefaults(cfg)
 	applyCertificatesDefaults(cfg)
-
-	// Must be last, because the certificate definition needs to know if there is an explicit account.
-	cfg.Accounts[DefaultAccountID] = &Account{
-		Server:  lego.DirectoryURLLetsEncrypt,
-		KeyType: certcrypto.EC256,
-	}
 }
 
 func applyServersDefaults(cfg *Configuration) {
@@ -92,6 +86,10 @@ func applyCertificatesDefaults(cfg *Configuration) {
 	for _, cert := range cfg.Certificates {
 		if cert.Account == "" {
 			cert.Account = defaultAccount
+		}
+
+		if cert.Account == DefaultAccountID {
+			setDefaultAccount(cfg)
 		}
 
 		if cert.KeyType == "" {
@@ -163,6 +161,17 @@ func setDefaultDNSPersist01(cfg *Configuration) {
 	}
 
 	cfg.Challenges[defaultDNSPersist01] = &Challenge{DNSPersist: &DNSPersistChallenge{}}
+}
+
+func setDefaultAccount(cfg *Configuration) {
+	if _, ok := cfg.Accounts[DefaultAccountID]; ok {
+		return
+	}
+
+	cfg.Accounts[DefaultAccountID] = &Account{
+		Server:  lego.DirectoryURLLetsEncrypt,
+		KeyType: certcrypto.EC256,
+	}
 }
 
 func getDefaultAccountID(cfg *Configuration) string {

--- a/cmd/internal/configuration/configuration_defaults.go
+++ b/cmd/internal/configuration/configuration_defaults.go
@@ -138,25 +138,31 @@ func applyRenewDefaults(cert *Certificate) {
 }
 
 func setDefaultHTTP01(cfg *Configuration) {
-	if _, ok := cfg.Challenges[defaultHTTP01]; !ok {
-		cfg.Challenges[defaultHTTP01] = &Challenge{HTTP: &HTTPChallenge{
-			Address: defaultHTTPAddress,
-		}}
+	if _, ok := cfg.Challenges[defaultHTTP01]; ok {
+		return
 	}
+
+	cfg.Challenges[defaultHTTP01] = &Challenge{HTTP: &HTTPChallenge{
+		Address: defaultHTTPAddress,
+	}}
 }
 
 func setDefaultTLSALPN01(cfg *Configuration) {
-	if _, ok := cfg.Challenges[defaultTLSALPN01]; !ok {
-		cfg.Challenges[defaultTLSALPN01] = &Challenge{TLS: &TLSChallenge{
-			Address: defaultTLSAddress,
-		}}
+	if _, ok := cfg.Challenges[defaultTLSALPN01]; ok {
+		return
 	}
+
+	cfg.Challenges[defaultTLSALPN01] = &Challenge{TLS: &TLSChallenge{
+		Address: defaultTLSAddress,
+	}}
 }
 
 func setDefaultDNSPersist01(cfg *Configuration) {
-	if _, ok := cfg.Challenges[defaultDNSPersist01]; !ok {
-		cfg.Challenges[defaultDNSPersist01] = &Challenge{DNSPersist: &DNSPersistChallenge{}}
+	if _, ok := cfg.Challenges[defaultDNSPersist01]; ok {
+		return
 	}
+
+	cfg.Challenges[defaultDNSPersist01] = &Challenge{DNSPersist: &DNSPersistChallenge{}}
 }
 
 func getDefaultAccountID(cfg *Configuration) string {

--- a/cmd/internal/configuration/configuration_defaults_test.go
+++ b/cmd/internal/configuration/configuration_defaults_test.go
@@ -15,14 +15,9 @@ func TestApplyDefaults(t *testing.T) {
 	ApplyDefaults(cfg)
 
 	expected := &Configuration{
-		Storage: defaultLegoDirectory,
-		Servers: map[string]*Server{},
-		Accounts: map[string]*Account{
-			DefaultAccountID: {
-				Server:  lego.DirectoryURLLetsEncrypt,
-				KeyType: certcrypto.EC256,
-			},
-		},
+		Storage:      defaultLegoDirectory,
+		Servers:      map[string]*Server{},
+		Accounts:     map[string]*Account{},
 		Challenges:   map[string]*Challenge{},
 		Certificates: map[string]*Certificate{},
 	}
@@ -215,11 +210,18 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "empty certificate",
 			cfg: &Configuration{
+				Accounts: map[string]*Account{},
 				Certificates: map[string]*Certificate{
 					"a": {},
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Certificates: map[string]*Certificate{
 					"a": {
 						Account: DefaultAccountID,
@@ -304,6 +306,7 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "explicit renew",
 			cfg: &Configuration{
+				Accounts: map[string]*Account{},
 				Certificates: map[string]*Certificate{
 					"a": {
 						Renew: &RenewConfiguration{
@@ -313,6 +316,12 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Certificates: map[string]*Certificate{
 					"a": {
 						Account: DefaultAccountID,
@@ -328,6 +337,7 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "explicit ari",
 			cfg: &Configuration{
+				Accounts: map[string]*Account{},
 				Certificates: map[string]*Certificate{
 					"a": {
 						Renew: &RenewConfiguration{
@@ -339,6 +349,12 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Certificates: map[string]*Certificate{
 					"a": {
 						Account: DefaultAccountID,
@@ -355,6 +371,7 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "default HTTP challenge",
 			cfg: &Configuration{
+				Accounts:   map[string]*Account{},
 				Challenges: map[string]*Challenge{},
 				Certificates: map[string]*Certificate{
 					"a": {
@@ -363,6 +380,12 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Challenges: map[string]*Challenge{
 					defaultHTTP01: {HTTP: &HTTPChallenge{
 						Address: defaultHTTPAddress,
@@ -383,6 +406,7 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "default TLS challenge",
 			cfg: &Configuration{
+				Accounts:   map[string]*Account{},
 				Challenges: map[string]*Challenge{},
 				Certificates: map[string]*Certificate{
 					"a": {
@@ -391,6 +415,12 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Challenges: map[string]*Challenge{
 					defaultTLSALPN01: {TLS: &TLSChallenge{
 						Address: defaultTLSAddress,
@@ -411,6 +441,7 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 		{
 			desc: "default if only one challenge",
 			cfg: &Configuration{
+				Accounts: map[string]*Account{},
 				Challenges: map[string]*Challenge{
 					"chlgA": {DNS: &DNSChallenge{Provider: "foo"}},
 				},
@@ -419,6 +450,12 @@ func Test_applyCertificatesDefaults(t *testing.T) {
 				},
 			},
 			expected: &Configuration{
+				Accounts: map[string]*Account{
+					DefaultAccountID: {
+						Server:  lego.DirectoryURLLetsEncrypt,
+						KeyType: certcrypto.EC256,
+					},
+				},
 				Challenges: map[string]*Challenge{
 					"chlgA": {DNS: &DNSChallenge{Provider: "foo"}},
 				},


### PR DESCRIPTION
When defining the default for a configuration, we can create the default internal account only if it's require.