### PR TITLE
feat(dnscale): add DNScale DNS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,188 +123,188 @@ If your DNS provider is not supported, please open an [issue](https://github.com
 </tr><tr>
   <td><a href="https://go-acme.github.io/lego/dns/dnsmadeeasy/">DNS Made Easy</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rfc2136/">DNS Update (RFC2136)</a></td>
+  <td><a href="https://go-acme.github.io/lego/dns/dnscale/">DNScale</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dnsexit/">DNSExit</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/dnshomede/">dnsHome.de</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/dnshomede/">dnsHome.de</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dnsimple/">DNSimple</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dnspod/">DNSPod (deprecated)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dode/">Domain Offensive (do.de)</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/domeneshop/">Domeneshop</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/domeneshop/">Domeneshop</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dreamhost/">DreamHost</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/duckdns/">Duck DNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dyn/">Dyn</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/dyndnsfree/">DynDnsFree.de</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/dyndnsfree/">DynDnsFree.de</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/dynu/">Dynu</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/easydns/">EasyDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/edgecenter/">EdgeCenter</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/efficientip/">Efficient IP</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/efficientip/">Efficient IP</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/epik/">Epik</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/eurodns/">EuroDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/excedo/">Excedo</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/exoscale/">Exoscale</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/exoscale/">Exoscale</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/exec/">External program</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/f5xc/">F5 XC</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/freemyip/">freemyip.com</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/namesurfer/">FusionLayer NameSurfer</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/namesurfer/">FusionLayer NameSurfer</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gcore/">G-Core</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gandi/">Gandi</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gandiv5/">Gandi Live DNS (v5)</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/gigahostno/">Gigahost.no</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/gigahostno/">Gigahost.no</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/glesys/">Glesys</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/godaddy/">Go Daddy</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gcloud/">Google Cloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/googledomains/">Google Domains</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/googledomains/">Google Domains</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gravity/">Gravity</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hetzner/">Hetzner</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hostingde/">Hosting.de</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/hostingnl/">Hosting.nl</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/hostingnl/">Hosting.nl</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hostinger/">Hostinger</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hosttech/">Hosttech</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/httpreq/">HTTP request</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/httpnet/">http.net</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/httpnet/">http.net</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/huaweicloud/">Huawei Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hurricane/">Hurricane Electric DNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hyperone/">HyperOne</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ibmcloud/">IBM Cloud (SoftLayer)</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ibmcloud/">IBM Cloud (SoftLayer)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/iijdpf/">IIJ DNS Platform Service</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/infoblox/">Infoblox</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/infomaniak/">Infomaniak</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/iij/">Internet Initiative Japan</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/iij/">Internet Initiative Japan</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/internetbs/">Internet.bs</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/inwx/">INWX</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ionos/">Ionos</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ionoscloud/">Ionos Cloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ionoscloud/">Ionos Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ipv64/">IPv64</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ispconfig/">ISPConfig 3</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ispconfigddns/">ISPConfig 3 - Dynamic DNS (DDNS) Module</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/iwantmyname/">iwantmyname (Deprecated)</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/iwantmyname/">iwantmyname (Deprecated)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/jdcloud/">JD Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/joker/">Joker</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/acme-dns/">Joohoi&#39;s ACME-DNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/keyhelp/">KeyHelp</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/keyhelp/">KeyHelp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/leaseweb/">Leaseweb</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/liara/">Liara</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/limacity/">Lima-City</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/linode/">Linode (v4)</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/linode/">Linode (v4)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/liquidweb/">Liquid Web</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/loopia/">Loopia</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/luadns/">LuaDNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/mailinabox/">Mail-in-a-Box</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/mailinabox/">Mail-in-a-Box</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/manageengine/">ManageEngine CloudDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/manual/">Manual</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/metaname/">Metaname</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/metaregistrar/">Metaregistrar</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/metaregistrar/">Metaregistrar</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mijnhost/">mijn.host</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mittwald/">Mittwald</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/myaddr/">myaddr.{tools,dev,io}</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/mydnsjp/">MyDNS.jp</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/mydnsjp/">MyDNS.jp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mythicbeasts/">MythicBeasts</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/namedotcom/">Name.com</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/namecheap/">Namecheap</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/namesilo/">Namesilo</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/namesilo/">Namesilo</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nearlyfreespeech/">NearlyFreeSpeech.NET</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/neodigit/">Neodigit</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/netcup/">Netcup</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/netlify/">Netlify</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/netlify/">Netlify</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/netnod/">Netnod</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nicmanager/">Nicmanager</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nifcloud/">NIFCloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/njalla/">Njalla</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/njalla/">Njalla</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nodion/">Nodion</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ns1/">NS1</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/octenium/">Octenium</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/onlinenet/">Online.net</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/onlinenet/">Online.net</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/otc/">Open Telekom Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/oraclecloud/">Oracle Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ovh/">OVH</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/plesk/">plesk.com</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/plesk/">plesk.com</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/porkbun/">Porkbun</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/pdns/">PowerDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rackspace/">Rackspace</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/rainyun/">Rain Yun/雨云</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/rainyun/">Rain Yun/雨云</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rcodezero/">RcodeZero</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/regru/">reg.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/regfish/">Regfish</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/rimuhosting/">RimuHosting</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/rimuhosting/">RimuHosting</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nicru/">RU CENTER</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/sakuracloud/">Sakura Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/scaleway/">Scaleway</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/selectel/">Selectel</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/selectel/">Selectel</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selectelv2/">Selectel v2</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selfhostde/">SelfHost.(de|eu)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/servercow/">Servercow</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/shellrent/">Shellrent</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/shellrent/">Shellrent</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/simply/">Simply.com</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/sonic/">Sonic</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/spaceship/">Spaceship</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/stackpath/">Stackpath</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/stackpath/">Stackpath</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/syse/">Syse</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/technitium/">Technitium</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/tencentcloud/">Tencent Cloud DNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/edgeone/">Tencent EdgeOne</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/edgeone/">Tencent EdgeOne</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/timewebcloud/">Timeweb Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/todaynic/">TodayNIC/时代互联</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/transip/">TransIP</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ucloud/">UCloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ucloud/">UCloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ultradns/">Ultradns</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/uniteddomains/">United-Domains</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/variomedia/">Variomedia</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vegadns/">VegaDNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vegadns/">VegaDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vercel/">Vercel</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/versio/">Versio.[nl|eu|uk]</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vinyldns/">VinylDNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/virtualname/">Virtualname</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/virtualname/">Virtualname</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vkcloud/">VK Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/volcengine/">Volcano Engine/火山引擎</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vscale/">Vscale</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vultr/">Vultr</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vultr/">Vultr</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/webnamesca/">webnames.ca</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/webnames/">webnames.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/websupport/">Websupport</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/wedos/">WEDOS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/wedos/">WEDOS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/westcn/">West.cn/西部数码</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandex360/">Yandex 360</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandexcloud/">Yandex Cloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/yandex/">Yandex PDD</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/yandex/">Yandex PDD</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zoneee/">Zone.ee</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zoneedit/">ZoneEdit</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zonomi/">Zonomi</a></td>
-  <td></td>
 </tr></table>
 
 <!-- END DNS PROVIDERS LIST -->

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -56,6 +56,7 @@ func allDNSCodes() string {
 		"designate",
 		"digitalocean",
 		"directadmin",
+		"dnscale",
 		"dnsexit",
 		"dnshomede",
 		"dnsimple",
@@ -1188,6 +1189,27 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/directadmin`)
+
+	case "dnscale":
+		// generated from: providers/dns/dnscale/dnscale.toml
+		ew.writeln(`Configuration for DNScale.`)
+		ew.writeln(`Code:	'dnscale'`)
+		ew.writeln(`Since:	'v4.22.0'`)
+		ew.writeln()
+
+		ew.writeln(`Credentials:`)
+		ew.writeln(`	- "DNSCALE_API_TOKEN":	API token (create at app.dnscale.eu with records:read and records:write scopes)`)
+		ew.writeln()
+
+		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "DNSCALE_API_URL":	API URL (Default: https://api.dnscale.eu)`)
+		ew.writeln(`	- "DNSCALE_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
+		ew.writeln(`	- "DNSCALE_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 5)`)
+		ew.writeln(`	- "DNSCALE_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 120)`)
+		ew.writeln(`	- "DNSCALE_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
+
+		ew.writeln()
+		ew.writeln(`More information: https://go-acme.github.io/lego/dns/dnscale`)
 
 	case "dnsexit":
 		// generated from: providers/dns/dnsexit/dnsexit.toml

--- a/docs/content/dns/zz_gen_dnscale.md
+++ b/docs/content/dns/zz_gen_dnscale.md
@@ -1,0 +1,68 @@
+---
+title: "DNScale"
+date: 2019-03-03T16:39:46+01:00
+draft: false
+slug: dnscale
+dnsprovider:
+  since:    "v4.22.0"
+  code:     "dnscale"
+  url:      "https://dnscale.eu"
+---
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/dnscale/dnscale.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+
+
+Configuration for [DNScale](https://dnscale.eu).
+
+
+<!--more-->
+
+- Code: `dnscale`
+- Since: v4.22.0
+
+
+Here is an example bash command using the DNScale provider:
+
+```bash
+DNSCALE_API_TOKEN=xxxxxxxx \
+lego --dns dnscale -d '*.example.com' -d example.com run
+```
+
+
+
+
+## Credentials
+
+| Environment Variable Name | Description |
+|-----------------------|-------------|
+| `DNSCALE_API_TOKEN` | API token (create at app.dnscale.eu with records:read and records:write scopes) |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+
+## Additional Configuration
+
+| Environment Variable Name | Description |
+|--------------------------------|-------------|
+| `DNSCALE_API_URL` | API URL (Default: https://api.dnscale.eu) |
+| `DNSCALE_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
+| `DNSCALE_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 5) |
+| `DNSCALE_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 120) |
+| `DNSCALE_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+
+
+
+## More information
+
+- [API documentation](https://docs.dnscale.eu)
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/dnscale/dnscale.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->

--- a/providers/dns/dnscale/dnscale.go
+++ b/providers/dns/dnscale/dnscale.go
@@ -1,0 +1,141 @@
+// Package dnscale implements a DNS provider for solving the DNS-01 challenge using the DNScale API.
+package dnscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v4/challenge/dns01"
+	"github.com/go-acme/lego/v4/platform/config/env"
+	"github.com/go-acme/lego/v4/providers/dns/dnscale/internal"
+)
+
+// Environment variables names.
+const (
+	envNamespace = "DNSCALE_"
+
+	EnvAPIToken = envNamespace + "API_TOKEN"
+	EnvAPIURL   = envNamespace + "API_URL"
+
+	EnvTTL                = envNamespace + "TTL"
+	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
+	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
+	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+)
+
+const defaultBaseURL = "https://api.dnscale.eu"
+
+// Ensure DNSProvider implements the required interfaces.
+var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
+
+// Config is used to configure the creation of the DNSProvider.
+type Config struct {
+	APIToken           string
+	BaseURL            string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider.
+func NewDefaultConfig() *Config {
+	return &Config{
+		BaseURL:            env.GetOrDefaultString(EnvAPIURL, defaultBaseURL),
+		TTL:                env.GetOrDefaultInt(EnvTTL, 120),
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 120*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 5*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+		},
+	}
+}
+
+// DNSProvider implements the challenge.Provider interface.
+type DNSProvider struct {
+	config *Config
+	client *internal.Client
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for DNScale.
+// Credentials must be passed in the environment variable: DNSCALE_API_TOKEN.
+func NewDNSProvider() (*DNSProvider, error) {
+	values, err := env.Get(EnvAPIToken)
+	if err != nil {
+		return nil, fmt.Errorf("dnscale: %w", err)
+	}
+
+	config := NewDefaultConfig()
+	config.APIToken = values[EnvAPIToken]
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig returns a DNSProvider instance configured for DNScale.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("dnscale: the configuration of the DNS provider is nil")
+	}
+
+	if config.APIToken == "" {
+		return nil, errors.New("dnscale: some credentials information are missing: DNSCALE_API_TOKEN")
+	}
+
+	client := internal.NewClient(config.BaseURL, config.APIToken)
+	if config.HTTPClient != nil {
+		client.HTTPClient = config.HTTPClient
+	}
+
+	return &DNSProvider{config: config, client: client}, nil
+}
+
+// Present creates a TXT record to fulfill the dns-01 challenge.
+func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+	ctx := context.Background()
+
+	info := dns01.GetChallengeInfo(domain, keyAuth)
+
+	zoneID, _, err := d.client.FindZoneByFQDN(ctx, info.EffectiveFQDN)
+	if err != nil {
+		return fmt.Errorf("dnscale: could not find zone for domain %q: %w", domain, err)
+	}
+
+	recordName := dns01.UnFqdn(info.EffectiveFQDN)
+
+	err = d.client.CreateTXTRecord(ctx, zoneID, recordName, info.Value, d.config.TTL)
+	if err != nil {
+		return fmt.Errorf("dnscale: create TXT record for %s: %w", recordName, err)
+	}
+
+	return nil
+}
+
+// CleanUp removes the TXT record matching the specified parameters.
+func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	ctx := context.Background()
+
+	info := dns01.GetChallengeInfo(domain, keyAuth)
+
+	zoneID, _, err := d.client.FindZoneByFQDN(ctx, info.EffectiveFQDN)
+	if err != nil {
+		return fmt.Errorf("dnscale: could not find zone for domain %q: %w", domain, err)
+	}
+
+	recordName := dns01.UnFqdn(info.EffectiveFQDN)
+
+	err = d.client.DeleteTXTRecord(ctx, zoneID, recordName, info.Value)
+	if err != nil {
+		return fmt.Errorf("dnscale: delete TXT record for %s: %w", recordName, err)
+	}
+
+	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
+}

--- a/providers/dns/dnscale/dnscale.toml
+++ b/providers/dns/dnscale/dnscale.toml
@@ -1,0 +1,23 @@
+Name = "DNScale"
+Description = ''''''
+URL = "https://dnscale.eu"
+Code = "dnscale"
+Since = "v4.22.0"
+
+Example = '''
+DNSCALE_API_TOKEN=xxxxxxxx \
+lego --dns dnscale -d '*.example.com' -d example.com run
+'''
+
+[Configuration]
+  [Configuration.Credentials]
+    DNSCALE_API_TOKEN = "API token (create at app.dnscale.eu with records:read and records:write scopes)"
+  [Configuration.Additional]
+    DNSCALE_API_URL = "API URL (Default: https://api.dnscale.eu)"
+    DNSCALE_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 5)"
+    DNSCALE_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 120)"
+    DNSCALE_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
+    DNSCALE_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
+
+[Links]
+  API = "https://docs.dnscale.eu"

