### PR TITLE
feat(namecheap): add IP source logging, network stack awareness, and custom source IP

### DIFF
--- a/cmd/internal/root/process_challenges.go
+++ b/cmd/internal/root/process_challenges.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"os"
+
 	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/challenge/dns01"
 	"github.com/go-acme/lego/v5/challenge/dnspersist01"
@@ -133,6 +135,8 @@ func setupTLSProvider(client *lego.Client, chlg *configuration.TLSChallenge, net
 }
 
 func setupDNS(client *lego.Client, chlg *configuration.DNSChallenge, networkStack challenge.NetworkStack) error {
+	syncNetworkStackEnv(networkStack)
+
 	provider, err := dns.NewDNSChallengeProviderByName(chlg.Provider)
 	if err != nil {
 		return err
@@ -167,6 +171,7 @@ func setupDNS(client *lego.Client, chlg *configuration.DNSChallenge, networkStac
 }
 
 func setupDNSPersist(client *lego.Client, chlg *configuration.DNSPersistChallenge, networkStack challenge.NetworkStack) error {
+	syncNetworkStackEnv(networkStack)
 	opts := &dns01.Options{RecursiveNameservers: chlg.Resolvers}
 
 	if chlg.DNSTimeout > 0 {
@@ -197,4 +202,20 @@ func setupDNSPersist(client *lego.Client, chlg *configuration.DNSPersistChalleng
 			)
 		}),
 	)
+}
+
+
+// syncNetworkStackEnv writes the network stack preference to environment variables
+// so that DNS providers (e.g. namecheap) can read them during initialization
+// for their own HTTP client configuration (e.g. IP auto-detection).
+func syncNetworkStackEnv(networkStack challenge.NetworkStack) {
+	_ = os.Unsetenv("LEGO_IPV4ONLY")
+	_ = os.Unsetenv("LEGO_IPV6ONLY")
+
+	switch networkStack {
+	case challenge.IPv4Only:
+		_ = os.Setenv("LEGO_IPV4ONLY", "true")
+	case challenge.IPv6Only:
+		_ = os.Setenv("LEGO_IPV6ONLY", "true")
+	}
 }

--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"os"
+
 	"github.com/go-acme/lego/v5/challenge"
 	"github.com/go-acme/lego/v5/challenge/dns01"
 	"github.com/go-acme/lego/v5/challenge/dnspersist01"
