### PR TITLE
docs: fix description of --deploy-hook and --pre-hook flags 

### DIFF
--- a/docs/content/advanced/hooks.md
+++ b/docs/content/advanced/hooks.md
@@ -16,7 +16,7 @@ There are three hooks available:
 
 ## Pre-Hook
 
-The hook is executed only when the certificates are effectively renewed or created.
+This hook is executed, before the creation or the renewal, in cases where a certificate will be effectively created/renewed.
 
 {{< tabs groupid="usage-examples" >}}
 {{% tab title="Classic Way" %}}
@@ -43,7 +43,7 @@ hooks:
 
 ## Deploy-Hook
 
-This hook is executed, before the creation or the renewal, in cases where a certificate will be effectively created/renewed.
+This hook is executed after the successful creation or the renewal of a certificate.
 
 {{< tabs groupid="usage-examples" >}}
 {{% tab title="Classic Way" %}}


### PR DESCRIPTION
The current documentation for the `--deploy-hook` flag indicates that it runs **before** the certificate is updated/renewed. This does not appear to reflect reality. In fact, the [the v5 release blog post](https://ldez.github.io/blog/2026/05/11/lego-v5/#-pre-hook-deploy-hook-and-post-hook) described the expected behavior (which thus differs from lego's current docs).

It seems when preparing #2947, the `--deploy-hook` docs were confused with the `--pre-hook` docs during editing.

To clarify the docs, I moved the current documentation of the `--deploy-hook` flag to the `--pre-hook` section and added some new docs for the `--deploy-hook` flag.