--- a/providers/dns/dnscale/dnscale_test.go
+++ b/providers/dns/dnscale/dnscale_test.go
@@ -1,0 +1,277 @@
+package dnscale
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-acme/lego/v4/platform/tester"
+	"github.com/go-acme/lego/v4/providers/dns/dnscale/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const envDomain = envNamespace + "DOMAIN"
+
+var envTest = tester.NewEnvTest(
+	EnvAPIToken).
+	WithDomain(envDomain)
+
+func TestNewDNSProvider(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			desc: "success",
+			envVars: map[string]string{
+				EnvAPIToken: "test-token",
+			},
+		},
+		{
+			desc: "missing credentials",
+			envVars: map[string]string{
+				EnvAPIToken: "",
+			},
+			expected: "dnscale: some credentials information are missing: DNSCALE_API_TOKEN",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer envTest.RestoreEnv()
+
+			envTest.ClearEnv()
+
+			envTest.Apply(test.envVars)
+
+			p, err := NewDNSProvider()
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestNewDNSProviderConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		apiToken string
+		expected string
+	}{
+		{
+			desc:     "success",
+			apiToken: "test-token",
+		},
+		{
+			desc:     "missing credentials",
+			expected: "dnscale: some credentials information are missing: DNSCALE_API_TOKEN",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			config := NewDefaultConfig()
+			config.APIToken = test.apiToken
+
+			p, err := NewDNSProviderConfig(config)
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestNewDNSProviderConfig_NilConfig(t *testing.T) {
+	_, err := NewDNSProviderConfig(nil)
+	require.EqualError(t, err, "dnscale: the configuration of the DNS provider is nil")
+}
+
+func setupMockServer(t *testing.T, zones []internal.Zone) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(internal.ZonesResponse{
+			Status: "success",
+			Data:   internal.ZonesData{Zones: zones},
+		})
+	})
+
+	mux.HandleFunc("/v1/zones/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+
+			assert.Equal(t, "TXT", body["type"])
+			assert.NotEmpty(t, body["name"])
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodDelete:
+			content := r.URL.Query().Get("content")
+			assert.NotEmpty(t, content)
+
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestPresent(t *testing.T) {
+	server := setupMockServer(t, []internal.Zone{
+		{ID: "zone-123", Name: "example.com"},
+	})
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.Present("example.com", "token", "keyAuth")
+	require.NoError(t, err)
+}
+
+func TestPresent_Subdomain(t *testing.T) {
+	server := setupMockServer(t, []internal.Zone{
+		{ID: "zone-123", Name: "example.com"},
+	})
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.Present("sub.example.com", "token", "keyAuth")
+	require.NoError(t, err)
+}
+
+func TestPresent_ZoneNotFound(t *testing.T) {
+	server := setupMockServer(t, []internal.Zone{
+		{ID: "zone-other", Name: "other.com"},
+	})
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.Present("example.com", "token", "keyAuth")
+	require.Error(t, err)
+}
+
+func TestPresent_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(internal.ZonesResponse{
+			Status: "success",
+			Data:   internal.ZonesData{Zones: []internal.Zone{{ID: "zone-123", Name: "example.com"}}},
+		})
+	})
+	mux.HandleFunc("/v1/zones/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "forbidden", "message": "insufficient permissions",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.Present("example.com", "token", "keyAuth")
+	require.Error(t, err)
+}
+
+func TestCleanUp(t *testing.T) {
+	server := setupMockServer(t, []internal.Zone{
+		{ID: "zone-123", Name: "example.com"},
+	})
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.CleanUp("example.com", "token", "keyAuth")
+	require.NoError(t, err)
+}
+
+func TestCleanUp_ZoneNotFound(t *testing.T) {
+	server := setupMockServer(t, []internal.Zone{})
+	defer server.Close()
+
+	config := NewDefaultConfig()
+	config.APIToken = "test-token"
+	config.BaseURL = server.URL
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	err = provider.CleanUp("example.com", "token", "keyAuth")
+	require.Error(t, err)
+}
+
+func TestLivePresent(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	err = provider.Present(envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}
+
+func TestLiveCleanUp(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	err = provider.CleanUp(envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}

--- a/providers/dns/dnscale/internal/client.go
+++ b/providers/dns/dnscale/internal/client.go
@@ -1,0 +1,196 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Client is an HTTP client for the DNScale API.
+type Client struct {
+	baseURL    string
+	apiToken   string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new DNScale API client.
+func NewClient(baseURL, apiToken string) *Client {
+	return &Client{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		apiToken:   apiToken,
+		HTTPClient: &http.Client{},
+	}
+}
+
+// FindZoneByFQDN finds the zone that manages the given FQDN.
+// It strips labels from the left until a matching zone is found.
+// Returns the zone ID, zone name, and any error.
+func (c *Client) FindZoneByFQDN(ctx context.Context, fqdn string) (string, string, error) {
+	zones, err := c.listZones(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("list zones: %w", err)
+	}
+
+	// Strip the trailing dot from the FQDN.
+	name := strings.TrimSuffix(fqdn, ".")
+
+	// Walk up the domain labels to find the zone.
+	for {
+		for _, z := range zones {
+			zoneName := strings.TrimSuffix(z.Name, ".")
+			if strings.EqualFold(zoneName, name) {
+				return z.ID, z.Name, nil
+			}
+		}
+
+		// Remove the leftmost label.
+		idx := strings.Index(name, ".")
+		if idx < 0 {
+			break
+		}
+		name = name[idx+1:]
+	}
+
+	return "", "", fmt.Errorf("no zone found for %s", fqdn)
+}
+
+// CreateTXTRecord creates a TXT record in the given zone.
+func (c *Client) CreateTXTRecord(ctx context.Context, zoneID, name, value string, ttl int) error {
+	payload := RecordRequest{
+		Name:    name,
+		Type:    "TXT",
+		Content: value,
+		TTL:     ttl,
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/zones/%s/records", c.baseURL, zoneID)
+
+	req, err := c.newJSONRequest(ctx, http.MethodPost, endpoint, payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+
+	return nil
+}
+
+// DeleteTXTRecord deletes a specific TXT record by name and content value.
+func (c *Client) DeleteTXTRecord(ctx context.Context, zoneID, name, value string) error {
+	endpoint := fmt.Sprintf("%s/v1/zones/%s/records/by-name/%s/TXT?content=%s",
+		c.baseURL, zoneID, name, url.QueryEscape(value))
+
+	req, err := c.newJSONRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+
+	return nil
+}
+
+func (c *Client) listZones(ctx context.Context) ([]Zone, error) {
+	var allZones []Zone
+	offset := 0
+	limit := 100
+
+	for {
+		endpoint := fmt.Sprintf("%s/v1/zones?offset=%d&limit=%d", c.baseURL, offset, limit)
+
+		req, err := c.newJSONRequest(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP request failed: %w", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if err != nil {
+			return nil, fmt.Errorf("read response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result ZonesResponse
+		err = json.Unmarshal(body, &result)
+		if err != nil {
+			return nil, fmt.Errorf("decode response: %w", err)
+		}
+
+		allZones = append(allZones, result.Data.Zones...)
+
+		if len(result.Data.Zones) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return allZones, nil
+}
+
+func (c *Client) newJSONRequest(ctx context.Context, method, endpoint string, payload any) (*http.Request, error) {
+	var body io.Reader
+
+	if payload != nil {
+		buf := new(bytes.Buffer)
+		err := json.NewEncoder(buf).Encode(payload)
+		if err != nil {
+			return nil, fmt.Errorf("encode request body: %w", err)
+		}
+		body = buf
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Accept", "application/json")
+
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+func (c *Client) parseError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var apiErr APIError
+	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Code != "" {
+		return fmt.Errorf("API error %d: %s - %s", resp.StatusCode, apiErr.Error.Code, apiErr.Error.Message)
+	}
+
+	return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}

--- a/providers/dns/dnscale/internal/client_test.go
+++ b/providers/dns/dnscale/internal/client_test.go
@@ -1,0 +1,259 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	client := NewClient(server.URL, "test-token")
+	return client, server
+}
+
+func TestFindZoneByFQDN_ExactMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data:   ZonesData{Zones: []Zone{{ID: "z1", Name: "example.com"}}},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, name, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z1", id)
+	assert.Equal(t, "example.com", name)
+}
+
+func TestFindZoneByFQDN_SubdomainMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data:   ZonesData{Zones: []Zone{{ID: "z1", Name: "example.com"}}},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, _, err := client.FindZoneByFQDN(context.Background(), "_acme-challenge.sub.example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z1", id)
+}
+
+func TestFindZoneByFQDN_CaseInsensitive(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data:   ZonesData{Zones: []Zone{{ID: "z1", Name: "Example.COM"}}},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, _, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z1", id)
+}
+
+func TestFindZoneByFQDN_NoMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data:   ZonesData{Zones: []Zone{{ID: "z1", Name: "other.com"}}},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	_, _, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.Error(t, err)
+}
+
+func TestFindZoneByFQDN_ZoneWithTrailingDot(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data:   ZonesData{Zones: []Zone{{ID: "z1", Name: "example.com."}}},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, _, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z1", id)
+}
+
+func TestFindZoneByFQDN_MostSpecificMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ZonesResponse{
+			Status: "success",
+			Data: ZonesData{
+				Zones: []Zone{
+					{ID: "z-parent", Name: "example.com"},
+					{ID: "z-sub", Name: "sub.example.com"},
+				},
+			},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, _, err := client.FindZoneByFQDN(context.Background(), "_acme-challenge.sub.example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z-sub", id)
+}
+
+func TestCreateTXTRecord_Success(t *testing.T) {
+	mux := http.NewServeMux()
+
+	var received RecordRequest
+	mux.HandleFunc("/v1/zones/z1/records", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		json.NewDecoder(r.Body).Decode(&received)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.CreateTXTRecord(context.Background(), "z1", "_acme-challenge.example.com", "token-value", 120)
+	require.NoError(t, err)
+	assert.Equal(t, "_acme-challenge.example.com", received.Name)
+	assert.Equal(t, "TXT", received.Type)
+	assert.Equal(t, "token-value", received.Content)
+	assert.Equal(t, 120, received.TTL)
+}
+
+func TestCreateTXTRecord_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones/z1/records", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(APIError{
+			Status: "error",
+			Error:  APIErrorDetails{Code: "FORBIDDEN", Message: "insufficient scopes"},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.CreateTXTRecord(context.Background(), "z1", "test", "val", 120)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FORBIDDEN")
+}
+
+func TestDeleteTXTRecord_Success(t *testing.T) {
+	mux := http.NewServeMux()
+
+	var receivedContent string
+	mux.HandleFunc("/v1/zones/z1/records/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		receivedContent = r.URL.Query().Get("content")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.DeleteTXTRecord(context.Background(), "z1", "_acme-challenge.example.com", "token-value")
+	require.NoError(t, err)
+	assert.Equal(t, "token-value", receivedContent)
+}
+
+func TestDeleteTXTRecord_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones/z1/records/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(APIError{
+			Status: "error",
+			Error:  APIErrorDetails{Code: "NOT_FOUND", Message: "record not found"},
+		})
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.DeleteTXTRecord(context.Background(), "z1", "test", "val")
+	require.Error(t, err)
+}
+
+func TestListZones_Pagination(t *testing.T) {
+	mux := http.NewServeMux()
+	callCount := 0
+
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		offset := r.URL.Query().Get("offset")
+		if offset == "" || offset == "0" {
+			zones := make([]Zone, 100)
+			for i := range zones {
+				zones[i] = Zone{ID: "z-filler", Name: "filler.com"}
+			}
+			json.NewEncoder(w).Encode(ZonesResponse{Status: "success", Data: ZonesData{Zones: zones}})
+		} else {
+			json.NewEncoder(w).Encode(ZonesResponse{
+				Status: "success",
+				Data:   ZonesData{Zones: []Zone{{ID: "z-last", Name: "last.com"}}},
+			})
+		}
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	id, _, err := client.FindZoneByFQDN(context.Background(), "last.com.")
+	require.NoError(t, err)
+	assert.Equal(t, "z-last", id)
+	assert.GreaterOrEqual(t, callCount, 2)
+}
+
+func TestListZones_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	_, _, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.Error(t, err)
+}
+
+func TestListZones_InvalidJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	})
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	_, _, err := client.FindZoneByFQDN(context.Background(), "example.com.")
+	require.Error(t, err)
+}

--- a/providers/dns/dnscale/internal/types.go
+++ b/providers/dns/dnscale/internal/types.go
@@ -1,0 +1,40 @@
+package internal
+
+// Zone represents a DNScale DNS zone.
+type Zone struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ZonesData wraps the zone list in a paginated payload.
+type ZonesData struct {
+	Zones []Zone `json:"zones"`
+}
+
+// ZonesResponse is the API response for listing zones.
+// The DNScale API wraps responses as {"status":"success","data":{...}}.
+type ZonesResponse struct {
+	Status string    `json:"status"`
+	Data   ZonesData `json:"data"`
+}
+
+// RecordRequest is the request body for creating a DNS record.
+type RecordRequest struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	TTL     int    `json:"ttl"`
+}
+
+// APIErrorDetails holds the nested error fields.
+type APIErrorDetails struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// APIError is the error response from the DNScale API.
+// Shape: {"status":"error","error":{"code":"...","message":"..."}}.
+type APIError struct {
+	Status string          `json:"status"`
+	Error  APIErrorDetails `json:"error"`
+}

