### PR TITLE
fix: recursive NSs propagation checks

### DIFF
--- a/challenge/dns01/client_nameservers.go
+++ b/challenge/dns01/client_nameservers.go
@@ -11,7 +11,7 @@ import (
 
 // checkRecursiveNameserversPropagation queries each of the recursive nameservers for the expected TXT record.
 func (c *Client) checkRecursiveNameserversPropagation(ctx context.Context, fqdn, value string) (bool, error) {
-	return c.checkNameserversPropagationCustom(ctx, fqdn, value, c.core.GetRecursiveNameservers(), false)
+	return c.checkNameserversPropagationCustom(ctx, fqdn, value, c.core.GetRecursiveNameservers(), false, true)
 }
 
 // checkRecursiveNameserversPropagation queries each of the authoritative nameservers for the expected TXT record.
@@ -21,17 +21,17 @@ func (c *Client) checkAuthoritativeNameserversPropagation(ctx context.Context, f
 		return false, err
 	}
 
-	return c.checkNameserversPropagationCustom(ctx, fqdn, value, authoritativeNss, true)
+	return c.checkNameserversPropagationCustom(ctx, fqdn, value, authoritativeNss, true, false)
 }
 
 // checkNameserversPropagationCustom queries each of the given nameservers for the expected TXT record.
-func (c *Client) checkNameserversPropagationCustom(ctx context.Context, fqdn, value string, nameservers []string, addPort bool) (bool, error) {
+func (c *Client) checkNameserversPropagationCustom(ctx context.Context, fqdn, value string, nameservers []string, addPort, recursive bool) (bool, error) {
 	for _, ns := range nameservers {
 		if addPort {
 			ns = net.JoinHostPort(ns, c.authoritativeNSPort)
 		}
 
-		r, err := c.core.SendQueryCustom(ctx, fqdn, dns.TypeTXT, []string{ns}, false)
+		r, err := c.core.SendQueryCustom(ctx, fqdn, dns.TypeTXT, []string{ns}, recursive)
 		if err != nil {
 			return false, err
 		}

--- a/challenge/dns01/client_nameservers_test.go
+++ b/challenge/dns01/client_nameservers_test.go
@@ -59,7 +59,7 @@ func TestClient_checkNameserversPropagationCustom_authoritativeNss(t *testing.T)
 
 			addr := test.fakeDNSServer.Build(t)
 
-			ok, err := client.checkNameserversPropagationCustom(t.Context(), test.fqdn, test.value, []string{addr.String()}, false)
+			ok, err := client.checkNameserversPropagationCustom(t.Context(), test.fqdn, test.value, []string{addr.String()}, false, false)
 
 			if test.expectedError == "" {
 				require.NoError(t, err)


### PR DESCRIPTION
Add `rd` to recursive NSs propagation checks.

Related to https://github.com/go-acme/lego/discussions/3079