### PR TITLE
feat: require EAB parameters only when needed

### DIFF
--- a/cmd/cmd_accounts_register.go
+++ b/cmd/cmd_accounts_register.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -109,6 +110,10 @@ func registerAccount(ctx context.Context, cmd *cli.Command, client *lego.Client)
 	accepted := handleTOS(cmd, client)
 	if !accepted {
 		log.Fatal("You did not accept the TOS. Unable to proceed.")
+	}
+
+	if client.GetServerMetadata().ExternalAccountRequired && !cmd.IsSet(flags.FlgEAB) {
+		return nil, errors.New("server requires External Account Binding (EAB)")
 	}
 
 	if cmd.Bool(flags.FlgEAB) {

--- a/cmd/internal/root/process.go
+++ b/cmd/internal/root/process.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -51,10 +50,6 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 			client, errC := lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
 			if errC != nil {
 				return nil, errC
-			}
-
-			if client.GetServerMetadata().ExternalAccountRequired && accountNode.ExternalAccountBinding == nil {
-				return nil, errors.New("server requires External Account Binding (EAB)")
 			}
 
 			return client, nil

--- a/cmd/internal/root/process.go
+++ b/cmd/internal/root/process.go
@@ -47,12 +47,7 @@ func process(ctx context.Context, cfg *configuration.Configuration) error {
 		}
 
 		lazyClient := sync.OnceValues(func() (*lego.Client, error) {
-			client, errC := lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
-			if errC != nil {
-				return nil, errC
-			}
-
-			return client, nil
+			return lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
 		})
 
 		err = handleRegistration(ctx, lazyClient, accountNode.Account, store.Account, account, true)

--- a/cmd/internal/root/process_register.go
+++ b/cmd/internal/root/process_register.go
@@ -78,6 +78,10 @@ func registerAccount(ctx context.Context, client *lego.Client, accountConfig *co
 		return nil, errors.New("you did not accept the TOS: unable to proceed")
 	}
 
+	if client.GetServerMetadata().ExternalAccountRequired && accountConfig.ExternalAccountBinding == nil {
+		return nil, errors.New("server requires External Account Binding (EAB)")
+	}
+
 	if accountConfig.ExternalAccountBinding != nil {
 		return client.Registration.RegisterWithExternalAccountBinding(ctx, registration.RegisterEABOptions{
 			TermsOfServiceAgreed: true,

--- a/cmd/internal/root/revoke.go
+++ b/cmd/internal/root/revoke.go
@@ -28,12 +28,7 @@ func Revoke(ctx context.Context, cmd *cli.Command, cfg *configuration.Configurat
 		}
 
 		lazyClient := sync.OnceValues(func() (*lego.Client, error) {
-			client, errC := lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
-			if errC != nil {
-				return nil, errC
-			}
-
-			return client, nil
+			return lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
 		})
 
 		err = handleRegistration(ctx, lazyClient, accountNode.Account, store.Account, account, false)

--- a/cmd/internal/root/revoke.go
+++ b/cmd/internal/root/revoke.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -32,10 +31,6 @@ func Revoke(ctx context.Context, cmd *cli.Command, cfg *configuration.Configurat
 			client, errC := lego.NewClient(newClientConfig(accountNode.ServerConfig, account, cfg.UserAgent))
 			if errC != nil {
 				return nil, errC
-			}
-
-			if client.GetServerMetadata().ExternalAccountRequired && accountNode.ExternalAccountBinding == nil {
-				return nil, errors.New("server requires External Account Binding (EAB)")
 			}
 
 			return client, nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -22,12 +22,7 @@ import (
 type lzSetUp func() (*lego.Client, error)
 
 func newClient(cmd *cli.Command, account registration.User) (*lego.Client, error) {
-	client, err := lego.NewClient(newClientConfig(cmd, account))
-	if err != nil {
-		return nil, fmt.Errorf("new client: %w", err)
-	}
-
-	return client, nil
+	return lego.NewClient(newClientConfig(cmd, account))
 }
 
 func newClientConfig(cmd *cli.Command, account registration.User) *lego.Config {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,10 +25,6 @@ func newClient(cmd *cli.Command, account registration.User) (*lego.Client, error
 	client, err := lego.NewClient(newClientConfig(cmd, account))
 	if err != nil {
 		return nil, fmt.Errorf("new client: %w", err)
-	}
-
-	if client.GetServerMetadata().ExternalAccountRequired && !cmd.IsSet(flags.FlgEAB) {
-		return nil, errors.New("server requires External Account Binding (EAB)")
 	}
 
 	return client, nil

--- a/e2e/eab/eab_test.go
+++ b/e2e/eab/eab_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-acme/lego/v5/certcrypto"
@@ -60,6 +62,103 @@ func TestChallengeHTTP_Run_EAB(t *testing.T) {
 		"--eab",
 		"--eab.kid", "kid-3",
 		"--eab.hmac", "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc",
+	)
+	require.NoError(t, err)
+}
+
+func TestAccount_Register(t *testing.T) {
+	loader.CleanLegoFiles(t.Context())
+
+	err := load.RunLego(t.Context(),
+		"accounts", "register",
+		"-m", testEmail1,
+		"--accept-tos",
+		"-s", caDirectory,
+		"--eab",
+		"--eab.kid", "kid-3",
+		"--eab.hmac", "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc",
+	)
+	require.NoError(t, err)
+}
+
+func TestAccount_Recover(t *testing.T) {
+	loader.CleanLegoFiles(t.Context())
+
+	err := load.RunLego(t.Context(),
+		"accounts", "register",
+		"-m", testEmail1,
+		"--accept-tos",
+		"-s", caDirectory,
+		"--eab",
+		"--eab.kid", "kid-3",
+		"--eab.hmac", "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc",
+	)
+	require.NoError(t, err)
+
+	file, err := os.ReadFile(filepath.FromSlash(".lego/accounts/localhost_16000/lego@example.com/lego@example.com.key"))
+	require.NoError(t, err)
+
+	privateKeyPath := filepath.Join(t.TempDir(), "foo.key")
+
+	err = os.WriteFile(privateKeyPath, file, 0o600)
+	require.NoError(t, err)
+
+	// Delete the account directory
+	err = os.RemoveAll(filepath.FromSlash(".lego/accounts/"))
+	require.NoError(t, err)
+
+	stdinReader, stdinWriter := io.Pipe()
+
+	defer func() { _ = stdinReader.Close() }()
+
+	go func() {
+		defer func() { _ = stdinWriter.Close() }()
+
+		_, err = io.WriteString(stdinWriter, "Y\n")
+	}()
+
+	// NOTE: the EAB is not required when the account already exists in the CA server.
+	err = load.RunLegoWithInput(t.Context(),
+		stdinReader,
+		"accounts", "recover",
+		"-m", testEmail1,
+		"-s", caDirectory,
+		"--private-key", privateKeyPath,
+	)
+	require.NoError(t, err)
+}
+
+func TestAccount_KeyRollover(t *testing.T) {
+	loader.CleanLegoFiles(t.Context())
+
+	err := load.RunLego(t.Context(),
+		"accounts", "register",
+		"-m", testEmail1,
+		"--accept-tos",
+		"-s", caDirectory,
+		"--eab",
+		"--eab.kid", "kid-3",
+		"--eab.hmac", "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc",
+	)
+	require.NoError(t, err)
+
+	stdinReader, stdinWriter := io.Pipe()
+
+	defer func() { _ = stdinReader.Close() }()
+
+	go func() {
+		defer func() { _ = stdinWriter.Close() }()
+
+		_, err = io.WriteString(stdinWriter, "Y\n")
+	}()
+
+	// NOTE: the EAB is not required when the account already exists in the CA server.
+	err = load.RunLegoWithInput(t.Context(),
+		stdinReader,
+		"accounts", "keyrollover",
+		"-m", testEmail1,
+		"-s", caDirectory,
+		"--key-type", "rsa2048",
 	)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Currently, lego requires the EAB parameters to create a new Client if the CA requires them, but the EAB is only required for `newAccount` requests and specifically for new account.

This means any other requests not related to `newAccount` don't require the EAB parameters.
And this also means that `newAccount` requests related to existing accounts (keyrollover, recovery) don't require the EAB parameters.

> externalAccountRequired (optional, boolean): If this field is
> present and set to "true", then the CA requires that all
> newAccount requests include an "externalAccountBinding" field
> associating the new account with an external account.
> https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.1

IMHO, the RFC is not obvious on that, this could have been expressed more clearly, but I checked with the pebble implementation and added tests.

I move the check only when `newAccount` is called to create a new account (register).

Note: this wrong check was here since the v1.0.0 (2018), it was added during the support of ACME v2 inside the PR #516.

