### PR TITLE
chore: extra payload signature verification

### DIFF
--- a/acme/api/internal/secure/jws.go
+++ b/acme/api/internal/secure/jws.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/go-acme/lego/v4/acme/api/internal/nonces"
-	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4"
 )
 
 // JWS Represents a JWS.
@@ -72,6 +72,15 @@ func (j *JWS) SignContent(url string, content []byte) (*jose.JSONWebSignature, e
 	signed, err := signer.Sign(content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign content: %w", err)
+	}
+
+	// Verify the signed payload.
+	key, ok := signKey.Key.(jose.JSONWebKey)
+	if ok {
+		_, err = signed.Verify(key.Public())
+		if err != nil {
+			return nil, fmt.Errorf("verify signature: %w", err)
+		}
 	}
 
 	return signed, nil


### PR DESCRIPTION
Related to #3032

Add an extra payload signature verification, this is more a debug thing than something we will ship.

<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout feat/verify-signature
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego`

</details>
