### PR TITLE
feat: backup current configuration

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -40,14 +40,23 @@ func CreateCommands() []*cli.Command {
 }
 
 func rootRun(ctx context.Context, cmd *cli.Command) error {
-	filename, err := getConfigurationPath(cmd)
+	cfg, err := loadConfiguration(cmd)
 	if err != nil {
 		return err
 	}
 
+	return root.Process(ctx, cfg)
+}
+
+func loadConfiguration(cmd *cli.Command) (*configuration.Configuration, error) {
+	filename, err := getConfigurationPath(cmd)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg, err := configuration.ReadConfiguration(filename)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	setUpLogger(cmd, cfg.Log)
@@ -56,13 +65,13 @@ func rootRun(ctx context.Context, cmd *cli.Command) error {
 
 	err = configuration.Validate(cfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Set effective User Agent.
 	cfg.UserAgent = getUserAgent(cmd, cfg.UserAgent)
 
-	return root.Process(ctx, cfg)
+	return cfg, nil
 }
 
 func getConfigurationPath(cmd *cli.Command) (string, error) {

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/root"
+	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/urfave/cli/v3"
 )
 
@@ -45,7 +46,14 @@ func rootRun(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	return root.Process(ctx, cfg)
+	err = root.Process(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	store := storage.NewConfigurationStorage(cfg.Storage)
+
+	return store.Backup(cfg)
 }
 
 func loadConfiguration(cmd *cli.Command) (*configuration.Configuration, error) {

--- a/cmd/internal/configuration/configuration_validation.go
+++ b/cmd/internal/configuration/configuration_validation.go
@@ -48,21 +48,21 @@ func validateCertificates(cfg *Configuration) error {
 
 		err := validateCertificate(cert)
 		if err != nil {
-			return fmt.Errorf("%s: %w", name, err)
+			return fmt.Errorf("certificate '%s': %w", name, err)
 		}
 
 		err = existInMap(cfg.Accounts, cert.Account)
 		if err != nil {
-			return fmt.Errorf("%s: account: %w", name, err)
+			return fmt.Errorf("certificate '%s': account: %w", name, err)
 		}
 
 		err = existInMap(cfg.Challenges, cert.Challenge)
 		if err != nil {
-			return fmt.Errorf("%s: challenge: %w", name, err)
+			return fmt.Errorf("certificate '%s': challenge: %w", name, err)
 		}
 
 		if cert.PFX != nil && !certcrypto.IsPKCS12Supported(cert.PFX.Format) {
-			return fmt.Errorf("%s: invalid PFX format: %s", name, cert.PFX.Format)
+			return fmt.Errorf("certificate '%s': invalid PFX format: %s", name, cert.PFX.Format)
 		}
 	}
 
@@ -105,7 +105,7 @@ func validateChallenges(cfg *Configuration) error {
 
 		err := validateChallenge(challenge)
 		if err != nil {
-			return fmt.Errorf("%s: %w", name, err)
+			return fmt.Errorf("challenge '%s': %w", name, err)
 		}
 	}
 

--- a/cmd/internal/configuration/configuration_validation_test.go
+++ b/cmd/internal/configuration/configuration_validation_test.go
@@ -55,7 +55,7 @@ func Test_validateChallenges(t *testing.T) {
 					"a": {},
 				},
 			},
-			expected: "a: at least one challenge type must be defined",
+			expected: "challenge 'a': at least one challenge type must be defined",
 		},
 		{
 			desc: "DNS challenge without a provider",
@@ -66,7 +66,7 @@ func Test_validateChallenges(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: a provider is required",
+			expected: "challenge 'a': a provider is required",
 		},
 		{
 			desc: "DNS challenge propagation: wait and DisableAuthoritativeNameservers",
@@ -83,7 +83,7 @@ func Test_validateChallenges(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: 'wait' and 'disableAuthoritativeNameservers' are mutually exclusive",
+			expected: "challenge 'a': 'wait' and 'disableAuthoritativeNameservers' are mutually exclusive",
 		},
 		{
 			desc: "DNS challenge propagation: wait and DisableRecursiveNameservers",
@@ -100,7 +100,7 @@ func Test_validateChallenges(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: 'wait' and 'disableRecursiveNameservers' are mutually exclusive",
+			expected: "challenge 'a': 'wait' and 'disableRecursiveNameservers' are mutually exclusive",
 		},
 		{
 			desc: "DNS persist challenge propagation: wait and DisableAuthoritativeNameservers",
@@ -116,7 +116,7 @@ func Test_validateChallenges(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: 'wait' and 'disableAuthoritativeNameservers' are mutually exclusive",
+			expected: "challenge 'a': 'wait' and 'disableAuthoritativeNameservers' are mutually exclusive",
 		},
 		{
 			desc: "DNS persist challenge propagation: wait and DisableRecursiveNameservers",
@@ -132,7 +132,7 @@ func Test_validateChallenges(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: 'wait' and 'disableRecursiveNameservers' are mutually exclusive",
+			expected: "challenge 'a': 'wait' and 'disableRecursiveNameservers' are mutually exclusive",
 		},
 	}
 
@@ -174,7 +174,7 @@ func Test_validateCertificates(t *testing.T) {
 					"a": {},
 				},
 			},
-			expected: "a: at least one domain or CSR must be provided",
+			expected: "certificate 'a': at least one domain or CSR must be provided",
 		},
 		{
 			desc: "domain and CSR",
@@ -186,7 +186,7 @@ func Test_validateCertificates(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: domains and CSR are mutually exclusive",
+			expected: "certificate 'a': domains and CSR are mutually exclusive",
 		},
 		{
 			desc: "missing account",
@@ -195,7 +195,7 @@ func Test_validateCertificates(t *testing.T) {
 					"a": {Domains: []string{"example.com"}},
 				},
 			},
-			expected: "a: an account is required",
+			expected: "certificate 'a': an account is required",
 		},
 		{
 			desc: "missing challenge",
@@ -207,7 +207,7 @@ func Test_validateCertificates(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: a challenge is required",
+			expected: "certificate 'a': a challenge is required",
 		},
 		{
 			desc: "not existing account",
@@ -221,7 +221,7 @@ func Test_validateCertificates(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: account: 'acc' not found",
+			expected: "certificate 'a': account: 'acc' not found",
 		},
 		{
 			desc: "not existing challenge",
@@ -238,7 +238,7 @@ func Test_validateCertificates(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: challenge: 'chlg' not found",
+			expected: "certificate 'a': challenge: 'chlg' not found",
 		},
 		{
 			desc: "unsupported key type",
@@ -258,7 +258,7 @@ func Test_validateCertificates(t *testing.T) {
 					},
 				},
 			},
-			expected: "a: unsupported key type: foo",
+			expected: "certificate 'a': unsupported key type: foo",
 		},
 	}
 

--- a/cmd/internal/storage/storage.go
+++ b/cmd/internal/storage/storage.go
@@ -1,15 +1,17 @@
 package storage
 
 type Storage struct {
-	Certificate *CertificatesStorage
-	Account     *AccountsStorage
-	Archiver    *Archiver
+	Certificate   *CertificatesStorage
+	Account       *AccountsStorage
+	Archiver      *Archiver
+	Configuration *ConfigurationStorage
 }
 
 func New(basePath string) *Storage {
 	return &Storage{
-		Certificate: NewCertificatesStorage(basePath),
-		Account:     NewAccountsStorage(basePath),
-		Archiver:    NewArchiver(basePath),
+		Certificate:   NewCertificatesStorage(basePath),
+		Account:       NewAccountsStorage(basePath),
+		Archiver:      NewArchiver(basePath),
+		Configuration: NewConfigurationStorage(basePath),
 	}
 }

--- a/cmd/internal/storage/storage_configuration.go
+++ b/cmd/internal/storage/storage_configuration.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/go-acme/lego/v5/cmd/internal/configuration"
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigurationStorage is a storage for the configuration.
+// The backup is the effective configuration and cannot be used directly.
+type ConfigurationStorage struct {
+	backupPath string
+}
+
+// NewConfigurationStorage creates a new ConfigurationStorage.
+func NewConfigurationStorage(basePath string) *ConfigurationStorage {
+	return &ConfigurationStorage{
+		backupPath: filepath.Join(basePath, ".lego.bck.yaml"),
+	}
+}
+
+// Backup saves the configuration to the storage.
+func (s *ConfigurationStorage) Backup(cfg *configuration.Configuration) error {
+	file, err := os.Create(s.backupPath)
+	if err != nil {
+		return err
+	}
+
+	encoder := yaml.NewEncoder(file)
+	encoder.SetIndent(2)
+
+	defer func() { _ = encoder.Close() }()
+
+	return encoder.Encode(cfg)
+}
+
+// ReadBackup reads the backup configuration.
+func (s *ConfigurationStorage) ReadBackup() (*configuration.Configuration, error) {
+	file, err := os.Open(s.backupPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = file.Close() }()
+
+	cfg := &configuration.Configuration{}
+
+	err = yaml.NewDecoder(file).Decode(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
When running with a configuration, and no errors occurs, the effective configuration is stored into the storage.
For now, this "backup" of the configuration is not used during the process, but I think I need to add it now to being able to add new features later.
