### PR TITLE
feat: use config file for list related commands

### DIFF
--- a/cmd/cmd_accounts_list.go
+++ b/cmd/cmd_accounts_list.go
@@ -29,15 +29,17 @@ func createAccountsList() *cli.Command {
 }
 
 func listAccounts(ctx context.Context, cmd *cli.Command) error {
+	basePath := cmd.String(flags.FlgPath)
+
 	if cmd.Bool(flags.FlgFormatJSON) {
-		return listAccountsJSON(ctx, cmd)
+		return listAccountsJSON(basePath)
 	}
 
-	return listAccountsText(ctx, cmd)
+	return listAccountsText(basePath)
 }
 
-func listAccountsText(_ context.Context, cmd *cli.Command) error {
-	accounts, err := readAccounts(cmd)
+func listAccountsText(basePath string) error {
+	accounts, err := readAccounts(basePath)
 	if err != nil {
 		return err
 	}
@@ -61,8 +63,8 @@ func listAccountsText(_ context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func listAccountsJSON(_ context.Context, cmd *cli.Command) error {
-	accounts, err := readAccounts(cmd)
+func listAccountsJSON(basePath string) error {
+	accounts, err := readAccounts(basePath)
 	if err != nil {
 		return err
 	}
@@ -70,8 +72,8 @@ func listAccountsJSON(_ context.Context, cmd *cli.Command) error {
 	return json.NewEncoder(os.Stdout).Encode(accounts)
 }
 
-func readAccounts(cmd *cli.Command) ([]ListAccount, error) {
-	accountsStorage := storage.NewAccountsStorage(cmd.String(flags.FlgPath))
+func readAccounts(basePath string) ([]ListAccount, error) {
+	accountsStorage := storage.NewAccountsStorage(basePath)
 
 	matches, err := zglob.Glob(filepath.Join(accountsStorage.GetRootPath(), "**", "account.json"))
 	if err != nil {

--- a/cmd/cmd_accounts_list.go
+++ b/cmd/cmd_accounts_list.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
+	"github.com/go-acme/lego/v5/log"
 	"github.com/mattn/go-zglob"
 	"github.com/urfave/cli/v3"
 )
@@ -28,8 +30,15 @@ func createAccountsList() *cli.Command {
 	}
 }
 
-func listAccounts(ctx context.Context, cmd *cli.Command) error {
+func listAccounts(_ context.Context, cmd *cli.Command) error {
 	basePath := cmd.String(flags.FlgPath)
+
+	cfg, err := loadConfiguration(cmd)
+	if err == nil {
+		log.Debug("Configuration loaded from a file.", slog.String("cmd", "accounts list"))
+
+		basePath = cfg.Storage
+	}
 
 	if cmd.Bool(flags.FlgFormatJSON) {
 		return listAccountsJSON(basePath)

--- a/cmd/cmd_archives_list.go
+++ b/cmd/cmd_archives_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"slices"
 
@@ -17,14 +18,21 @@ func createArchivesList() *cli.Command {
 		Name:   "list",
 		Usage:  "List all archives.",
 		Action: listArchives,
-		Flags: []cli.Flag{
-			flags.CreatePathFlag(false),
-		},
+		Flags:  flags.CreateArchivesListFlags(),
 	}
 }
 
 func listArchives(_ context.Context, cmd *cli.Command) error {
-	archiver := storage.NewArchiver(cmd.String(flags.FlgPath))
+	basePath := cmd.String(flags.FlgPath)
+
+	cfg, err := loadConfiguration(cmd)
+	if err == nil {
+		log.Debug("Configuration loaded from a file.", slog.String("cmd", "archives list"))
+
+		basePath = cfg.Storage
+	}
+
+	archiver := storage.NewArchiver(basePath)
 
 	accountPaths, err := archiver.ListArchivedAccounts()
 	if err != nil {

--- a/cmd/cmd_archives_restore.go
+++ b/cmd/cmd_archives_restore.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -19,14 +20,21 @@ func createArchivesRestore() *cli.Command {
 		Name:   "restore",
 		Usage:  "Restore an archive.",
 		Action: restoreArchive,
-		Flags: []cli.Flag{
-			flags.CreatePathFlag(false),
-		},
+		Flags:  flags.CreateArchivesRestoreFlags(),
 	}
 }
 
 func restoreArchive(_ context.Context, cmd *cli.Command) error {
-	archiver := storage.NewArchiver(cmd.String(flags.FlgPath))
+	basePath := cmd.String(flags.FlgPath)
+
+	cfg, err := loadConfiguration(cmd)
+	if err == nil {
+		log.Debug("Configuration loaded from a file.", slog.String("cmd", "accounts list"))
+
+		basePath = cfg.Storage
+	}
+
+	archiver := storage.NewArchiver(basePath)
 
 	accountPaths, err := archiver.ListArchivedAccounts()
 	if err != nil {

--- a/cmd/cmd_certificates_list.go
+++ b/cmd/cmd_certificates_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
 	"github.com/go-acme/lego/v5/internal"
+	"github.com/go-acme/lego/v5/log"
 	"github.com/mattn/go-zglob"
 	"github.com/urfave/cli/v3"
 )
@@ -36,8 +38,15 @@ func createListCertificates() *cli.Command {
 	}
 }
 
-func listCertificates(ctx context.Context, cmd *cli.Command) error {
+func listCertificates(_ context.Context, cmd *cli.Command) error {
 	basePath := cmd.String(flags.FlgPath)
+
+	cfg, err := loadConfiguration(cmd)
+	if err == nil {
+		log.Debug("Configuration loaded from a file.", slog.String("cmd", "certificates list"))
+
+		basePath = cfg.Storage
+	}
 
 	if cmd.Bool(flags.FlgFormatJSON) {
 		return listCertificatesJSON(basePath)

--- a/cmd/cmd_certificates_list.go
+++ b/cmd/cmd_certificates_list.go
@@ -37,15 +37,17 @@ func createListCertificates() *cli.Command {
 }
 
 func listCertificates(ctx context.Context, cmd *cli.Command) error {
+	basePath := cmd.String(flags.FlgPath)
+
 	if cmd.Bool(flags.FlgFormatJSON) {
-		return listCertificatesJSON(ctx, cmd)
+		return listCertificatesJSON(basePath)
 	}
 
-	return listCertificatesText(ctx, cmd)
+	return listCertificatesText(basePath)
 }
 
-func listCertificatesText(_ context.Context, cmd *cli.Command) error {
-	certs, err := readCertificates(cmd)
+func listCertificatesText(basePath string) error {
+	certs, err := readCertificates(basePath)
 	if err != nil {
 		return err
 	}
@@ -82,8 +84,8 @@ func listCertificatesText(_ context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func listCertificatesJSON(_ context.Context, cmd *cli.Command) error {
-	certs, err := readCertificates(cmd)
+func listCertificatesJSON(basePath string) error {
+	certs, err := readCertificates(basePath)
 	if err != nil {
 		return err
 	}
@@ -91,8 +93,8 @@ func listCertificatesJSON(_ context.Context, cmd *cli.Command) error {
 	return json.NewEncoder(os.Stdout).Encode(certs)
 }
 
-func readCertificates(cmd *cli.Command) ([]ListCertificate, error) {
-	certsStorage := storage.NewCertificatesStorage(cmd.String(flags.FlgPath))
+func readCertificates(basePath string) ([]ListCertificate, error) {
+	certsStorage := storage.NewCertificatesStorage(basePath)
 
 	matches, err := zglob.Glob(filepath.Join(certsStorage.GetRootPath(), "**", "*.json"))
 	if err != nil {

--- a/cmd/cmd_certificates_revoke.go
+++ b/cmd/cmd_certificates_revoke.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/go-acme/lego/v5/certcrypto"
@@ -29,6 +30,8 @@ func createRevoke() *cli.Command {
 func revokeFromConfig(ctx context.Context, cmd *cli.Command) error {
 	cfg, err := loadConfiguration(cmd)
 	if err == nil {
+		log.Debug("Configuration loaded from a file.", slog.String("cmd", "revoke"))
+
 		if len(cmd.StringSlice(flags.FlgCertName)) == 0 && !prompt.Confirm("Are you sure you want to revoke all certificates defined in the configuration file?") {
 			return nil
 		}

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/root"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
@@ -58,40 +57,4 @@ func rootRun(ctx context.Context, cmd *cli.Command) error {
 	store := storage.NewConfigurationStorage(cfg.Storage)
 
 	return store.Backup(cfg)
-}
-
-func loadConfiguration(cmd *cli.Command) (*configuration.Configuration, error) {
-	filename, err := getConfigurationPath(cmd)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg, err := configuration.ReadConfiguration(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	setUpLogger(cmd, cfg.Log)
-
-	configuration.ApplyDefaults(cfg)
-
-	err = configuration.Validate(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set effective User Agent.
-	cfg.UserAgent = getUserAgent(cmd, cfg.UserAgent)
-
-	return cfg, nil
-}
-
-func getConfigurationPath(cmd *cli.Command) (string, error) {
-	configPath := cmd.String(flags.FlgConfig)
-
-	if configPath != "" {
-		return configPath, nil
-	}
-
-	return configuration.FindDefaultConfigurationFile()
 }

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -112,6 +112,7 @@ func CreateRenewFlags() []cli.Flag {
 
 func CreateRevokeFlags() []cli.Flag {
 	flags := []cli.Flag{
+		createConfigFlag(),
 		CreatePathFlag(false),
 		createCertNamesFlag(),
 		createKeyTypeFlag("Key type to use for the private key of the account."),
@@ -131,7 +132,6 @@ func CreateRevokeFlags() []cli.Flag {
 				" 9 (privilegeWithdrawn), or 10 (aACompromise).",
 			Value: acme.CRLReasonUnspecified,
 		},
-		createConfigFlag(),
 	}
 
 	flags = append(flags, createAccountFlags()...)
@@ -190,11 +190,19 @@ func CreateKeyRolloverFlags() []cli.Flag {
 
 func CreateListFlags() []cli.Flag {
 	return []cli.Flag{
+		createConfigFlag(),
 		CreatePathFlag(false),
 		&cli.BoolFlag{
 			Name:  FlgFormatJSON,
 			Usage: "Format the output as JSON.",
 		},
+	}
+}
+
+func CreateArchivesListFlags() []cli.Flag {
+	return []cli.Flag{
+		createConfigFlag(),
+		CreatePathFlag(false),
 	}
 }
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -206,6 +206,13 @@ func CreateArchivesListFlags() []cli.Flag {
 	}
 }
 
+func CreateArchivesRestoreFlags() []cli.Flag {
+	return []cli.Flag{
+		createConfigFlag(),
+		CreatePathFlag(false),
+	}
+}
+
 func CreateMigrateFlags() []cli.Flag {
 	return []cli.Flag{
 		CreatePathFlag(false),

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/cmd/internal"
+	"github.com/go-acme/lego/v5/cmd/internal/configuration"
 	"github.com/go-acme/lego/v5/cmd/internal/flags"
 	"github.com/go-acme/lego/v5/cmd/internal/hook"
 	"github.com/go-acme/lego/v5/cmd/internal/storage"
@@ -128,4 +129,40 @@ func parseAddress(cmd *cli.Command, flgName string) (string, string, error) {
 	}
 
 	return host, port, nil
+}
+
+func loadConfiguration(cmd *cli.Command) (*configuration.Configuration, error) {
+	filename, err := getConfigurationPath(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := configuration.ReadConfiguration(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	setUpLogger(cmd, cfg.Log)
+
+	configuration.ApplyDefaults(cfg)
+
+	err = configuration.Validate(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set effective User Agent.
+	cfg.UserAgent = getUserAgent(cmd, cfg.UserAgent)
+
+	return cfg, nil
+}
+
+func getConfigurationPath(cmd *cli.Command) (string, error) {
+	configPath := cmd.String(flags.FlgConfig)
+
+	if configPath != "" {
+		return configPath, nil
+	}
+
+	return configuration.FindDefaultConfigurationFile()
 }

--- a/docs/content/advanced/file-configuration.md
+++ b/docs/content/advanced/file-configuration.md
@@ -18,6 +18,7 @@ The configuration file is used by the following commands:
 - `lego certificates list`
 - `lego accounts list`
 - `lego archives list`
+- `lego archives restore`
 
 ## File Location and Format
 

--- a/docs/content/advanced/file-configuration.md
+++ b/docs/content/advanced/file-configuration.md
@@ -15,6 +15,9 @@ The configuration file is used by the following commands:
 
 - `lego`
 - `lego certificates revoke`
+- `lego certificates list`
+- `lego accounts list`
+- `lego archives list`
 
 ## File Location and Format
 

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -543,6 +543,12 @@ lego archives restore [options]
 |------|-------|-------|
 | `--help`, `-h` |  | show help  |
 
+#### Flags related to the configuration file:
+
+| Flag | Env Var | Usage |
+|------|-------|-------|
+| `--config string` | `LEGO_CONFIG` | Path to the configuration file.  |
+
 #### Flags related to the storage:
 
 | Flag | Env Var | Usage |

--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -391,6 +391,12 @@ lego accounts list [options]
 | `--help`, `-h` |  | show help  |
 | `--json` |  | Format the output as JSON.  |
 
+#### Flags related to the configuration file:
+
+| Flag | Env Var | Usage |
+|------|-------|-------|
+| `--config string` | `LEGO_CONFIG` | Path to the configuration file.  |
+
 #### Flags related to the storage:
 
 | Flag | Env Var | Usage |
@@ -497,6 +503,12 @@ lego certificates list [options]
 | `--help`, `-h` |  | show help  |
 | `--json` |  | Format the output as JSON.  |
 
+#### Flags related to the configuration file:
+
+| Flag | Env Var | Usage |
+|------|-------|-------|
+| `--config string` | `LEGO_CONFIG` | Path to the configuration file.  |
+
 #### Flags related to the storage:
 
 | Flag | Env Var | Usage |
@@ -564,6 +576,12 @@ lego archives list [options]
 | Flag | Env Var | Usage |
 |------|-------|-------|
 | `--help`, `-h` |  | show help  |
+
+#### Flags related to the configuration file:
+
+| Flag | Env Var | Usage |
+|------|-------|-------|
+| `--config string` | `LEGO_CONFIG` | Path to the configuration file.  |
 
 #### Flags related to the storage:
 


### PR DESCRIPTION
Use the configuration file for the following commands:

- `lego certificates list`
- `lego accounts list`
- `lego archives list`
- `lego archives restore`

The flags don't override the configuration.


Related #3118, https://github.com/go-acme/lego/discussions/3127