### PR TITLE
timewebcloud: update API client to new API version

### DIFF
--- a/providers/dns/timewebcloud/internal/client.go
+++ b/providers/dns/timewebcloud/internal/client.go
@@ -20,7 +20,7 @@ const defaultBaseURL = "https://api.timeweb.cloud/api"
 
 // Client Timeweb Cloud client.
 type Client struct {
-	baseURL    *url.URL
+	BaseURL    *url.URL
 	httpClient *http.Client
 }
 
@@ -33,7 +33,7 @@ func NewClient(hc *http.Client) *Client {
 	}
 
 	return &Client{
-		baseURL:    baseURL,
+		BaseURL:    baseURL,
 		httpClient: hc,
 	}
 }
@@ -41,7 +41,7 @@ func NewClient(hc *http.Client) *Client {
 // CreateRecord creates a DNS record.
 // https://timeweb.cloud/api-docs#tag/Domeny/operation/createDomainDNSRecordV2
 func (c *Client) CreateRecord(ctx context.Context, zone string, payload DNSRecordPayload) (*DNSRecord, error) {
-	endpoint := c.baseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records")
+	endpoint := c.BaseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records")
 
 	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, payload)
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *Client) CreateRecord(ctx context.Context, zone string, payload DNSRecor
 // DeleteRecord deletes a DNS record.
 // https://timeweb.cloud/api-docs#tag/Domeny/operation/deleteDomainDNSRecordV2
 func (c *Client) DeleteRecord(ctx context.Context, zone string, recordID int) error {
-	endpoint := c.baseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records", strconv.Itoa(recordID))
+	endpoint := c.BaseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records", strconv.Itoa(recordID))
 
 	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)
 	if err != nil {

--- a/providers/dns/timewebcloud/internal/client.go
+++ b/providers/dns/timewebcloud/internal/client.go
@@ -40,7 +40,7 @@ func NewClient(hc *http.Client) *Client {
 
 // CreateRecord creates a DNS record.
 // https://timeweb.cloud/api-docs#tag/Domeny/operation/createDomainDNSRecordV2
-func (c *Client) CreateRecord(ctx context.Context, zone string, payload DNSRecordPayload) (*DNSRecord, error) {
+func (c *Client) CreateRecord(ctx context.Context, zone string, payload DNSRecordRequest) (*DNSRecord, error) {
 	endpoint := c.BaseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records")
 
 	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, payload)

--- a/providers/dns/timewebcloud/internal/client.go
+++ b/providers/dns/timewebcloud/internal/client.go
@@ -39,11 +39,11 @@ func NewClient(hc *http.Client) *Client {
 }
 
 // CreateRecord creates a DNS record.
-// https://timeweb.cloud/api-docs#tag/Domeny/operation/createDomainDNSRecord
-func (c *Client) CreateRecord(ctx context.Context, zone string, record DNSRecord) (*DNSRecord, error) {
-	endpoint := c.baseURL.JoinPath("v1", "domains", dns01.UnFqdn(zone), "dns-records")
+// https://timeweb.cloud/api-docs#tag/Domeny/operation/createDomainDNSRecordV2
+func (c *Client) CreateRecord(ctx context.Context, zone string, payload DNSRecordPayload) (*DNSRecord, error) {
+	endpoint := c.baseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records")
 
-	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, record)
+	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -59,9 +59,9 @@ func (c *Client) CreateRecord(ctx context.Context, zone string, record DNSRecord
 }
 
 // DeleteRecord deletes a DNS record.
-// https://timeweb.cloud/api-docs#tag/Domeny/operation/deleteDomainDNSRecord
+// https://timeweb.cloud/api-docs#tag/Domeny/operation/deleteDomainDNSRecordV2
 func (c *Client) DeleteRecord(ctx context.Context, zone string, recordID int) error {
-	endpoint := c.baseURL.JoinPath("v1", "domains", dns01.UnFqdn(zone), "dns-records", strconv.Itoa(recordID))
+	endpoint := c.baseURL.JoinPath("v2", "domains", dns01.UnFqdn(zone), "dns-records", strconv.Itoa(recordID))
 
 	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)
 	if err != nil {

--- a/providers/dns/timewebcloud/internal/client_test.go
+++ b/providers/dns/timewebcloud/internal/client_test.go
@@ -26,23 +26,27 @@ func mockBuilder() *servermock.Builder[*Client] {
 
 func TestClient_CreateRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /v1/domains/example.com/dns-records",
+		Route("POST /v2/domains/_acme-challenge.example.com/dns-records",
 			servermock.ResponseFromFixture("createDomainDNSRecord.json"),
-			servermock.CheckRequestJSONBody(`{"type":"TXT","value":"w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI","subdomain":"_acme-challenge"}`)).
+			servermock.CheckRequestJSONBody(`{"type":"TXT","value":"w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI"}`)).
 		Build(t)
 
-	payload := DNSRecord{
-		Type:      "TXT",
-		Value:     "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI",
-		SubDomain: "_acme-challenge",
+	payload := DNSRecordPayload{
+		Type:  "TXT",
+		Value: "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI",
 	}
 
-	response, err := client.CreateRecord(t.Context(), "example.com.", payload)
+	response, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", payload)
 	require.NoError(t, err)
 
 	expected := &DNSRecord{
-		Type: "TXT",
 		ID:   123,
+		Type: "TXT",
+		Fqdn: "example.com",
+		Data: DNSRecordData{
+			Value:     payload.Value,
+			Subdomain: "_acme-challenge",
+		},
 	}
 
 	assert.Equal(t, expected, response)
@@ -50,12 +54,12 @@ func TestClient_CreateRecord(t *testing.T) {
 
 func TestClient_CreateRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /v1/domains/example.com/dns-records",
+		Route("POST /v2/domains/_acme-challenge.example.com/dns-records",
 			servermock.ResponseFromFixture("error_bad_request.json").
 				WithStatusCode(http.StatusBadRequest)).
 		Build(t)
 
-	_, err := client.CreateRecord(t.Context(), "example.com.", DNSRecord{})
+	_, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", DNSRecordPayload{})
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "400: Value must be a number conforming to the specified constraints (bad_request) [15095f25-aac3-4d60-a788-96cb5136f186]")
@@ -63,23 +67,23 @@ func TestClient_CreateRecord_error(t *testing.T) {
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /v1/domains/example.com/dns-records/123",
+		Route("DELETE /v2/domains/_acme-challenge.example.com/dns-records/123",
 			servermock.Noop().
 				WithStatusCode(http.StatusNoContent)).
 		Build(t)
 
-	err := client.DeleteRecord(t.Context(), "example.com.", 123)
+	err := client.DeleteRecord(t.Context(), "_acme-challenge.example.com.", 123)
 	require.NoError(t, err)
 }
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("DELETE /v1/domains/example.com/dns-records/123",
+		Route("DELETE /v2/domains/_acme-challenge.example.com/dns-records/123",
 			servermock.ResponseFromFixture("error_unauthorized.json").
 				WithStatusCode(http.StatusBadRequest)).
 		Build(t)
 
-	err := client.DeleteRecord(t.Context(), "example.com.", 123)
+	err := client.DeleteRecord(t.Context(), "_acme-challenge.example.com.", 123)
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "401: Unauthorized (unauthorized) [15095f25-aac3-4d60-a788-96cb5136f186]")

--- a/providers/dns/timewebcloud/internal/client_test.go
+++ b/providers/dns/timewebcloud/internal/client_test.go
@@ -33,7 +33,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		).
 		Build(t)
 
-	payload := DNSRecordPayload{
+	payload := DNSRecordRequest{
 		Type:  "TXT",
 		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
 	}
@@ -45,7 +45,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		ID:   123,
 		Type: "TXT",
 		Fqdn: "example.com",
-		Data: DNSRecordData{
+		Data: Data{
 			Value:     payload.Value,
 			Subdomain: "_acme-challenge",
 		},
@@ -62,7 +62,7 @@ func TestClient_CreateRecord_error(t *testing.T) {
 		).
 		Build(t)
 
-	_, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", DNSRecordPayload{})
+	_, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", DNSRecordRequest{})
 	require.Error(t, err)
 
 	assert.EqualError(t, err, "400: Value must be a number conforming to the specified constraints (bad_request) [15095f25-aac3-4d60-a788-96cb5136f186]")

--- a/providers/dns/timewebcloud/internal/client_test.go
+++ b/providers/dns/timewebcloud/internal/client_test.go
@@ -15,11 +15,12 @@ func mockBuilder() *servermock.Builder[*Client] {
 	return servermock.NewBuilder[*Client](
 		func(server *httptest.Server) (*Client, error) {
 			client := NewClient(OAuthStaticAccessToken(server.Client(), "secret"))
-			client.baseURL, _ = url.Parse(server.URL)
+			client.BaseURL, _ = url.Parse(server.URL)
 
 			return client, nil
 		},
-		servermock.CheckHeader().WithJSONHeaders().
+		servermock.CheckHeader().
+			WithJSONHeaders().
 			WithAuthorization("Bearer secret"),
 	)
 }
@@ -28,12 +29,13 @@ func TestClient_CreateRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /v2/domains/_acme-challenge.example.com/dns-records",
 			servermock.ResponseFromFixture("createDomainDNSRecord.json"),
-			servermock.CheckRequestJSONBody(`{"type":"TXT","value":"w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI"}`)).
+			servermock.CheckRequestJSONBodyFromFixture("createDomainDNSRecord-request.json"),
+		).
 		Build(t)
 
 	payload := DNSRecordPayload{
 		Type:  "TXT",
-		Value: "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
 	}
 
 	response, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", payload)
@@ -56,7 +58,8 @@ func TestClient_CreateRecord_error(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /v2/domains/_acme-challenge.example.com/dns-records",
 			servermock.ResponseFromFixture("error_bad_request.json").
-				WithStatusCode(http.StatusBadRequest)).
+				WithStatusCode(http.StatusBadRequest),
+		).
 		Build(t)
 
 	_, err := client.CreateRecord(t.Context(), "_acme-challenge.example.com.", DNSRecordPayload{})
@@ -69,7 +72,8 @@ func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("DELETE /v2/domains/_acme-challenge.example.com/dns-records/123",
 			servermock.Noop().
-				WithStatusCode(http.StatusNoContent)).
+				WithStatusCode(http.StatusNoContent),
+		).
 		Build(t)
 
 	err := client.DeleteRecord(t.Context(), "_acme-challenge.example.com.", 123)
@@ -80,7 +84,8 @@ func TestClient_DeleteRecord_error(t *testing.T) {
 	client := mockBuilder().
 		Route("DELETE /v2/domains/_acme-challenge.example.com/dns-records/123",
 			servermock.ResponseFromFixture("error_unauthorized.json").
-				WithStatusCode(http.StatusBadRequest)).
+				WithStatusCode(http.StatusBadRequest),
+		).
 		Build(t)
 
 	err := client.DeleteRecord(t.Context(), "_acme-challenge.example.com.", 123)

--- a/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord-request.json
+++ b/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord-request.json
@@ -1,0 +1,4 @@
+{
+  "type": "TXT",
+  "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY"
+}

--- a/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord.json
+++ b/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord.json
@@ -4,7 +4,7 @@
     "type": "TXT",
     "fqdn": "example.com",
     "data": {
-      "value": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI",
+      "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
       "sub": "_acme-challenge"
     }
   },

--- a/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord.json
+++ b/providers/dns/timewebcloud/internal/fixtures/createDomainDNSRecord.json
@@ -1,11 +1,11 @@
 {
   "dns_record": {
-    "type": "TXT",
     "id": 123,
+    "type": "TXT",
+    "fqdn": "example.com",
     "data": {
-      "priority": 0,
-      "subdomain": "example.com",
-      "value": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI"
+      "value": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI",
+      "sub": "_acme-challenge"
     }
   },
   "response_id": "15095f25-aac3-4d60-a788-96cb5136f186"

--- a/providers/dns/timewebcloud/internal/types.go
+++ b/providers/dns/timewebcloud/internal/types.go
@@ -2,13 +2,21 @@ package internal
 
 import "fmt"
 
-type DNSRecord struct {
-	ID    int    `json:"id,omitempty"`
+type DNSRecordPayload struct {
 	Type  string `json:"type,omitempty"`
 	Value string `json:"value,omitempty"`
+}
 
-	// SubDomain is the full name of a subdomain (not only the subdomain label).
-	SubDomain string `json:"subdomain,omitempty"`
+type DNSRecord struct {
+	ID   int           `json:"id,omitempty"`
+	Type string        `json:"type,omitempty"`
+	Fqdn string        `json:"fqdn,omitempty"`
+	Data DNSRecordData `json:"data"`
+}
+
+type DNSRecordData struct {
+	Value     string `json:"value,omitempty"`
+	Subdomain string `json:"sub,omitempty"`
 }
 
 type CreateRecordResponse struct {

--- a/providers/dns/timewebcloud/internal/types.go
+++ b/providers/dns/timewebcloud/internal/types.go
@@ -2,19 +2,19 @@ package internal
 
 import "fmt"
 
-type DNSRecordPayload struct {
+type DNSRecordRequest struct {
 	Type  string `json:"type,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
 type DNSRecord struct {
-	ID   int           `json:"id,omitempty"`
-	Type string        `json:"type,omitempty"`
-	Fqdn string        `json:"fqdn,omitempty"`
-	Data DNSRecordData `json:"data"`
+	ID   int    `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+	Fqdn string `json:"fqdn,omitempty"`
+	Data Data   `json:"data"`
 }
 
-type DNSRecordData struct {
+type Data struct {
 	Value     string `json:"value,omitempty"`
 	Subdomain string `json:"sub,omitempty"`
 }

--- a/providers/dns/timewebcloud/timewebcloud.go
+++ b/providers/dns/timewebcloud/timewebcloud.go
@@ -117,7 +117,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 
 	response, err := d.client.CreateRecord(ctx, info.EffectiveFQDN, record)
 	if err != nil {
-		return fmt.Errorf("timewebcloud: %w", err)
+		return fmt.Errorf("timewebcloud: create record: %w", err)
 	}
 
 	d.recordIDsMu.Lock()
@@ -146,7 +146,7 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 
 	err = d.client.DeleteRecord(ctx, info.EffectiveFQDN, recordID)
 	if err != nil {
-		return fmt.Errorf("timewebcloud: %w", err)
+		return fmt.Errorf("timewebcloud: delete record: %w", err)
 	}
 
 	d.recordIDsMu.Lock()

--- a/providers/dns/timewebcloud/timewebcloud.go
+++ b/providers/dns/timewebcloud/timewebcloud.go
@@ -105,18 +105,17 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string) error {
 	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	_, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("timewebcloud: could not find zone for domain %q: %w", domain, err)
 	}
 
-	record := internal.DNSRecord{
-		Type:      "TXT",
-		Value:     info.Value,
-		SubDomain: dns01.UnFqdn(info.EffectiveFQDN),
+	record := internal.DNSRecordPayload{
+		Type:  "TXT",
+		Value: info.Value,
 	}
 
-	response, err := d.client.CreateRecord(ctx, authZone, record)
+	response, err := d.client.CreateRecord(ctx, info.EffectiveFQDN, record)
 	if err != nil {
 		return fmt.Errorf("timewebcloud: %w", err)
 	}
@@ -132,7 +131,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
 	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
 
-	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
+	_, err := dns01.DefaultClient().FindZoneByFqdn(ctx, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("timewebcloud: could not find zone for domain %q: %w", domain, err)
 	}
@@ -145,7 +144,7 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("timewebcloud: unknown record ID for '%s'", info.EffectiveFQDN)
 	}
 
-	err = d.client.DeleteRecord(ctx, authZone, recordID)
+	err = d.client.DeleteRecord(ctx, info.EffectiveFQDN, recordID)
 	if err != nil {
 		return fmt.Errorf("timewebcloud: %w", err)
 	}

--- a/providers/dns/timewebcloud/timewebcloud.go
+++ b/providers/dns/timewebcloud/timewebcloud.go
@@ -110,7 +110,7 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("timewebcloud: could not find zone for domain %q: %w", domain, err)
 	}
 
-	record := internal.DNSRecordPayload{
+	record := internal.DNSRecordRequest{
 		Type:  "TXT",
 		Value: info.Value,
 	}

--- a/providers/dns/timewebcloud/timewebcloud_test.go
+++ b/providers/dns/timewebcloud/timewebcloud_test.go
@@ -1,10 +1,14 @@
 package timewebcloud
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/go-acme/lego/v5/internal/tester"
+	"github.com/go-acme/lego/v5/internal/tester/servermock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,5 +123,53 @@ func TestLiveCleanUp(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	err = provider.CleanUp(t.Context(), envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}
+
+func mockBuilder() *servermock.Builder[*DNSProvider] {
+	return servermock.NewBuilder(
+		func(server *httptest.Server) (*DNSProvider, error) {
+			config := NewDefaultConfig()
+			config.AuthToken = "secret"
+			config.HTTPClient = server.Client()
+
+			p, err := NewDNSProviderConfig(config)
+			if err != nil {
+				return nil, err
+			}
+
+			p.client.BaseURL, _ = url.Parse(server.URL)
+
+			return p, nil
+		},
+		servermock.CheckHeader().
+			WithJSONHeaders().
+			WithAuthorization("Bearer secret"),
+	)
+}
+
+func TestDNSProvider_Present(t *testing.T) {
+	provider := mockBuilder().
+		Route("POST /v2/domains/_acme-challenge.example.com/dns-records",
+			servermock.ResponseFromInternal("createDomainDNSRecord.json"),
+			servermock.CheckRequestJSONBodyFromInternal("createDomainDNSRecord-request.json"),
+		).
+		Build(t)
+
+	err := provider.Present(t.Context(), "example.com", "abc", "123d==")
+	require.NoError(t, err)
+}
+
+func TestDNSProvider_CleanUp(t *testing.T) {
+	provider := mockBuilder().
+		Route("DELETE /v2/domains/_acme-challenge.example.com/dns-records/123",
+			servermock.Noop().
+				WithStatusCode(http.StatusNoContent),
+		).
+		Build(t)
+
+	provider.recordIDs["abc"] = 123
+
+	err := provider.CleanUp(t.Context(), "example.com", "abc", "123d==")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

IMPORTANT:

1. Create an issue and wait for a maintainer to approve it BEFORE opening a pull request.
2. Don't open a work-in-progress pull request. If you open a PR, the PR must be ready to be reviewed.
3. If a pull request doesn't follow one of the previous elements, it will be closed.

Also, pull requests from a fork inside a GitHub organization are not allowed because of access limitation on them.
Only pull requests from personal forks are allowed. 

-->


Real example of the latest run:

<details>

```console

~/dev/nodenotready.ru/lego (main*) » /Users/aglukhov/dev/lego/dist/lego run --dns timewebcloud -d '*.test.nodenotready.ru' -d test.nodenotready.ru -s letsencrypt-staging --dns.propagation.wait 5m 
2026-05-22T12:17:28.165078000+03:00 INFO  Obtaining bundled SAN certificate. domains="*.test.nodenotready.ru, test.nodenotready.ru"
2026-05-22T12:17:29.376650000+03:00 INFO  Use solver. domain=*.test.nodenotready.ru type=dns-01
2026-05-22T12:17:29.376728000+03:00 INFO  Use solver. domain=test.nodenotready.ru type=dns-01
2026-05-22T12:17:29.376783000+03:00 INFO  dns01: preparing to solve the challenge. domain=*.test.nodenotready.ru
2026-05-22T12:17:29.600648000+03:00 INFO  dns01: preparing to solve the challenge. domain=test.nodenotready.ru
2026-05-22T12:17:29.689463000+03:00 INFO  dns01: trying to solve the challenge. domain=*.test.nodenotready.ru
2026-05-22T12:17:29.694336000+03:00 INFO  dns01: waiting for record propagation timeout=1m0s interval=2s domain=*.test.nodenotready.ru
2026-05-22T12:17:31.695536000+03:00 INFO  dns01: the active propagation check is disabled, waiting for the propagation instead. wait=5m0s domain=*.test.nodenotready.ru
2026-05-22T12:22:38.470775000+03:00 INFO  The server validated our request. domain=*.test.nodenotready.ru
2026-05-22T12:22:38.470876000+03:00 INFO  dns01: trying to solve the challenge. domain=test.nodenotready.ru
2026-05-22T12:22:38.496564000+03:00 INFO  dns01: waiting for record propagation timeout=1m0s interval=2s domain=test.nodenotready.ru
2026-05-22T12:22:40.496775000+03:00 INFO  dns01: the active propagation check is disabled, waiting for the propagation instead. wait=5m0s domain=test.nodenotready.ru
2026-05-22T12:27:47.011206000+03:00 INFO  The server validated our request. domain=test.nodenotready.ru
2026-05-22T12:27:47.011303000+03:00 INFO  dns01: cleaning DNS-01 challenge. domain=*.test.nodenotready.ru
2026-05-22T12:27:47.249184000+03:00 INFO  dns01: cleaning DNS-01 challenge. domain=test.nodenotready.ru
2026-05-22T12:27:47.338560000+03:00 INFO  Validations succeeded; requesting certificates. domains="*.test.nodenotready.ru, test.nodenotready.ru"
2026-05-22T12:27:47.533265000+03:00 INFO  Waiting for certificates. timeout=30s interval=500ms domains="*.test.nodenotready.ru, test.nodenotready.ru"
2026-05-22T12:27:48.988472000+03:00 INFO  Server responded with a certificate. domains="*.test.nodenotready.ru, test.nodenotready.ru"
2026-05-22T12:27:48.990128000+03:00 INFO  Writing file. filepath=/Users/aglukhov/dev/nodenotready.ru/lego/.lego/certificates/_.test.nodenotready.ru.crt
2026-05-22T12:27:48.991289000+03:00 INFO  Writing file. filepath=/Users/aglukhov/dev/nodenotready.ru/lego/.lego/certificates/_.test.nodenotready.ru.issuer.crt
2026-05-22T12:27:48.991718000+03:00 INFO  Writing file. filepath=/Users/aglukhov/dev/nodenotready.ru/lego/.lego/certificates/_.test.nodenotready.ru.key
2026-05-22T12:27:48.992536000+03:00 INFO  Writing file. filepath=/Users/aglukhov/dev/nodenotready.ru/lego/.lego/certificates/_.test.nodenotready.ru.json
```
</details>

Fixes #3119