### PR TITLE
mijnhost: use single endpoints

### DIFF
--- a/providers/dns/mijnhost/internal/client.go
+++ b/providers/dns/mijnhost/internal/client.go
@@ -66,7 +66,7 @@ func (c *Client) GetRecords(ctx context.Context, domain string) ([]Record, error
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	var results Response[RecordData]
+	var results Response[RecordsData]
 
 	err = c.do(req, &results)
 	if err != nil {
@@ -81,17 +81,38 @@ func (c *Client) GetRecords(ctx context.Context, domain string) ([]Record, error
 func (c *Client) UpdateRecords(ctx context.Context, domain string, records []Record) error {
 	endpoint := c.BaseURL.JoinPath("domains", domain, "dns")
 
-	req, err := newJSONRequest(ctx, http.MethodPut, endpoint, RecordData{Records: records})
+	req, err := newJSONRequest(ctx, http.MethodPut, endpoint, RecordsData{Records: records})
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	err = c.do(req, nil)
+	return c.do(req, nil)
+}
+
+// UpdateRecord Update a single DNS record.
+// https://mijn.host/api/doc/api-3600003
+func (c *Client) UpdateRecord(ctx context.Context, domain string, record Record) error {
+	endpoint := c.BaseURL.JoinPath("domains", domain, "dns")
+
+	req, err := newJSONRequest(ctx, http.MethodPatch, endpoint, RecordData{Record: record})
 	if err != nil {
-		return err
+		return fmt.Errorf("create request: %w", err)
 	}
 
-	return nil
+	return c.do(req, nil)
+}
+
+// DeleteRecord Delete a single DNS record.
+// https://mijn.host/api/doc/api-4293957
+func (c *Client) DeleteRecord(ctx context.Context, domain string, record Record) error {
+	endpoint := c.BaseURL.JoinPath("domains", domain, "dns")
+
+	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, RecordData{Record: record})
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	return c.do(req, nil)
 }
 
 func (c *Client) do(req *http.Request, result any) error {

--- a/providers/dns/mijnhost/internal/client_test.go
+++ b/providers/dns/mijnhost/internal/client_test.go
@@ -138,3 +138,40 @@ func TestClient_UpdateRecords(t *testing.T) {
 	err := client.UpdateRecords(t.Context(), "example.com", records)
 	require.NoError(t, err)
 }
+
+func TestClient_UpdateRecord(t *testing.T) {
+	client := mockBuilder().
+		Route("PATCH /domains/example.com/dns",
+			servermock.ResponseFromFixture("update_dns_record.json"),
+			servermock.CheckRequestJSONBodyFromFixture("update_dns_record-request.json"),
+		).
+		Build(t)
+
+	record := Record{
+		Type:  "TXT",
+		Name:  "_acme-challenge",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+		TTL:   120,
+	}
+
+	err := client.UpdateRecord(t.Context(), "example.com", record)
+	require.NoError(t, err)
+}
+
+func TestClient_DeleteRecord(t *testing.T) {
+	client := mockBuilder().
+		Route("DELETE /domains/example.com/dns",
+			servermock.ResponseFromFixture("delete_dns_record.json"),
+			servermock.CheckRequestJSONBodyFromFixture("delete_dns_record-request.json"),
+		).
+		Build(t)
+
+	record := Record{
+		Type:  "TXT",
+		Name:  "_acme-challenge",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+	}
+
+	err := client.DeleteRecord(t.Context(), "example.com", record)
+	require.NoError(t, err)
+}

--- a/providers/dns/mijnhost/internal/fixtures/delete_dns_record-request.json
+++ b/providers/dns/mijnhost/internal/fixtures/delete_dns_record-request.json
@@ -1,0 +1,7 @@
+{
+  "record": {
+    "type": "TXT",
+    "name":  "_acme-challenge",
+    "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY"
+  }
+}

--- a/providers/dns/mijnhost/internal/fixtures/delete_dns_record.json
+++ b/providers/dns/mijnhost/internal/fixtures/delete_dns_record.json
@@ -1,0 +1,4 @@
+{
+  "status": 0,
+  "status_description": "string"
+}

--- a/providers/dns/mijnhost/internal/fixtures/update_dns_record-request.json
+++ b/providers/dns/mijnhost/internal/fixtures/update_dns_record-request.json
@@ -1,0 +1,8 @@
+{
+  "record": {
+    "type": "TXT",
+    "name":  "_acme-challenge",
+    "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+    "ttl": 120
+  }
+}

--- a/providers/dns/mijnhost/internal/fixtures/update_dns_record.json
+++ b/providers/dns/mijnhost/internal/fixtures/update_dns_record.json
@@ -1,0 +1,4 @@
+{
+  "status": 0,
+  "status_description": "string"
+}

--- a/providers/dns/mijnhost/internal/types.go
+++ b/providers/dns/mijnhost/internal/types.go
@@ -17,9 +17,13 @@ type Response[T any] struct {
 	Data              T      `json:"data,omitempty"`
 }
 
-type RecordData struct {
+type RecordsData struct {
 	Domain  string   `json:"domain,omitempty"`
 	Records []Record `json:"records,omitempty"`
+}
+
+type RecordData struct {
+	Record Record `json:"record"`
 }
 
 type Record struct {

--- a/providers/dns/mijnhost/mijnhost.go
+++ b/providers/dns/mijnhost/mijnhost.go
@@ -125,11 +125,6 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("mijnhost: find domain: %w", err)
 	}
 
-	records, err := d.client.GetRecords(ctx, dom.Domain)
-	if err != nil {
-		return fmt.Errorf("mijnhost: get records: %w", err)
-	}
-
 	subDomain, err := dns01.ExtractSubDomain(info.EffectiveFQDN, dom.Domain)
 	if err != nil {
 		return fmt.Errorf("mijnhost: %w", err)
@@ -142,17 +137,9 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		TTL:   d.config.TTL,
 	}
 
-	// mijn.host doesn't support multiple values for a domain,
-	// so we removed existing record for the subdomain.
-	cleanedRecords := filterRecords(records, func(record internal.Record) bool {
-		return record.Type == txtType && (record.Name == subDomain || record.Name == dns01.UnFqdn(info.EffectiveFQDN))
-	})
-
-	cleanedRecords = append(cleanedRecords, record)
-
-	err = d.client.UpdateRecords(ctx, dom.Domain, cleanedRecords)
+	err = d.client.UpdateRecord(ctx, dom.Domain, record)
 	if err != nil {
-		return fmt.Errorf("mijnhost: update records: %w", err)
+		return fmt.Errorf("mijnhost: update record: %w", err)
 	}
 
 	return nil
@@ -172,18 +159,20 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("mijnhost: find domain: %w", err)
 	}
 
-	records, err := d.client.GetRecords(ctx, dom.Domain)
+	subDomain, err := dns01.ExtractSubDomain(info.EffectiveFQDN, dom.Domain)
 	if err != nil {
-		return fmt.Errorf("mijnhost: get records: %w", err)
+		return fmt.Errorf("mijnhost: %w", err)
 	}
 
-	cleanedRecords := filterRecords(records, func(record internal.Record) bool {
-		return record.Type == txtType && record.Value == info.Value
-	})
+	record := internal.Record{
+		Type:  txtType,
+		Name:  subDomain,
+		Value: info.Value,
+	}
 
-	err = d.client.UpdateRecords(ctx, dom.Domain, cleanedRecords)
+	err = d.client.DeleteRecord(ctx, dom.Domain, record)
 	if err != nil {
-		return fmt.Errorf("mijnhost: update records: %w", err)
+		return fmt.Errorf("mijnhost: delete record: %w", err)
 	}
 
 	return nil
@@ -199,18 +188,4 @@ func findDomain(domains []internal.Domain, fqdn string) (internal.Domain, error)
 	}
 
 	return internal.Domain{}, fmt.Errorf("domain %s not found", fqdn)
-}
-
-func filterRecords(records []internal.Record, fn func(record internal.Record) bool) []internal.Record {
-	var newRecords []internal.Record
-
-	for _, record := range records {
-		if record.Type == "TXT" && fn(record) {
-			continue
-		}
-
-		newRecords = append(newRecords, record)
-	}
-
-	return newRecords
 }

--- a/providers/dns/mijnhost/mijnhost_test.go
+++ b/providers/dns/mijnhost/mijnhost_test.go
@@ -147,12 +147,9 @@ func TestDNSProvider_Present(t *testing.T) {
 		Route("GET /domains",
 			servermock.ResponseFromInternal("list_domains.json"),
 		).
-		Route("GET /domains/example.com/dns",
-			servermock.ResponseFromInternal("get_dns_records.json"),
-		).
-		Route("PUT /domains/example.com/dns",
-			servermock.ResponseFromInternal("update_dns_records.json"),
-			servermock.CheckRequestJSONBodyFromInternal("update_dns_records-request_add.json"),
+		Route("PATCH /domains/example.com/dns",
+			servermock.ResponseFromInternal("update_dns_record.json"),
+			servermock.CheckRequestJSONBodyFromInternal("update_dns_record-request.json"),
 		).
 		Build(t)
 
@@ -165,12 +162,9 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 		Route("GET /domains",
 			servermock.ResponseFromInternal("list_domains.json"),
 		).
-		Route("GET /domains/example.com/dns",
-			servermock.ResponseFromInternal("get_dns_records-existing.json"),
-		).
-		Route("PUT /domains/example.com/dns",
-			servermock.ResponseFromInternal("update_dns_records.json"),
-			servermock.CheckRequestJSONBodyFromInternal("update_dns_records-request_remove.json"),
+		Route("DELETE /domains/example.com/dns",
+			servermock.ResponseFromInternal("delete_dns_record.json"),
+			servermock.CheckRequestJSONBodyFromInternal("delete_dns_record-request.json"),
 		).
 		Build(t)
 


### PR DESCRIPTION
Related to #3041


<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout feat/v5/dns/mijnhost-single
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    MIJNHOST_API_KEY="xxx"
    ./dist/lego run --dns mijnhost -d '*.example.com' -d example.com -s letsencrypt-staging
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>