### PR TITLE
remove extra key-type flag

### DIFF
--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -175,7 +175,6 @@ func CreateKeyRolloverFlags() []cli.Flag {
 			Sources: cli.EnvVars(toEnvName(FlgPrivateKey)),
 			Usage:   "Path to the new account private key (PEM encoded). If not specified, the private key will be generated.",
 		},
-		createKeyTypeFlag("Key type to use for the new private key of the account."),
 	}
 
 	flags = append(flags, createACMEClientFlags()...)


### PR DESCRIPTION
keyrollover lists the `--key-type` flag twice in the help:

```
azureuser@aljtemptempnew:~/release$ ./lego accounts keyrollover -h
NAME:
   lego accounts keyrollover - Update the account private key.

USAGE:
   lego accounts keyrollover [options]

OPTIONS:
   --email string, -m string     Email used for registration and recovery contact. [$LEGO_EMAIL]
   --help, -h                    show help
   --key-type string, -k string  Key type to use for private keys. Supported: EC256, EC384, RSA2048, RSA3072, RSA4096, RSA8192. (default: "EC256") [$LEGO_KEY_TYPE]
   --key-type string, -k string  Key type to use for the new private key of the account. Supported: EC256, EC384, RSA2048, RSA3072, RSA4096, RSA8192. (default: "EC256") [$LEGO_KEY_TYPE]
   --private-key string          Path to the new account private key (PEM encoded). If not specified, the private key will be generated. [$LEGO_PRIVATE_KEY]
   --server string, -s string    CA (ACME server). It can be either a URL or a shortcode.
                                 (available shortcodes: actalis, digicert, freessl, globalsign, googletrust, googletrust-staging, letsencrypt, letsencrypt-staging, litessl, peeringhub, sslcomecc, sslcomrsa, sectigo, sectigoev, sectigoov, zerossl) (default: "https://acme-v02.api.letsencrypt.org/directory") [$LEGO_SERVER]

-=-=- snip =-=-=-

```


This PR removes the extra key-type flag.