### PR TITLE
docs: Add Installation Instructions for Fedora

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -30,6 +30,12 @@ docker run goacme/lego -h
   yay -S lego-bin
   ```
 
+- [Fedora](https://packages.fedoraproject.org/pkgs/golang-github-acme-lego/golang-github-acme-lego/) (official):
+
+  ```bash
+  sudo dnf install golang-github-acme-lego
+  ```
+
 - [Snap](https://snapcraft.io/lego) (official):
 
   ```bash


### PR DESCRIPTION
Fedora package [lego]. Adding it to the Installation page, at the end of the official packages. As the list seemed to be ordered by official/unofficial and then lexicographically so I followed that convention when adding the entry

[lego]: https://packages.fedoraproject.org/pkgs/golang-github-acme-lego/golang-github-acme-lego/