### PR TITLE
chore: improve logs and error messages

### DIFF
--- a/acme/api/internal/sender/headers.go
+++ b/acme/api/internal/sender/headers.go
@@ -58,7 +58,7 @@ func GetRetryAfter(resp *http.Response) time.Duration {
 
 	retryAfter, err := parseRetryAfter(resp.Header.Get("Retry-After"))
 	if err != nil {
-		log.Warn("acme: Failed to parse Retry-After header.", log.ErrorAttr(err))
+		log.Warn("Failed to parse Retry-After header.", log.ErrorAttr(err))
 	}
 
 	return retryAfter

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -193,9 +193,9 @@ func (c *Certifier) Obtain(ctx context.Context, request ObtainRequest) (*Resourc
 	domains := sanitizeDomain(request.Domains)
 
 	if request.Bundle {
-		log.Info("acme: Obtaining bundled SAN certificate.", log.DomainsAttr(domains))
+		log.Info("Obtaining bundled SAN certificate.", log.DomainsAttr(domains))
 	} else {
-		log.Info("acme: Obtaining SAN certificate.", log.DomainsAttr(domains))
+		log.Info("Obtaining SAN certificate.", log.DomainsAttr(domains))
 	}
 
 	orderOpts := &api.OrderOptions{
@@ -224,7 +224,7 @@ func (c *Certifier) Obtain(ctx context.Context, request ObtainRequest) (*Resourc
 		return nil, err
 	}
 
-	log.Info("acme: Validations succeeded; requesting certificates.", log.DomainsAttr(domains))
+	log.Info("Validations succeeded; requesting certificates.", log.DomainsAttr(domains))
 
 	failures := errutils.NewDomainsError("certificates")
 
@@ -271,9 +271,9 @@ func (c *Certifier) ObtainForCSR(ctx context.Context, request ObtainForCSRReques
 	domains := certcrypto.ExtractDomainsCSR(request.CSR)
 
 	if request.Bundle {
-		log.Info("acme: Obtaining bundled SAN certificate given a CSR.", log.DomainsAttr(domains))
+		log.Info("Obtaining bundled SAN certificate given a CSR.", log.DomainsAttr(domains))
 	} else {
-		log.Info("acme: Obtaining SAN certificate given a CSR.", log.DomainsAttr(domains))
+		log.Info("Obtaining SAN certificate given a CSR.", log.DomainsAttr(domains))
 	}
 
 	orderOpts := &api.OrderOptions{
@@ -302,7 +302,7 @@ func (c *Certifier) ObtainForCSR(ctx context.Context, request ObtainForCSRReques
 		return nil, err
 	}
 
-	log.Info("acme: Validations succeeded; requesting certificates.", log.DomainsAttr(domains))
+	log.Info("Validations succeeded; requesting certificates.", log.DomainsAttr(domains))
 
 	failures := errutils.NewDomainsError("certificates")
 
@@ -419,7 +419,7 @@ func (c *Certifier) getForCSR(ctx context.Context, certRes *Resource, order acme
 
 	interval := timeout / 60
 
-	log.Info("acme: waiting for certificates.",
+	log.Info("Waiting for certificates.",
 		slog.Duration("timeout", timeout),
 		slog.Duration("interval", interval),
 		log.DomainsAttr(certRes.Domains),
@@ -566,12 +566,12 @@ func (c *Certifier) Renew(ctx context.Context, certRes Resource, options *RenewO
 
 	x509Cert := certificates[0]
 	if x509Cert.IsCA {
-		return nil, fmt.Errorf("[%s] Certificate bundle starts with a CA certificate", strings.Join(certRes.Domains, ", "))
+		return nil, fmt.Errorf("certificate bundle starts with a CA certificate (%s)", strings.Join(certRes.Domains, ", "))
 	}
 
 	// This is just meant to be informal for the user.
 	timeLeft := x509Cert.NotAfter.Sub(time.Now().UTC())
-	log.Info("acme: Trying renewal.",
+	log.Info("Trying renewal.",
 		log.DomainsAttr(certRes.Domains),
 		slog.Int("hoursRemaining", int(timeLeft.Hours())),
 	)

--- a/challenge/challenges.go
+++ b/challenge/challenges.go
@@ -36,7 +36,7 @@ func FindChallenge(chlgType Type, authz acme.Authorization) (acme.Challenge, err
 		}
 	}
 
-	return acme.Challenge{}, fmt.Errorf("[%s] acme: unable to find challenge %s", GetTargetedDomain(authz), chlgType)
+	return acme.Challenge{}, fmt.Errorf("acme: unable to find challenge %s (%s)", chlgType, GetTargetedDomain(authz))
 }
 
 func GetTargetedDomain(authz acme.Authorization) string {

--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -73,7 +73,7 @@ func (c *Challenge) PreSolve(ctx context.Context, authz acme.Authorization) erro
 	}
 
 	if c.provider == nil {
-		return fmt.Errorf("[%s] dns01: no DNS Provider configured", domain)
+		return fmt.Errorf("dns01: no DNS Provider configured (%s)", domain)
 	}
 
 	// Generate the Key Authorization for the challenge
@@ -84,7 +84,7 @@ func (c *Challenge) PreSolve(ctx context.Context, authz acme.Authorization) erro
 
 	err = c.provider.Present(ctx, authz.Identifier.Value, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] dns01: error presenting token: %w", domain, err)
+		return fmt.Errorf("dns01: error presenting token (%s): %w", domain, err)
 	}
 
 	return nil

--- a/challenge/http01/http_challenge.go
+++ b/challenge/http01/http_challenge.go
@@ -76,7 +76,7 @@ func (c *Challenge) Solve(ctx context.Context, authz acme.Authorization) error {
 
 	err = c.provider.Present(ctx, authz.Identifier.Value, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] http01: error presenting token: %w", domain, err)
+		return fmt.Errorf("http01: error presenting token (%s): %w", domain, err)
 	}
 
 	defer func() {

--- a/challenge/resolver/prober.go
+++ b/challenge/resolver/prober.go
@@ -2,7 +2,7 @@ package resolver
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -65,7 +65,7 @@ func (p *Prober) Solve(ctx context.Context, authorizations []acme.Authorization)
 		domain := challenge.GetTargetedDomain(authz)
 		if authz.Status == acme.StatusValid {
 			// Boulder might recycle recent validated authz (see issue #267)
-			log.Info("acme: authorization already valid; skipping challenge.", log.DomainAttr(domain))
+			log.Info("Authorization is already valid; skipping the challenge.", log.DomainAttr(domain))
 			continue
 		}
 
@@ -83,7 +83,7 @@ func (p *Prober) Solve(ctx context.Context, authorizations []acme.Authorization)
 				authSolvers = append(authSolvers, authSolver)
 			}
 		} else {
-			failures.Add(domain, fmt.Errorf("[%s] acme: could not determine solvers", domain))
+			failures.Add(domain, errors.New("prober: could not determine solvers"))
 		}
 	}
 
@@ -109,8 +109,10 @@ func sequentialSolve(ctx context.Context, authSolvers []*selectedAuthSolver, fai
 
 		if solvr, ok := authSolver.solver.(preSolver); ok {
 			if _, ok := uniq[authSolver.authz.Identifier.Value+chlg.Token]; ok && chlg.Token != "" {
-				log.Debug("acme: duplicate token (DNS-01); skipping pre-solve.",
-					slog.String("identifier", authSolver.authz.Identifier.Value))
+				log.Debug("Duplicate token; skipping pre-solve.",
+					slog.String("identifier", authSolver.authz.Identifier.Value),
+					slog.String("type", challenge.DNS01.String()),
+				)
 
 				continue
 			}
@@ -150,8 +152,10 @@ func sequentialSolve(ctx context.Context, authSolvers []*selectedAuthSolver, fai
 
 			delete(uniq, authSolver.authz.Identifier.Value+chlg.Token)
 		} else {
-			log.Debug("acme: duplicate token (DNS-01); skipping cleanup.",
-				slog.String("identifier", authSolver.authz.Identifier.Value))
+			log.Debug("Duplicate token; skipping cleanup.",
+				slog.String("identifier", authSolver.authz.Identifier.Value),
+				slog.String("type", challenge.DNS01.String()),
+			)
 		}
 	}
 }
@@ -168,8 +172,10 @@ func parallelSolve(ctx context.Context, authSolvers []*selectedAuthSolver, failu
 		chlg, err := challenge.FindChallenge(challenge.DNS01, authz)
 		if err == nil {
 			if _, ok := uniq[authz.Identifier.Value+chlg.Token]; ok {
-				log.Debug("acme: duplicate token (DNS-01); skipping pre-solve.",
-					slog.String("identifier", authSolver.authz.Identifier.Value))
+				log.Debug("Duplicate token; skipping pre-solve.",
+					slog.String("identifier", authSolver.authz.Identifier.Value),
+					slog.String("type", challenge.DNS01.String()),
+				)
 
 				continue
 			}
@@ -193,8 +199,10 @@ func parallelSolve(ctx context.Context, authSolvers []*selectedAuthSolver, failu
 				if _, ok := uniq[authSolver.authz.Identifier.Value+chlg.Token]; ok {
 					delete(uniq, authSolver.authz.Identifier.Value+chlg.Token)
 				} else {
-					log.Debug("acme: duplicate token (DNS-01); skipping cleanup.",
-						slog.String("identifier", authSolver.authz.Identifier.Value))
+					log.Debug("Duplicate token; skipping cleanup.",
+						slog.String("identifier", authSolver.authz.Identifier.Value),
+						slog.String("type", challenge.DNS01.String()),
+					)
 
 					continue
 				}
@@ -227,7 +235,7 @@ func cleanUp(ctx context.Context, solvr solver, authz acme.Authorization) {
 
 		err := solvr.CleanUp(ctx, authz)
 		if err != nil {
-			log.Warn("acme: cleaning up failed.", log.DomainAttr(domain), log.ErrorAttr(err))
+			log.Warn("Cleaning up failed.", log.DomainAttr(domain), log.ErrorAttr(err))
 		}
 	}
 }

--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -101,11 +101,11 @@ func (c *SolverManager) chooseSolver(authz acme.Authorization) solver {
 
 	for _, chlg := range authz.Challenges {
 		if solvr, ok := c.solvers[challenge.Type(chlg.Type)]; ok {
-			log.Debug("acme: Use solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
+			log.Debug("Use solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
 			return solvr
 		}
 
-		log.Info("acme: Could not find the solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
+		log.Info("Could not find the solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
 	}
 
 	return nil

--- a/challenge/resolver/solver_manager.go
+++ b/challenge/resolver/solver_manager.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -105,7 +107,11 @@ func (c *SolverManager) chooseSolver(authz acme.Authorization) solver {
 			return solvr
 		}
 
-		log.Info("Could not find the solver.", log.DomainAttr(domain), slog.String("type", chlg.Type))
+		log.Info("Could not find the solver.",
+			log.DomainAttr(domain),
+			slog.String("type", chlg.Type),
+			slog.String("solvers", solversToString(c.solvers)),
+		)
 	}
 
 	return nil
@@ -200,4 +206,18 @@ func checkAuthorizationStatus(authz acme.Authorization) (bool, error) {
 	default:
 		return false, fmt.Errorf("the server returned an unexpected authorization status: %s", authz.Status)
 	}
+}
+
+func solversToString(s map[challenge.Type]solver) string {
+	if len(s) == 0 {
+		return "empty"
+	}
+
+	var types []string
+
+	for k := range maps.Keys(s) {
+		types = append(types, k.String())
+	}
+
+	return strings.Join(types, ", ")
 }

--- a/challenge/resolver/solver_manager_test.go
+++ b/challenge/resolver/solver_manager_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/acme/api"
+	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/internal/tester"
 	"github.com/go-acme/lego/v5/internal/tester/servermock"
 	"github.com/go-jose/go-jose/v4"
@@ -18,7 +20,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestByType(t *testing.T) {
+func TestSolverManager_chooseSolver(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		solvers    map[challenge.Type]solver
+		challenges []acme.Challenge
+		expected   assert.ValueAssertionFunc
+	}{
+		{
+			desc: "not found",
+			solvers: map[challenge.Type]solver{
+				challenge.DNS01:  &solverMock{},
+				challenge.HTTP01: &solverMock{},
+			},
+			challenges: []acme.Challenge{
+				{Type: challenge.TLSALPN01.String()},
+			},
+			expected: assert.Nil,
+		},
+		{
+			desc: "found",
+			solvers: map[challenge.Type]solver{
+				challenge.HTTP01: &solverMock{},
+				challenge.DNS01:  &solverMock{},
+			},
+			challenges: []acme.Challenge{
+				{Type: challenge.HTTP01.String()},
+				{Type: challenge.TLSALPN01.String()},
+			},
+			expected: assert.NotNil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			manager := SolverManager{
+				solvers: test.solvers,
+			}
+
+			authz := acme.Authorization{
+				Identifier: acme.Identifier{Type: "dns", Value: "example.com"},
+				Challenges: test.challenges,
+			}
+
+			solvr := manager.chooseSolver(authz)
+
+			test.expected(t, solvr)
+		})
+	}
+}
+
+func Test_byType(t *testing.T) {
 	challenges := []acme.Challenge{
 		{Type: "dns-01"}, {Type: "dns-persist-01"}, {Type: "tlsalpn-01"}, {Type: "http-01"},
 	}
@@ -32,7 +86,7 @@ func TestByType(t *testing.T) {
 	assert.Equal(t, expected, challenges)
 }
 
-func TestValidate(t *testing.T) {
+func Test_validate(t *testing.T) {
 	var statuses []string
 
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 1024)
@@ -278,5 +332,11 @@ func validateNoBody(privateKey *rsa.PrivateKey, r *http.Request) error {
 		return fmt.Errorf(`expected JWS POST body "{}" or "", got %q`, bodyStr)
 	}
 
+	return nil
+}
+
+type solverMock struct{}
+
+func (s *solverMock) Solve(ctx context.Context, authz acme.Authorization) error {
 	return nil
 }

--- a/challenge/tlsalpn01/tls_alpn_challenge.go
+++ b/challenge/tlsalpn01/tls_alpn_challenge.go
@@ -75,7 +75,7 @@ func (c *Challenge) Solve(ctx context.Context, authz acme.Authorization) error {
 
 	err = c.provider.Present(ctx, domain, chlng.Token, keyAuth)
 	if err != nil {
-		return fmt.Errorf("[%s] tlsalpn01: error presenting token: %w", challenge.GetTargetedDomain(authz), err)
+		return fmt.Errorf("tlsalpn01: error presenting token (%s): %w", challenge.GetTargetedDomain(authz), err)
 	}
 
 	defer func() {

--- a/log/lazy.go
+++ b/log/lazy.go
@@ -23,26 +23,26 @@ func (l LazyMessage) String() string {
 }
 
 // Debugf calls [Logger.Debug] on the default logger.
-func Debugf(msg LazyMessage, args ...slog.Attr) {
+func Debugf(msg fmt.Stringer, args ...slog.Attr) {
 	logLazy(slog.LevelDebug, msg, args...)
 }
 
 // Infof calls [Logger.Info] on the default logger.
-func Infof(msg LazyMessage, args ...slog.Attr) {
+func Infof(msg fmt.Stringer, args ...slog.Attr) {
 	logLazy(slog.LevelInfo, msg, args...)
 }
 
 // Warnf calls [Logger.Warn] on the default logger.
-func Warnf(msg LazyMessage, args ...slog.Attr) {
+func Warnf(msg fmt.Stringer, args ...slog.Attr) {
 	logLazy(slog.LevelWarn, msg, args...)
 }
 
 // Errorf calls [Logger.Error] on the default logger.
-func Errorf(msg LazyMessage, args ...slog.Attr) {
+func Errorf(msg fmt.Stringer, args ...slog.Attr) {
 	logLazy(slog.LevelError, msg, args...)
 }
 
-func logLazy(level slog.Level, msg LazyMessage, args ...slog.Attr) {
+func logLazy(level slog.Level, msg fmt.Stringer, args ...slog.Attr) {
 	ctx := context.Background()
 
 	if Default().Enabled(ctx, level) {

--- a/registration/registar.go
+++ b/registration/registar.go
@@ -51,7 +51,7 @@ func (r *Registrar) Register(ctx context.Context, options RegisterOptions) (*acm
 	}
 
 	if r.user.GetEmail() != "" {
-		log.Info("acme: Registering the account.", slog.String("email", r.user.GetEmail()))
+		log.Info("Registering the account.", slog.String("email", r.user.GetEmail()))
 
 		accMsg.Contact = []string{mailTo + r.user.GetEmail()}
 	}
@@ -76,7 +76,7 @@ func (r *Registrar) RegisterWithExternalAccountBinding(ctx context.Context, opti
 	}
 
 	if r.user.GetEmail() != "" {
-		log.Info("acme: Registering the account.", slog.String("email", r.user.GetEmail()))
+		log.Info("Registering the account (EAB).", slog.String("email", r.user.GetEmail()))
 
 		accMsg.Contact = []string{mailTo + r.user.GetEmail()}
 	}
@@ -103,7 +103,7 @@ func (r *Registrar) QueryRegistration(ctx context.Context) (*acme.ExtendedAccoun
 	}
 
 	// Log the URL here instead of the email as the email may not be set
-	log.Info("acme: Querying the account.", slog.String("registrationURI", r.user.GetRegistration().Location))
+	log.Info("Querying the account.", slog.String("registrationURI", r.user.GetRegistration().Location))
 
 	account, err := r.core.Accounts.Get(ctx, r.user.GetRegistration().Location)
 	if err != nil {
@@ -130,7 +130,7 @@ func (r *Registrar) UpdateRegistration(ctx context.Context, options RegisterOpti
 	}
 
 	if r.user.GetEmail() != "" {
-		log.Info("acme: Registering the account.", slog.String("email", r.user.GetEmail()))
+		log.Info("Updating the account.", slog.String("email", r.user.GetEmail()))
 		accMsg.Contact = []string{mailTo + r.user.GetEmail()}
 	}
 
@@ -150,7 +150,7 @@ func (r *Registrar) DeleteRegistration(ctx context.Context) error {
 		return errors.New("acme: cannot unregister a nil client or user")
 	}
 
-	log.Info("acme: Deleting the account.", slog.String("email", r.user.GetEmail()))
+	log.Info("Deleting the account.", slog.String("email", r.user.GetEmail()))
 
 	return r.core.Accounts.Deactivate(ctx, r.user.GetRegistration().Location)
 }
@@ -158,7 +158,7 @@ func (r *Registrar) DeleteRegistration(ctx context.Context) error {
 // ResolveAccountByKey will attempt to look up an account using the given account key
 // and return its registration resource.
 func (r *Registrar) ResolveAccountByKey(ctx context.Context) (*acme.ExtendedAccount, error) {
-	log.Info("acme: Trying to resolve the account by key")
+	log.Info("Trying to resolve the account by key")
 
 	accMsg := acme.Account{OnlyReturnExisting: true}
 


### PR DESCRIPTION
In the past, we were using `acme:` prefix inside logs and errors because the logs were missing some context.
With the new logger we don't need this anymore.
