### PR TITLE
docs: improve root command description

### DIFF
--- a/docs/data/zz_cli_help.toml
+++ b/docs/data/zz_cli_help.toml
@@ -6,7 +6,7 @@ title   = "lego -h"
 content = """
 ## `lego`
 
-> ACME client written in Go
+> Get or renew a certificate with a configuration file
 
 ### Usage
 

--- a/internal/generators/clihelp/generator.go
+++ b/internal/generators/clihelp/generator.go
@@ -103,6 +103,7 @@ func createStubApp() *cli.Command {
 
 	root := cmd.CreateRootCommand()
 	root.EnableShellCompletion = false
+	root.Usage = "Get or renew a certificate with a configuration file"
 
 	// Hides the subcommands for a better render of the root command.
 	for _, command := range root.Commands {


### PR DESCRIPTION
Change the usage description when generating the doc to avoid some ambiguities.