### PR TITLE
docs: add a note about JSON files migration

### DIFF
--- a/docs/content/migration/cli.md
+++ b/docs/content/migration/cli.md
@@ -128,6 +128,12 @@ The directory structure has been changed.
 {{% /tab %}}
 {{< /tabs >}}
 
+The directory structure has changed but also the content of the JSON files, so don't migrate the files manually.
+
+To migrate the directory structure and the files, run the command `lego migrate`.
+
+If you need to do it manually, please open a [discussion](https://github.com/go-acme/lego/discussions/new?category=q-a) and we will help you.
+
 ## Environment variables
 
 The following environment variables have been removed without replacement:


### PR DESCRIPTION
Add a note to explain that the `.lego` directory you not be migrated by hand.
