### PR TITLE
feat: add experimental support for dotenv files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -253,6 +253,9 @@ linters:
       - path: cmd/cmd_run_renew.go
         text: cyclomatic complexity \d+ of func `(renewForDomains|renewForCSR)` is high
         linters:
+      - path: cmd/cmd_run.go
+        text: cyclomatic complexity \d+ of func `run` is high
+        linters:
           - gocyclo
       - path: cmd/internal/root/process_renew.go
         text: cyclomatic complexity \d+ of func `(renewForDomains|renewForCSR)` is high

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -254,11 +254,6 @@ linters:
         text: cyclomatic complexity \d+ of func `(renewForDomains|renewForCSR)` is high
         linters:
           - gocyclo
-      - path: cmd/internal/root/process.go
-        text: (cognitive|cyclomatic) complexity \d+ of func `process` is high
-        linters:
-          - gocognit
-          - gocyclo
       - path: cmd/internal/root/process_renew.go
         text: cyclomatic complexity \d+ of func `(renewForDomains|renewForCSR)` is high
         linters:

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
+	"github.com/go-acme/lego/v5/internal/dotenv"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 	"github.com/urfave/cli/v3"
@@ -36,6 +37,11 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	account, err := store.Account.Get(cmd.String(flags.FlgServer), keyType, cmd.String(flags.FlgEmail), cmd.String(flags.FlgAccountID))
 	if err != nil {
 		return fmt.Errorf("set up account: %w", err)
+	}
+
+	_, err = dotenv.Load(dotenv.BaseFilePrefix)
+	if err != nil {
+		return fmt.Errorf("set up environment: %w", err)
 	}
 
 	lazyClient := sync.OnceValues(func() (*lego.Client, error) {

--- a/cmd/internal/root/process.go
+++ b/cmd/internal/root/process.go
@@ -75,39 +75,48 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 			// each certificate is different, so the metadata is different, except for the account information.
 			hookManager := hm.Clone()
 
-			lazySetup := sync.OnceValues(func() (*lego.Client, error) {
-				client, errC := lazyClient()
-				if errC != nil {
-					return nil, fmt.Errorf("set up client: %w", errC)
-				}
-
-				client.Challenge.RemoveAll()
-
-				errC = setupChallenges(client, chlgNode.Challenge, networkStack)
-				if errC != nil {
-					return nil, fmt.Errorf("setup challenges: %w", errC)
-				}
-
-				return client, nil
-			})
-
-			for _, cert := range chlgNode.Certificates {
-				// Renew
-				if store.Certificate.ExistsFile(cert.ID, storage.ExtResource) {
-					err = renew(ctx, lazySetup, cert.ID, cert, store.Certificate, hookManager)
-					if err != nil {
-						return err
-					}
-
-					continue
-				}
-
-				// Run
-				err := obtain(ctx, lazySetup, cert.ID, cert, store.Certificate, hookManager)
-				if err != nil {
-					return err
-				}
+			err := processChallenges(ctx, lazyClient, chlgNode, store, hookManager, networkStack)
+			if err != nil {
+				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func processChallenges(ctx context.Context, lazyClient lzSetUp, chlgNode *configuration.ChallengeNode, store *storage.Storage, hookManager *hook.Manager, networkStack challenge.NetworkStack) error {
+	lazySetup := sync.OnceValues(func() (*lego.Client, error) {
+		client, errC := lazyClient()
+		if errC != nil {
+			return nil, fmt.Errorf("set up client: %w", errC)
+		}
+
+		client.Challenge.RemoveAll()
+
+		errC = setupChallenges(client, chlgNode.Challenge, networkStack)
+		if errC != nil {
+			return nil, fmt.Errorf("setup challenges: %w", errC)
+		}
+
+		return client, nil
+	})
+
+	for _, cert := range chlgNode.Certificates {
+		// Renew
+		if store.Certificate.ExistsFile(cert.ID, storage.ExtResource) {
+			err := renew(ctx, lazySetup, cert.ID, cert, store.Certificate, hookManager)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		// Run
+		err := obtain(ctx, lazySetup, cert.ID, cert, store.Certificate, hookManager)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/cmd/internal/root/process.go
+++ b/cmd/internal/root/process.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
+	"github.com/go-acme/lego/v5/internal/dotenv"
 	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/registration"
 )
@@ -86,6 +87,16 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 }
 
 func processChallenges(ctx context.Context, lazyClient lzSetUp, chlgNode *configuration.ChallengeNode, store *storage.Storage, hookManager *hook.Manager, networkStack challenge.NetworkStack) error {
+	if chlgNode.DNS != nil {
+		cleanUp, err := dotenv.Load(dotenv.BaseFilePrefix, dotenv.BaseFilePrefix+"."+chlgNode.ID)
+
+		defer cleanUp()
+
+		if err != nil {
+			return fmt.Errorf("load environment variables: %w", err)
+		}
+	}
+
 	lazySetup := sync.OnceValues(func() (*lego.Client, error) {
 		client, errC := lazyClient()
 		if errC != nil {

--- a/e2e/configuration/challenges_test.go
+++ b/e2e/configuration/challenges_test.go
@@ -19,8 +19,7 @@ var load = loader.EnvLoader{
 	},
 	LegoOptions: []string{
 		"LEGO_CA_CERTIFICATES=../fixtures/certs/pebble.minica.pem",
-		"EXEC_PATH=../fixtures/update-dns-config-file.sh",
-		"EXEC_SEQUENCE_INTERVAL=5",
+		"12b79c45_2153_4e99_9518_67b3350d878b=./fixtures",
 		"LEGO_DEBUG_ACME_HTTP_CLIENT=1",
 	},
 	ChallSrv: &loader.CmdOption{

--- a/e2e/configuration/fixtures/.env.mychallenge
+++ b/e2e/configuration/fixtures/.env.mychallenge
@@ -1,0 +1,2 @@
+EXEC_PATH=../fixtures/update-dns-config-file.sh
+EXEC_SEQUENCE_INTERVAL=5

--- a/e2e/dnschallenge/challenges_test.go
+++ b/e2e/dnschallenge/challenges_test.go
@@ -20,8 +20,7 @@ var load = loader.EnvLoader{
 	},
 	LegoOptions: []string{
 		"LEGO_CA_CERTIFICATES=../fixtures/certs/pebble.minica.pem",
-		"EXEC_PATH=../fixtures/update-dns.sh",
-		"EXEC_SEQUENCE_INTERVAL=5",
+		"12b79c45_2153_4e99_9518_67b3350d878b=./fixtures",
 		"LEGO_DEBUG_ACME_HTTP_CLIENT=1",
 	},
 	ChallSrv: &loader.CmdOption{

--- a/e2e/dnschallenge/fixtures/.env
+++ b/e2e/dnschallenge/fixtures/.env
@@ -1,0 +1,2 @@
+EXEC_PATH=../fixtures/update-dns.sh
+EXEC_SEQUENCE_INTERVAL=5

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.187
 	github.com/iij/doapi v0.0.0-20190504054126-0bbf12d6d7df
 	github.com/infobloxopen/infoblox-go-client/v2 v2.10.0
+	github.com/joho/godotenv v1.5.1
 	github.com/labbsr0x/bindman-dns-webhook v1.0.2
 	github.com/ldez/grignotin v0.10.1
 	github.com/linode/linodego v1.65.0

--- a/internal/dotenv/loader.go
+++ b/internal/dotenv/loader.go
@@ -1,0 +1,101 @@
+package dotenv
+
+import (
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+
+	"github.com/go-acme/lego/v5/log"
+	"github.com/joho/godotenv"
+)
+
+const BaseFilePrefix = ".env"
+
+func Load(filenames ...string) (func(), error) {
+	// ONLY FOR TESTING PURPOSE: DON'T USE IT!!
+	prefix, ok := os.LookupEnv("12b79c45_2153_4e99_9518_67b3350d878b")
+	if ok {
+		var prefixed []string
+
+		for _, filename := range filenames {
+			prefixed = append(prefixed, filepath.Join(prefix, filename))
+		}
+
+		filenames = prefixed
+	}
+
+	envs, err := read(filenames)
+	if err != nil {
+		return noopCleanUp, err
+	}
+
+	backup := make(map[string]string)
+
+	var toDelete []string
+
+	for k, v := range envs {
+		existingValue, found := os.LookupEnv(k)
+		if found {
+			backup[k] = existingValue
+		} else {
+			toDelete = append(toDelete, k)
+		}
+
+		err = os.Setenv(k, v)
+		if err != nil {
+			return noopCleanUp, err
+		}
+	}
+
+	return func() {
+		for k, v := range backup {
+			_ = os.Setenv(k, v)
+		}
+
+		for _, k := range toDelete {
+			_ = os.Unsetenv(k)
+		}
+	}, nil
+}
+
+func noopCleanUp() {}
+
+func read(filenames []string) (map[string]string, error) {
+	envMap := make(map[string]string)
+
+	for _, filename := range filenames {
+		_, err := os.Stat(filename)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Debug("Environment file not found", slog.String("filename", filename))
+
+				continue
+			}
+		}
+
+		data, err := readFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(data) == 0 {
+			continue
+		}
+
+		maps.Copy(envMap, data)
+	}
+
+	return envMap, nil
+}
+
+func readFile(filename string) (map[string]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = file.Close() }()
+
+	return godotenv.Parse(file)
+}

--- a/internal/dotenv/loader_test.go
+++ b/internal/dotenv/loader_test.go
@@ -38,8 +38,6 @@ func TestLoad(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
 			cleanUp, err := Load(test.filenames...)
 
 			t.Cleanup(cleanUp)

--- a/internal/dotenv/loader_test.go
+++ b/internal/dotenv/loader_test.go
@@ -1,0 +1,70 @@
+package dotenv
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		filenames []string
+		expected  []string
+	}{
+		{
+			desc: "no file",
+		},
+		{
+			desc:      "non-existing file",
+			filenames: []string{filepath.Join("testdata", BaseFilePrefix+".non-existing")},
+		},
+		{
+			desc:      "simple",
+			filenames: []string{filepath.Join("testdata", BaseFilePrefix)},
+			expected:  []string{"LEGO_TEST_ENV_A=aGlobal", "LEGO_TEST_ENV_B=bGlobal"},
+		},
+		{
+			desc:      "multiple files",
+			filenames: []string{filepath.Join("testdata", BaseFilePrefix), filepath.Join("testdata", BaseFilePrefix+".foo")},
+			expected:  []string{"LEGO_TEST_ENV_A=aLocal", "LEGO_TEST_ENV_B=bGlobal"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cleanUp, err := Load(test.filenames...)
+
+			t.Cleanup(cleanUp)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, getTestEnviron())
+
+			cleanUp()
+
+			assert.Empty(t, getTestEnviron())
+		})
+	}
+}
+
+func getTestEnviron() []string {
+	var result []string
+
+	for _, v := range os.Environ() {
+		if strings.HasPrefix(v, "LEGO_TEST_ENV_") {
+			result = append(result, v)
+		}
+	}
+
+	slices.Sort(result)
+
+	return result
+}

--- a/internal/dotenv/testdata/.env
+++ b/internal/dotenv/testdata/.env
@@ -1,0 +1,2 @@
+LEGO_TEST_ENV_A=aGlobal
+LEGO_TEST_ENV_B=bGlobal

--- a/internal/dotenv/testdata/.env.foo
+++ b/internal/dotenv/testdata/.env.foo
@@ -1,0 +1,1 @@
+LEGO_TEST_ENV_A=aLocal


### PR DESCRIPTION
There are two cases:
1. when using `lego run`
2. when using `lego` (the root command)

When using `lego run`, the environment variables are loaded from the `.env` file.

When using `lego`, the environment variables are loaded from the `.env` file, and from the file `.env.XXX` where `XXX` is the name defined in the configuration file as the challenge name (not the provider name).
The environment variables defined in the file `.env.XXX` overrides the environment variables defined in file `.env` ("merge").

This is experimental for several reasons: I don't know if it's a good idea, maybe it requires some adjustments.

In the end, this PR allows storing environment variables in files (easier to use), the configuration file doesn't store sensitive information, and the approach is relatively standard.