### PR TITLE
feat: convert SetProxyHeader to an option

### DIFF
--- a/challenge/http01/http_challenge_server.go
+++ b/challenge/http01/http_challenge_server.go
@@ -18,10 +18,11 @@ import (
 var _ challenge.Provider = (*ProviderServer)(nil)
 
 type Options struct {
-	Network      string
-	NetworkStack challenge.NetworkStack
-	Address      string
-	SocketMode   fs.FileMode
+	Network         string
+	NetworkStack    challenge.NetworkStack
+	Address         string
+	SocketMode      fs.FileMode
+	ProxyHeaderName string
 }
 
 // ProviderServer implements ChallengeProvider for `http-01` challenge.
@@ -48,7 +49,7 @@ func NewProviderServerWithOptions(opts Options) *ProviderServer {
 		network:    opts.NetworkStack.Network(opts.Network),
 		address:    opts.Address,
 		socketMode: opts.SocketMode,
-		matcher:    &hostMatcher{},
+		matcher:    getMatcher(opts.ProxyHeaderName),
 	}
 }
 
@@ -115,26 +116,26 @@ func (s *ProviderServer) GetAddress() string {
 	return s.address
 }
 
-// SetProxyHeader changes the validation of incoming requests.
-// By default, s matches the "Host" header value to the domain name.
+// getMatcher gets the matcher for incoming requests.
+// By default, it matches the "Host" header value to the domain name.
 //
 // When the server runs behind a proxy server, this is not the correct place to look at;
 // Apache and NGINX have traditionally moved the original Host header into a new header named "X-Forwarded-Host".
 // Other webservers might use different names;
 // and RFC7239 has standardized a new header named "Forwarded" (with slightly different semantics).
 //
-// The exact behavior depends on the value of headerName:
+// The exact behavior depends on the value of proxyHeaderName:
 // - "" (the empty string) and "Host" will restore the default and only check the Host header
 // - "Forwarded" will look for a Forwarded header, and inspect it according to https://www.rfc-editor.org/rfc/rfc7239.html
 // - any other value will check the header value with the same name.
-func (s *ProviderServer) SetProxyHeader(headerName string) {
-	switch h := textproto.CanonicalMIMEHeaderKey(headerName); h {
+func getMatcher(proxyHeaderName string) domainMatcher {
+	switch h := textproto.CanonicalMIMEHeaderKey(proxyHeaderName); h {
 	case "", "Host":
-		s.matcher = &hostMatcher{}
+		return &hostMatcher{}
 	case "Forwarded":
-		s.matcher = &forwardedMatcher{}
+		return &forwardedMatcher{}
 	default:
-		s.matcher = arbitraryMatcher(h)
+		return arbitraryMatcher(h)
 	}
 }
 

--- a/challenge/http01/http_challenge_test.go
+++ b/challenge/http01/http_challenge_test.go
@@ -376,10 +376,13 @@ func testServeWithProxy(t *testing.T, header, extra *testProxyHeader, expectErro
 
 	server := tester.MockACMEServer().BuildHTTPS(t)
 
-	providerServer := NewProviderServer("localhost", "23457")
+	options := Options{Address: "localhost:23457"}
+
 	if header != nil {
-		providerServer.SetProxyHeader(header.name)
+		options.ProxyHeaderName = header.name
 	}
+
+	providerServer := NewProviderServerWithOptions(options)
 
 	validate := func(ctx context.Context, _ *api.Core, _ string, chlng acme.Challenge) error {
 		uri := "http://" + providerServer.GetAddress() + ChallengePath(chlng.Token)

--- a/cmd/internal/root/process_challenges.go
+++ b/cmd/internal/root/process_challenges.go
@@ -93,25 +93,19 @@ func createHTTPProvider(chlg *configuration.HTTPChallenge, networkStack challeng
 		}
 
 		srv := http01.NewProviderServerWithOptions(http01.Options{
-			Network: networkStack.Network("tcp"),
-			Address: net.JoinHostPort(host, port),
+			Network:         networkStack.Network("tcp"),
+			Address:         net.JoinHostPort(host, port),
+			ProxyHeaderName: chlg.ProxyHeader,
 		})
-
-		if header := chlg.ProxyHeader; header != "" {
-			srv.SetProxyHeader(header)
-		}
 
 		return srv, nil
 
 	default:
 		srv := http01.NewProviderServerWithOptions(http01.Options{
-			Network: networkStack.Network("tcp"),
-			Address: net.JoinHostPort("", ":80"),
+			Network:         networkStack.Network("tcp"),
+			Address:         net.JoinHostPort("", ":80"),
+			ProxyHeaderName: chlg.ProxyHeader,
 		})
-
-		if header := chlg.ProxyHeader; header != "" {
-			srv.SetProxyHeader(header)
-		}
 
 		return srv, nil
 	}

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -94,25 +94,19 @@ func createHTTPProvider(cmd *cli.Command) (challenge.Provider, error) {
 		}
 
 		ps := http01.NewProviderServerWithOptions(http01.Options{
-			Network: getNetworkStack(cmd).Network("tcp"),
-			Address: net.JoinHostPort(host, port),
+			Network:         getNetworkStack(cmd).Network("tcp"),
+			Address:         net.JoinHostPort(host, port),
+			ProxyHeaderName: cmd.String(flags.FlgHTTPProxyHeader),
 		})
-
-		if header := cmd.String(flags.FlgHTTPProxyHeader); header != "" {
-			ps.SetProxyHeader(header)
-		}
 
 		return ps, nil
 
 	default:
 		ps := http01.NewProviderServerWithOptions(http01.Options{
-			Network: getNetworkStack(cmd).Network("tcp"),
-			Address: net.JoinHostPort("", ":80"),
+			Network:         getNetworkStack(cmd).Network("tcp"),
+			Address:         net.JoinHostPort("", ":80"),
+			ProxyHeaderName: cmd.String(flags.FlgHTTPProxyHeader),
 		})
-
-		if header := cmd.String(flags.FlgHTTPProxyHeader); header != "" {
-			ps.SetProxyHeader(header)
-		}
 
 		return ps, nil
 	}

--- a/docs/content/migration/library.md
+++ b/docs/content/migration/library.md
@@ -52,6 +52,8 @@ The following methods now return an `*acme.ExtendedAccount` instead of an `*regi
 
 The structure `registration.Ressouce` has been removed.
 
+The method `http01.ProviderServer.SetProxyHeader` is removed and replaced by an option `http01.Options.ProxyHeaderName`.
+
 ## Fields changes
 
 The field `RetryAfter` of `acme.RateLimitedError` and `acme.ExtendedChallenge` is now a `time.Duration` instead of a `string`.


### PR DESCRIPTION
The method `http01.ProviderServer.SetProxyHeader` is removed and replaced by an option `http01.Options.ProxyHeaderName`.
