### PR TITLE
artfiles: add server name option

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -421,6 +421,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "ARTFILES_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
 		ew.writeln(`	- "ARTFILES_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)
 		ew.writeln(`	- "ARTFILES_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 360)`)
+		ew.writeln(`	- "ARTFILES_SERVER_NAME":	Your server name (Default: dcp)`)
 		ew.writeln(`	- "ARTFILES_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_artfiles.md
+++ b/docs/content/dns/zz_gen_artfiles.md
@@ -52,6 +52,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 | `ARTFILES_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
 | `ARTFILES_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |
 | `ARTFILES_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 360) |
+| `ARTFILES_SERVER_NAME` | Your server name (Default: dcp) |
 | `ARTFILES_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/artfiles/artfiles.go
+++ b/providers/dns/artfiles/artfiles.go
@@ -49,7 +49,8 @@ func NewDefaultConfig() *Config {
 		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 6*time.Minute),
 		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
 		HTTPClient: &http.Client{
-			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			Timeout:       env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+			CheckRedirect: internal.CheckRedirect,
 		},
 	}
 }

--- a/providers/dns/artfiles/artfiles.go
+++ b/providers/dns/artfiles/artfiles.go
@@ -21,8 +21,9 @@ import (
 const (
 	envNamespace = "ARTFILES_"
 
-	EnvUsername = envNamespace + "USERNAME"
-	EnvPassword = envNamespace + "PASSWORD"
+	EnvUsername   = envNamespace + "USERNAME"
+	EnvPassword   = envNamespace + "PASSWORD"
+	EnvServerName = envNamespace + "SERVER_NAME"
 
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
@@ -33,8 +34,9 @@ var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
 
 // Config is used to configure the creation of the DNSProvider.
 type Config struct {
-	Username string
-	Password string
+	Username   string
+	Password   string
+	ServerName string
 
 	PropagationTimeout time.Duration
 	PollingInterval    time.Duration
@@ -68,6 +70,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config := NewDefaultConfig()
 	config.Username = values[EnvUsername]
 	config.Password = values[EnvPassword]
+	config.ServerName = env.GetOrDefaultString(EnvServerName, "dcp")
 
 	return NewDNSProviderConfig(config)
 }
@@ -78,7 +81,7 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		return nil, errors.New("artfiles: the configuration of the DNS provider is nil")
 	}
 
-	client, err := internal.NewClient(config.Username, config.Password)
+	client, err := internal.NewClient(config.Username, config.Password, config.ServerName)
 	if err != nil {
 		return nil, fmt.Errorf("artfiles: %w", err)
 	}

--- a/providers/dns/artfiles/artfiles.toml
+++ b/providers/dns/artfiles/artfiles.toml
@@ -15,6 +15,7 @@ lego run --dns artfiles -d '*.example.com' -d example.com
     ARTFILES_USERNAME = "API username"
     ARTFILES_PASSWORD = "API password"
   [Configuration.Additional]
+    ARTFILES_SERVER_NAME = "Your server name (Default: dcp)"
     ARTFILES_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
     ARTFILES_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 360)"
     ARTFILES_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"

--- a/providers/dns/artfiles/internal/client.go
+++ b/providers/dns/artfiles/internal/client.go
@@ -14,8 +14,6 @@ import (
 	"github.com/go-acme/lego/v5/internal/useragent"
 )
 
-const defaultBaseURL = "https://dcp.c.artfiles.de/api/"
-
 // Client the ArtFiles API client.
 type Client struct {
 	username string
@@ -26,12 +24,15 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(username, password string) (*Client, error) {
+func NewClient(username, password, serverName string) (*Client, error) {
 	if username == "" || password == "" {
 		return nil, errors.New("credentials missing")
 	}
 
-	baseURL, _ := url.Parse(defaultBaseURL)
+	baseURL, err := url.Parse(getServerURL(serverName))
+	if err != nil {
+		return nil, fmt.Errorf("parse server URL: %w", err)
+	}
 
 	return &Client{
 		username:   username,
@@ -130,4 +131,12 @@ func (c *Client) do(req *http.Request) ([]byte, error) {
 	}
 
 	return raw, nil
+}
+
+func getServerURL(serverName string) string {
+	if serverName == "" {
+		serverName = "dcp"
+	}
+
+	return fmt.Sprintf("https://%s.c.artfiles.de/api/", serverName)
 }

--- a/providers/dns/artfiles/internal/client.go
+++ b/providers/dns/artfiles/internal/client.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/go-acme/lego/v5/internal/errutils"
 	"github.com/go-acme/lego/v5/internal/useragent"
+	"github.com/miekg/dns"
 )
+
+const maxRedirects = 5
 
 // Client the ArtFiles API client.
 type Client struct {
@@ -139,4 +142,26 @@ func getServerURL(serverName string) string {
 	}
 
 	return fmt.Sprintf("https://%s.c.artfiles.de/api/", serverName)
+}
+
+func CheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+
+	prev := via[len(via)-1]
+
+	// Same main domain: `c.artfiles.de` (3 labels in common).
+	if dns.CompareDomainName(req.URL.Host, prev.URL.Host) == 3 {
+		auth := prev.Header.Get("Authorization")
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+	}
+
+	return nil
 }

--- a/providers/dns/artfiles/internal/client_test.go
+++ b/providers/dns/artfiles/internal/client_test.go
@@ -15,7 +15,7 @@ import (
 func mockBuilder() *servermock.Builder[*Client] {
 	return servermock.NewBuilder[*Client](
 		func(server *httptest.Server) (*Client, error) {
-			client, err := NewClient("user", "secret")
+			client, err := NewClient("user", "secret", "")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Add new option `ARTFILES_SERVER_NAME` (Default: `dcp`).

Extra: if there are redirection on the same main domain (`c.artfiles.de`) the `Authorization` header is copied.

Fixes #3048