### PR TITLE
-

### DIFF
--- a/platform/env/env.go
+++ b/platform/env/env.go
@@ -170,7 +170,7 @@ func GetOrFile(envVar string) string {
 		return ""
 	}
 
-	return strings.TrimSuffix(string(fileContents), "\n")
+	return strings.TrimRight(string(fileContents), "\r\n")
 }
 
 // ParseSecond parses env var value (string) to a second (time.Duration).

--- a/platform/env/env_test.go
+++ b/platform/env/env_test.go
@@ -384,6 +384,30 @@ func TestGetOrFile_ReadsFiles(t *testing.T) {
 	}
 }
 
+func TestGetOrFile_TrimsWindowsNewline(t *testing.T) {
+	varEnvFileName := "TEST_LEGO_ENV_VAR_FILE"
+	varEnvName := "TEST_LEGO_ENV_VAR"
+
+	err := os.Unsetenv(varEnvFileName)
+	require.NoError(t, err)
+	err = os.Unsetenv(varEnvName)
+	require.NoError(t, err)
+
+	file, err := os.CreateTemp(t.TempDir(), "lego")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = file.Close() })
+
+	err = os.WriteFile(file.Name(), []byte("lego_file\r\n"), 0o644)
+	require.NoError(t, err)
+
+	t.Setenv(varEnvFileName, file.Name())
+
+	value := GetOrFile(varEnvName)
+
+	assert.Equal(t, "lego_file", value)
+}
+
 func TestGetOrFile_PrefersEnvVars(t *testing.T) {
 	varEnvFileName := "TEST_LEGO_ENV_VAR_FILE"
 	varEnvName := "TEST_LEGO_ENV_VAR"


### PR DESCRIPTION
Related #871

Small papercut, but it's real: `*_FILE` secrets with CRLF kept the `
`, so providers got a token or password with a hidden char.

Repro:
- write `lego_file
` into a temp secret file
- set `TEST_LEGO_ENV_VAR_FILE` to that path
- call `GetOrFile("TEST_LEGO_ENV_VAR")`
- before: `lego_file
`
- now: `lego_file`

No provider quota thing here, it happens before API calls. Windows-formatted files are enough.

Checks:
- `go test ./platform/env`
- `go test ./...`
- `make build`
- `golangci-lint run`