### PR TITLE
rfc2136: fix zones env var parsing

### DIFF
--- a/providers/dns/rfc2136/env.go
+++ b/providers/dns/rfc2136/env.go
@@ -37,7 +37,12 @@ func getEnvString(name string) string {
 }
 
 func getEnvStringSlice(name string) []string {
-	return strings.Split(getEnvString(name), ",")
+	v := getEnvString(name)
+	if v == "" {
+		return nil
+	}
+
+	return strings.Split(v, ",")
 }
 
 func getOrDefaultString(name, defaultValue string) string {

--- a/providers/dns/rfc2136/env_test.go
+++ b/providers/dns/rfc2136/env_test.go
@@ -44,3 +44,44 @@ func Test_altEnvNames(t *testing.T) {
 		})
 	}
 }
+
+func Test_getEnvStringSlice(t *testing.T) {
+	t.Setenv("LEGO_TEST_EMPTY", "")
+	t.Setenv("LEGO_TEST_SIMPLE", "bar")
+	t.Setenv("LEGO_TEST_MULTIPLE", "foo,bar")
+
+	testCases := []struct {
+		desc     string
+		name     string
+		expected []string
+	}{
+		{
+			desc: "non-existent env var",
+			name: "LEGO_TEST_FOO",
+		},
+		{
+			desc: "empty env var",
+			name: "LEGO_TEST_EMPTY",
+		},
+		{
+			desc:     "single value",
+			name:     "LEGO_TEST_SIMPLE",
+			expected: []string{"bar"},
+		},
+		{
+			desc:     "multiple values",
+			name:     "LEGO_TEST_MULTIPLE",
+			expected: []string{"foo", "bar"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			v := getEnvStringSlice(test.name)
+
+			assert.Equal(t, test.expected, v)
+		})
+	}
+}

--- a/providers/dns/rfc2136/rfc2136.go
+++ b/providers/dns/rfc2136/rfc2136.go
@@ -285,7 +285,7 @@ func (d *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 	}
 
 	if reply != nil && reply.Rcode != dns.RcodeSuccess {
-		return fmt.Errorf("DNS update failed: server replied: %s", dns.RcodeToString[reply.Rcode])
+		return fmt.Errorf("DNS update failed: server %s replied %s for %s %s", d.config.Nameserver, dns.RcodeToString[reply.Rcode], action, zone)
 	}
 
 	return nil

--- a/providers/dns/rfc2136/rfc2136_test.go
+++ b/providers/dns/rfc2136/rfc2136_test.go
@@ -398,7 +398,10 @@ func TestDNSProvider_Present_tsig_error(t *testing.T) {
 
 	err = provider.Present(fakeDomain, "", fakeKeyAuth)
 	require.Error(t, err)
-	require.EqualError(t, err, "dnsupdate: failed to insert: DNS update failed: server replied: NOTZONE")
+
+	require.EqualError(t, err,
+		"dnsupdate: failed to insert: DNS update failed: "+
+			"server "+addr.String()+" replied NOTZONE for INSERT _acme-challenge.123456789.www.example.com.")
 }
 
 func handleTSIG(w dns.ResponseWriter, req *dns.Msg) {


### PR DESCRIPTION
If the `DNSUPDATE_ZONES` env var was empty, the parsing was resulting in a slice with one empty value instead of nil.

Add more details when the DNS server returned an error.

Fixes #3019