--- a/providers/dns/zz_gen_dns_providers.go
+++ b/providers/dns/zz_gen_dns_providers.go
@@ -50,6 +50,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/designate"
 	"github.com/go-acme/lego/v4/providers/dns/digitalocean"
 	"github.com/go-acme/lego/v4/providers/dns/directadmin"
+	"github.com/go-acme/lego/v4/providers/dns/dnscale"
 	"github.com/go-acme/lego/v4/providers/dns/dnsexit"
 	"github.com/go-acme/lego/v4/providers/dns/dnshomede"
 	"github.com/go-acme/lego/v4/providers/dns/dnsimple"
@@ -294,6 +295,8 @@ func NewDNSChallengeProviderByName(name string) (challenge.Provider, error) {
 		return digitalocean.NewDNSProvider()
 	case "directadmin":
 		return directadmin.NewDNSProvider()
+	case "dnscale":
+		return dnscale.NewDNSProvider()
 	case "dnsexit":
 		return dnsexit.NewDNSProvider()
 	case "dnshomede":


### PR DESCRIPTION
Adds a DNS provider for [DNScale](https://dnscale.eu), an authoritative DNS service.

## Details

- Provider code: `dnscale`
- API documentation: https://api.dnscale.eu (DNScale docs)
- Scopes required: `zones:read`, `records:read`, `records:write`
- Configuration:
  - `DNSCALE_API_TOKEN` (required)
  - `DNSCALE_API_URL` (optional, defaults to `https://api.dnscale.eu`)
  - `DNSCALE_TTL`, `DNSCALE_PROPAGATION_TIMEOUT`, `DNSCALE_POLLING_INTERVAL`, `DNSCALE_HTTP_TIMEOUT` (optional)

## Usage

```bash
DNSCALE_API_TOKEN=xxxxxxxx lego --dns dnscale -d '*.example.com' -d example.com run
```

## Testing

- Unit tests in `providers/dns/dnscale/` and `providers/dns/dnscale/internal/`
- Tested against production DNScale API with Let's Encrypt staging — issue and cleanup flows both work
- `go test ./providers/dns/dnscale/...` passes
- Generated docs produced via `make generate-dns`