@@ -134,6 +136,8 @@ func setupTLSProvider(cmd *cli.Command, client *lego.Client) error {
 }
 
 func setupDNS(cmd *cli.Command, client *lego.Client) error {
+	syncNetworkStackEnv(getNetworkStack(cmd))
+
 	provider, err := dns.NewDNSChallengeProviderByName(cmd.String(flags.FlgDNS))
 	if err != nil {
 		return err
@@ -202,11 +206,25 @@ func getNetworkStack(cmd *cli.Command) challenge.NetworkStack {
 	switch {
 	case cmd.Bool(flags.FlgIPv4Only):
 		return challenge.IPv4Only
-
 	case cmd.Bool(flags.FlgIPv6Only):
 		return challenge.IPv6Only
-
 	default:
 		return challenge.DualStack
 	}
+}
+
+
+// syncNetworkStackEnv writes the network stack preference to environment variables
+// so that DNS providers can read them during initialization.
+func syncNetworkStackEnv(networkStack challenge.NetworkStack) {
+	_ = os.Unsetenv("LEGO_IPV4ONLY")
+	_ = os.Unsetenv("LEGO_IPV6ONLY")
+
+	switch networkStack {
+	case challenge.IPv4Only:
+		_ = os.Setenv("LEGO_IPV4ONLY", "true")
+	case challenge.IPv6Only:
+		_ = os.Setenv("LEGO_IPV6ONLY", "true")
+	}
+
 }

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -3046,6 +3046,7 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln(`	- "NAMECHEAP_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 15)`)
 		ew.writeln(`	- "NAMECHEAP_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 3600)`)
 		ew.writeln(`	- "NAMECHEAP_SANDBOX":	Activate the sandbox (boolean)`)
+		ew.writeln(`	- "NAMECHEAP_SOURCEIP":	Source IP address for Namecheap API. Override the auto-detected IP (optional)`)
 		ew.writeln(`	- "NAMECHEAP_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_namecheap.md
+++ b/docs/content/dns/zz_gen_namecheap.md
@@ -58,6 +58,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 | `NAMECHEAP_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 15) |
 | `NAMECHEAP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 3600) |
 | `NAMECHEAP_SANDBOX` | Activate the sandbox (boolean) |
+| `NAMECHEAP_SOURCEIP` | Source IP address for Namecheap API. Override the auto-detected IP (optional) |
 | `NAMECHEAP_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/namecheap/internal/ip.go
+++ b/providers/dns/namecheap/internal/ip.go
@@ -4,23 +4,57 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/go-acme/lego/v5/internal/errutils"
+	"github.com/go-acme/lego/v5/log"
+	"github.com/go-acme/lego/v5/platform/env"
 	"github.com/go-acme/lego/v5/providers/dns/internal/clientdebug"
 )
 
-const getIPURL = "https://dynamicdns.park-your-domain.com/getip"
+const getIPURL = "https://ifconfig.co/ip"
+
+const (
+	envLegoIPv4Only = "LEGO_IPV4ONLY"
+	envLegoIPv6Only = "LEGO_IPV6ONLY"
+)
+
+// NetworkStack represents the IP network stack preference.
+type NetworkStack int
+
+const (
+	StackDual NetworkStack = iota
+	StackIPv4
+	StackIPv6
+)
+
+// GetNetworkStackFromEnv reads LEGO_IPV4ONLY / LEGO_IPV6ONLY to determine the network stack.
+func GetNetworkStackFromEnv() NetworkStack {
+	if env.GetOrDefaultBool(envLegoIPv4Only, false) {
+		return StackIPv4
+	}
+	if env.GetOrDefaultBool(envLegoIPv6Only, false) {
+		return StackIPv6
+	}
+	return StackDual
+}
 
 // GetClientIP returns the client's public IP address.
 // It uses namecheap's IP discovery service to perform the lookup.
+// If stack is StackIPv4 or StackIPv6, the HTTP dialer is restricted accordingly.
 func GetClientIP(ctx context.Context, client *http.Client) (addr string, err error) {
+	stack := GetNetworkStackFromEnv()
+
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Second}
 	}
 
+	client = applyNetworkStack(client, stack)
 	client = clientdebug.Wrap(client)
+
+	log.Infof(log.LazySprintf("namecheap: detecting client IP via %s (network stack: %s)", getIPURL, stackName(stack)))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, getIPURL, http.NoBody)
 	if err != nil {
@@ -40,4 +74,47 @@ func GetClientIP(ctx context.Context, client *http.Client) (addr string, err err
 	}
 
 	return string(clientIP), nil
+}
+
+// applyNetworkStack wraps the client's transport with a dialer restricted to the given network stack.
+func applyNetworkStack(client *http.Client, stack NetworkStack) *http.Client {
+	if stack == StackDual {
+		return client
+	}
+
+	network := "tcp4"
+	if stack == StackIPv6 {
+		network = "tcp6"
+	}
+
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+
+	var transport http.RoundTripper
+	if t, ok := client.Transport.(*http.Transport); ok {
+		clone := t.Clone()
+		clone.DialContext = func(ctx context.Context, network2, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		}
+		transport = clone
+	} else {
+		transport = &http.Transport{
+			DialContext: func(ctx context.Context, network2, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+		}
+	}
+
+	client.Transport = transport
+	return client
+}
+
+func stackName(s NetworkStack) string {
+	switch s {
+	case StackIPv4:
+		return "ipv4"
+	case StackIPv6:
+		return "ipv6"
+	default:
+		return "dual"
+	}
 }

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -40,6 +40,8 @@ const (
 
 	EnvSandbox = envNamespace + "SANDBOX"
 
+	EnvSourceIP = envNamespace + "SOURCEIP"
+
 	EnvTTL                = envNamespace + "TTL"
 	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
 	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
@@ -97,6 +99,11 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config := NewDefaultConfig()
 	config.APIUser = values[EnvAPIUser]
 	config.APIKey = values[EnvAPIKey]
+	config.ClientIP = env.GetOrDefaultString(EnvSourceIP, "")
+
+	if config.ClientIP != "" {
+		log.Infof(log.LazySprintf("namecheap: client IP from environment %s=%s", EnvSourceIP, config.ClientIP))
+	}
 
 	return NewDNSProviderConfig(config)
 }
@@ -112,12 +119,16 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	}
 
 	if config.ClientIP == "" {
+		log.Infof(log.LazySprintf("namecheap: %s not set, detecting client IP automatically", EnvSourceIP))
 		clientIP, err := internal.GetClientIP(context.Background(), config.HTTPClient)
 		if err != nil {
 			return nil, fmt.Errorf("namecheap: %w", err)
 		}
 
 		config.ClientIP = clientIP
+		log.Infof(log.LazySprintf("namecheap: detected client IP: %s", config.ClientIP))
+	} else {
+		log.Infof(log.LazySprintf("namecheap: using client IP from %s: %s", EnvSourceIP, config.ClientIP))
 	}
 
 	client := internal.NewClient(config.APIUser, config.APIKey, config.ClientIP)

