### PR TITLE
fix: default port for the HTTP server

### DIFF
--- a/cmd/internal/root/process_challenges.go
+++ b/cmd/internal/root/process_challenges.go
@@ -103,7 +103,7 @@ func createHTTPProvider(chlg *configuration.HTTPChallenge, networkStack challeng
 	default:
 		srv := http01.NewProviderServerWithOptions(http01.Options{
 			Network:         networkStack.Network("tcp"),
-			Address:         net.JoinHostPort("", ":80"),
+			Address:         net.JoinHostPort("", "80"),
 			ProxyHeaderName: chlg.ProxyHeader,
 		})
 

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -104,7 +104,7 @@ func createHTTPProvider(cmd *cli.Command) (challenge.Provider, error) {
 	default:
 		ps := http01.NewProviderServerWithOptions(http01.Options{
 			Network:         getNetworkStack(cmd).Network("tcp"),
-			Address:         net.JoinHostPort("", ":80"),
+			Address:         net.JoinHostPort("", "80"),
 			ProxyHeaderName: cmd.String(flags.FlgHTTPProxyHeader),
 		})
 


### PR DESCRIPTION
related to https://github.com/go-acme/lego/issues/3074#issuecomment-4434038081