### PR TITLE
chore: fix flaky tests

### DIFF
--- a/acme/api/internal/sender/headers_test.go
+++ b/acme/api/internal/sender/headers_test.go
@@ -86,7 +86,8 @@ func Test_parseRetryAfter(t *testing.T) {
 			rt, err := parseRetryAfter(test.value)
 			require.NoError(t, err)
 
-			assert.InDelta(t, test.expected.Seconds(), rt.Seconds(), 1)
+			// use a delta of 1.2 because the CI on Windows is slow...
+			assert.InDelta(t, test.expected.Seconds(), rt.Seconds(), 1.2)
 		})
 	}
 }

--- a/providers/dns/nicru/internal/client.go
+++ b/providers/dns/nicru/internal/client.go
@@ -13,10 +13,7 @@ import (
 	"github.com/go-acme/lego/v5/internal/errutils"
 )
 
-const (
-	apiBaseURL = "https://api.nic.ru/dns-master"
-	tokenURL   = "https://api.nic.ru/oauth/token"
-)
+const apiBaseURL = "https://api.nic.ru/dns-master"
 
 const successStatus = "success"
 
@@ -228,6 +225,8 @@ func newXMLRequest(ctx context.Context, method string, endpoint *url.URL, payloa
 
 		encoder := xml.NewEncoder(body)
 		encoder.Indent("", "  ")
+
+		defer encoder.Close()
 
 		err := encoder.Encode(payload)
 		if err != nil {

--- a/providers/dns/nicru/internal/identity.go
+++ b/providers/dns/nicru/internal/identity.go
@@ -2,52 +2,18 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
 	"golang.org/x/oauth2"
 )
 
-// OauthConfiguration credentials.
-type OauthConfiguration struct {
-	OAuth2ClientID string
-	OAuth2SecretID string
-	Username       string
-	Password       string
-}
+const tokenURL = "https://api.nic.ru/oauth/token"
 
-func (config *OauthConfiguration) Validate() error {
-	msg := " is missing in credentials information"
-
-	if config.Username == "" {
-		return errors.New("username" + msg)
-	}
-
-	if config.Password == "" {
-		return errors.New("password" + msg)
-	}
-
-	if config.OAuth2ClientID == "" {
-		return errors.New("serviceID" + msg)
-	}
-
-	if config.OAuth2SecretID == "" {
-		return errors.New("secret" + msg)
-	}
-
-	return nil
-}
-
-func NewOauthClient(ctx context.Context, config *OauthConfiguration) (*http.Client, error) {
-	err := config.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	oauth2Config := oauth2.Config{
-		ClientID:     config.OAuth2ClientID,
-		ClientSecret: config.OAuth2SecretID,
+func NewOauthClient(ctx context.Context, clientID, clientSecret, username, password string) (*http.Client, error) {
+	oauth2Config := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 		Endpoint: oauth2.Endpoint{
 			TokenURL:  tokenURL,
 			AuthStyle: oauth2.AuthStyleInParams,
@@ -55,7 +21,8 @@ func NewOauthClient(ctx context.Context, config *OauthConfiguration) (*http.Clie
 		Scopes: []string{".+:/dns-master/.+"},
 	}
 
-	oauth2Token, err := oauth2Config.PasswordCredentialsToken(ctx, config.Username, config.Password)
+	// Note: under the hood, this function is doing a request to the token endpoint.
+	oauth2Token, err := oauth2Config.PasswordCredentialsToken(ctx, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create oauth2 token: %w", err)
 	}

--- a/providers/dns/nicru/nicru.go
+++ b/providers/dns/nicru/nicru.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-acme/lego/v5/challenge"
@@ -53,8 +54,9 @@ func NewDefaultConfig() *Config {
 
 // DNSProvider implements the challenge.Provider interface.
 type DNSProvider struct {
-	client *internal.Client
 	config *Config
+
+	lazyClient func() (*internal.Client, error)
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for RU Center.
@@ -79,26 +81,28 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("nicru: the configuration of the DNS provider is nil")
 	}
 
-	clientCfg := &internal.OauthConfiguration{
-		OAuth2ClientID: config.ServiceID,
-		OAuth2SecretID: config.Secret,
-		Username:       config.Username,
-		Password:       config.Password,
-	}
-
-	oauthClient, err := internal.NewOauthClient(context.Background(), clientCfg)
+	err := validate(config)
 	if err != nil {
 		return nil, fmt.Errorf("nicru: %w", err)
 	}
 
-	client, err := internal.NewClient(clientdebug.Wrap(oauthClient))
-	if err != nil {
-		return nil, fmt.Errorf("nicru: unable to build API client: %w", err)
-	}
+	lazyClient := sync.OnceValues(func() (*internal.Client, error) {
+		oauthClient, err := internal.NewOauthClient(context.Background(), config.ServiceID, config.Secret, config.Username, config.Password)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := internal.NewClient(clientdebug.Wrap(oauthClient))
+		if err != nil {
+			return nil, fmt.Errorf("unable to build the API client: %w", err)
+		}
+
+		return client, nil
+	})
 
 	return &DNSProvider{
-		client: client,
-		config: config,
+		config:     config,
+		lazyClient: lazyClient,
 	}, nil
 }
 
@@ -113,7 +117,12 @@ func (d *DNSProvider) Present(ctx context.Context, domain, _, keyAuth string) er
 
 	authZone = dns01.UnFqdn(authZone)
 
-	zone, err := d.findZone(ctx, authZone)
+	client, err := d.lazyClient()
+	if err != nil {
+		return fmt.Errorf("nicru: %w", err)
+	}
+
+	zone, err := findZone(ctx, client, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: find zone: %w", err)
 	}
@@ -123,7 +132,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, _, keyAuth string) er
 		return fmt.Errorf("nicru: %w", err)
 	}
 
-	records, err := d.client.GetRecords(ctx, zone.Service, authZone)
+	records, err := client.GetRecords(ctx, zone.Service, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: get records: %w", err)
 	}
@@ -145,12 +154,12 @@ func (d *DNSProvider) Present(ctx context.Context, domain, _, keyAuth string) er
 		TXT:  &internal.TXT{String: info.Value},
 	}}
 
-	_, err = d.client.AddRecords(ctx, zone.Service, authZone, rrs)
+	_, err = client.AddRecords(ctx, zone.Service, authZone, rrs)
 	if err != nil {
 		return fmt.Errorf("nicru: add records: %w", err)
 	}
 
-	err = d.client.CommitZone(ctx, zone.Service, authZone)
+	err = client.CommitZone(ctx, zone.Service, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: commit zone: %w", err)
 	}
@@ -169,7 +178,12 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, _, keyAuth string) er
 
 	authZone = dns01.UnFqdn(authZone)
 