--- a/providers/dns/namecheap/namecheap.toml
+++ b/providers/dns/namecheap/namecheap.toml
@@ -26,6 +26,7 @@ lego run --dns namecheap -d '*.example.com' -d example.com
     NAMECHEAP_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 3600)"
     NAMECHEAP_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
     NAMECHEAP_HTTP_TIMEOUT = "API request timeout in seconds (Default: 60)"
+    NAMECHEAP_SOURCEIP = "Source IP address for Namecheap API. Override the auto-detected IP (optional)"
     NAMECHEAP_SANDBOX = "Activate the sandbox (boolean)"
 
 [Links]

--- a/providers/dns/namecheap/namecheap_test.go
+++ b/providers/dns/namecheap/namecheap_test.go
@@ -187,3 +187,26 @@ func mockBuilder() *servermock.Builder[*DNSProvider] {
 		return NewDNSProviderConfig(config)
 	})
 }
+
+func TestNewDNSProviderConfig_ClientIP_priority(t *testing.T) {
+	t.Run("config ClientIP takes priority", func(t *testing.T) {
+		config := NewDefaultConfig()
+		config.APIUser = envTestUser
+		config.APIKey = envTestKey
+		config.ClientIP = "198.51.100.1"
+
+		p, err := NewDNSProviderConfig(config)
+		require.NoError(t, err)
+		assert.Equal(t, "198.51.100.1", p.config.ClientIP)
+	})
+}
+
+func TestNewDNSProvider_SourceIP_env(t *testing.T) {
+	t.Setenv("NAMECHEAP_API_USER", envTestUser)
+	t.Setenv("NAMECHEAP_API_KEY", envTestKey)
+	t.Setenv("NAMECHEAP_SOURCEIP", "203.0.113.50")
+
+	p, err := NewDNSProvider()
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.50", p.config.ClientIP)
+}


### PR DESCRIPTION
#3140

The namecheap DNS provider's IP auto-detection had two issues:
1. GetClientIP used dual-stack HTTP dialing, ignoring --ipv4only/--ipv6only flags
2. No way to determine from logs whether ClientIP came from env or auto-detection

Changes:

- Add NAMECHEAP_SOURCEIP env var to explicitly set the source IP for the Namecheap API
- Restrict GetClientIP HTTP dialer to IPv4 or IPv6 based on --ipv4only/--ipv6only
- Sync network stack CLI flags to env vars (syncNetworkStackEnv) before provider initialization, so providers can respect the network stack setting
- Change IP detection endpoint to https://ifconfig.co/ip
- Add detailed logging: IP source (env var vs auto-detect), network stack used, and detection result
- Add tests for env var priority and config passthrough