-	zone, err := d.findZone(ctx, authZone)
+	client, err := d.lazyClient()
+	if err != nil {
+		return fmt.Errorf("nicru: %w", err)
+	}
+
+	zone, err := findZone(ctx, client, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: find zone: %w", err)
 	}
@@ -179,7 +193,7 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, _, keyAuth string) er
 		return fmt.Errorf("nicru: %w", err)
 	}
 
-	records, err := d.client.GetRecords(ctx, zone.Service, authZone)
+	records, err := client.GetRecords(ctx, zone.Service, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: get records: %w", err)
 	}
@@ -195,13 +209,13 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, _, keyAuth string) er
 			continue
 		}
 
-		err = d.client.DeleteRecord(ctx, zone.Service, authZone, record.ID)
+		err = client.DeleteRecord(ctx, zone.Service, authZone, record.ID)
 		if err != nil {
 			return fmt.Errorf("nicru: delete record: %w", err)
 		}
 	}
 
-	err = d.client.CommitZone(ctx, zone.Service, authZone)
+	err = client.CommitZone(ctx, zone.Service, authZone)
 	if err != nil {
 		return fmt.Errorf("nicru: commit zone: %w", err)
 	}
@@ -215,8 +229,8 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
-func (d *DNSProvider) findZone(ctx context.Context, authZone string) (*internal.Zone, error) {
-	zones, err := d.client.ListZones(ctx)
+func findZone(ctx context.Context, client *internal.Client, authZone string) (*internal.Zone, error) {
+	zones, err := client.ListZones(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch dns zones: %w", err)
 	}
@@ -232,4 +246,26 @@ func (d *DNSProvider) findZone(ctx context.Context, authZone string) (*internal.
 	}
 
 	return nil, fmt.Errorf("zone not found for %s", authZone)
+}
+
+func validate(config *Config) error {
+	msg := " is missing in credentials information"
+
+	if config.Username == "" {
+		return errors.New("username" + msg)
+	}
+
+	if config.Password == "" {
+		return errors.New("password" + msg)
+	}
+
+	if config.ServiceID == "" {
+		return errors.New("serviceID" + msg)
+	}
+
+	if config.Secret == "" {
+		return errors.New("secret" + msg)
+	}
+
+	return nil
 }

--- a/providers/dns/nicru/nicru_test.go
+++ b/providers/dns/nicru/nicru_test.go
@@ -32,7 +32,6 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvUsername:  fakeUsername,
 				EnvPassword:  fakePassword,
 			},
-			expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\"",
 		},
 		{
 			desc: "missing serviceID",
@@ -107,7 +106,6 @@ func TestNewDNSProviderConfig(t *testing.T) {
 				Username:  fakeUsername,
 				Password:  fakePassword,
 			},
-			expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\"",
 		},
 		{
 			desc:     "nil config",


### PR DESCRIPTION
<details>
<summary>nicru</summary>

```
=== RUN   TestNewDNSProvider/success
    nicru_test.go:90: 
        	Error Trace:	/home/runner/work/lego/lego/providers/dns/nicru/nicru_test.go:90
        	Error:      	Error message not equal:
        	            	expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\""
        	            	actual  : "nicru: failed to create oauth2 token: Post \"https://api.nic.ru/oauth/token\": net/http: TLS handshake timeout"
```

```
 === RUN   TestNewDNSProviderConfig/success
    nicru_test.go:163: 
        	Error Trace:	/home/runner/work/lego/lego/providers/dns/nicru/nicru_test.go:163
        	Error:      	Error message not equal:
        	            	expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\""
        	            	actual  : "nicru: failed to create oauth2 token: Post \"https://api.nic.ru/oauth/token\": dial tcp 31.177.76.7:443: i/o timeout"
        	Test:       	TestNewDNSProviderConfig/success
```

```
=== RUN   TestNewDNSProvider/success
    nicru_test.go:90: 
        	Error Trace:	D:/a/lego/lego/providers/dns/nicru/nicru_test.go:90
        	Error:      	Error message not equal:
        	            	expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\""
        	            	actual  : "nicru: failed to create oauth2 token: Post \"https://api.nic.ru/oauth/token\": dial tcp 31.177.76.7:443: connectex: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."
```

```
=== RUN   TestNewDNSProviderConfig/success
    nicru_test.go:163: 
        	Error Trace:	D:/a/lego/lego/providers/dns/nicru/nicru_test.go:163
        	Error:      	Error message not equal:
        	            	expected: "nicru: failed to create oauth2 token: oauth2: \"unauthorized_client\""
        	            	actual  : "nicru: failed to create oauth2 token: Post \"https://api.nic.ru/oauth/token\": dial tcp 31.177.76.7:443: connectex: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."
```

</details>


<details>
<summary>parseRetryAfter on Windows CI</summary>

```
=== NAME  Test_parseRetryAfter/HTTP-date
    headers_test.go:89: 
        	Error Trace:	D:/a/lego/lego/acme/api/internal/sender/headers_test.go:89
        	Error:      	Max difference between 3 and 1.9749151 allowed is 1, but difference was 1.0250849
        	Test:       	Test_parseRetryAfter/HTTP-date
--- FAIL: Test_parseRetryAfter (0.03s)
    --- PASS: Test_parseRetryAfter/empty_header_value (0.00s)
    --- PASS: Test_parseRetryAfter/delay-seconds (0.00s)
    --- FAIL: Test_parseRetryAfter/HTTP-date (0.00s)

```

</details>