### PR TITLE
Add DNS provider for RackCorp

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,77 +258,77 @@ If your DNS provider is not supported, please open an [issue](https://github.com
   <td><a href="https://go-acme.github.io/lego/dns/porkbun/">Porkbun</a></td>
 </tr><tr>
   <td><a href="https://go-acme.github.io/lego/dns/pdns/">PowerDNS</a></td>
+  <td><a href="https://go-acme.github.io/lego/dns/rackcorp/">Rackcorp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rackspace/">Rackspace</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rage4/">Rage4</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/rainyun/">Rain Yun/雨云</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/rainyun/">Rain Yun/雨云</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rcodezero/">RcodeZero</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/regru/">reg.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/regfish/">Regfish</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/rimuhosting/">RimuHosting</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/rimuhosting/">RimuHosting</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nicru/">RU CENTER</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/sakuracloud/">Sakura Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/scaleway/">Scaleway</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/scannet/">ScanNet</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/scannet/">ScanNet</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selectel/">Selectel</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selectelv2/">Selectel v2</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selfhostde/">SelfHost.(de|eu)</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/servercow/">Servercow</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/servercow/">Servercow</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/shellrent/">Shellrent</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/simply/">Simply.com</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/sonic/">Sonic</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/spaceship/">Spaceship</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/spaceship/">Spaceship</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/stackpath/">Stackpath</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/syse/">Syse</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/technitium/">Technitium</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/tele3/">Tele3</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/tele3/">Tele3</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/tencentcloud/">Tencent Cloud DNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/edgeone/">Tencent EdgeOne</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/timewebcloud/">Timeweb Cloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/todaynic/">TodayNIC/时代互联</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/todaynic/">TodayNIC/时代互联</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/transip/">TransIP</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ucloud/">UCloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ultradns/">Ultradns</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/uniteddomains/">United-Domains</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/uniteddomains/">United-Domains</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/variomedia/">Variomedia</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/veesp/">Veesp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vegadns/">VegaDNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vercel/">Vercel</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vercel/">Vercel</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/versio/">Versio.[nl|eu|uk]</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vinyldns/">VinylDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/virtualname/">Virtualname</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vkcloud/">VK Cloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vkcloud/">VK Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/volcengine/">Volcano Engine/火山引擎</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vscale/">Vscale</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vultr/">Vultr</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/wannafind/">Wannafind</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/wannafind/">Wannafind</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/webnamesca/">webnames.ca</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/webnamesru/">webnames.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/websupport/">Websupport</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/wedos/">WEDOS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/wedos/">WEDOS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/westcn/">West.cn/西部数码</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/xinnet/">Xinnet</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandex360/">Yandex 360</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/yandexcloud/">Yandex Cloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/yandexcloud/">Yandex Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandex/">Yandex PDD</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zilore/">Zilore</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zoneee/">Zone.ee</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/zoneedit/">ZoneEdit</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/zoneedit/">ZoneEdit</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zonomi/">Zonomi</a></td>
-  <td></td>
   <td></td>
   <td></td>
 </tr></table>

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -169,6 +169,7 @@ func allDNSCodes() string {
 		"plesk",
 		"pointdns",
 		"porkbun",
+		"rackcorp",
 		"rackspace",
 		"rage4",
 		"rainyun",
@@ -3595,6 +3596,27 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/porkbun`)
+
+	case "rackcorp":
+		// generated from: providers/dns/rackcorp/rackcorp.toml
+		ew.writeln(`Configuration for Rackcorp.`)
+		ew.writeln(`Code:	'rackcorp'`)
+		ew.writeln(`Since:	'v5.1.0'`)
+		ew.writeln()
+
+		ew.writeln(`Credentials:`)
+		ew.writeln(`	- "RACKCORP_API_SECRET":	API key`)
+		ew.writeln(`	- "RACKCORP_API_UUID":	API key`)
+		ew.writeln()
+
+		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "RACKCORP_HTTP_TIMEOUT":	API request timeout in seconds (Default: 10)`)
+		ew.writeln(`	- "RACKCORP_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)
+		ew.writeln(`	- "RACKCORP_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 60)`)
+		ew.writeln(`	- "RACKCORP_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
+
+		ew.writeln()
+		ew.writeln(`More information: https://go-acme.github.io/lego/dns/rackcorp`)
 
 	case "rackspace":
 		// generated from: providers/dns/rackspace/rackspace.toml

--- a/docs/content/dns/zz_gen_rackcorp.md
+++ b/docs/content/dns/zz_gen_rackcorp.md
@@ -1,0 +1,74 @@
+---
+title: "Rackcorp"
+date: 2019-03-03T16:39:46+01:00
+draft: false
+slug: rackcorp
+dnsprovider:
+  since:    "v5.1.0"
+  code:     "rackcorp"
+  url:      "https://rackcorp.com"
+---
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/rackcorp/rackcorp.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+
+
+Configuration for [Rackcorp](https://rackcorp.com).
+
+
+<!--more-->
+
+- Code: `rackcorp`
+- Since: v5.1.0
+
+
+Here is an example bash command using the Rackcorp provider:
+
+```bash
+RACKCORP_API_UUID=xxxx \
+RACKCORP_API_SECRET=xxxx \
+lego run --dns rackcorp -d '*.example.com' -d example.com
+```
+
+
+
+
+## Credentials
+
+| Environment Variable Name | Description |
+|-----------------------|-------------|
+| `RACKCORP_API_SECRET` | API key |
+| `RACKCORP_API_UUID` | API key |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+
+## Additional Configuration
+
+| Environment Variable Name | Description |
+|--------------------------------|-------------|
+| `RACKCORP_HTTP_TIMEOUT` | API request timeout in seconds (Default: 10) |
+| `RACKCORP_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |
+| `RACKCORP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 60) |
+| `RACKCORP_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+## Description
+
+To authenticate you need to provide a valid API key UUID and Secret.
+The API key must have permissions for: dns.domain.getall, dns.domain.get,
+  dns.record.create, dns.record.get, dns.record.update, and dns.record.delete.
+
+
+
+## More information
+
+- [API documentation](https://github.com/RackCorpCloud/rackcorp-api/wiki/RACKCORP-REST-API)
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/rackcorp/rackcorp.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->

--- a/providers/dns/rackcorp/internal/client.go
+++ b/providers/dns/rackcorp/internal/client.go
@@ -1,0 +1,237 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+type DNSRecord struct {
+	ID       json.Number `json:"id"`
+	Lookup   string      `json:"lookup"`
+	Type     string      `json:"type"`
+	Data     string      `json:"data"`
+	TTL      json.Number `json:"ttl"`
+	DomainID json.Number `json:"domainId"`
+}
+
+type DNSDomain struct {
+	ID      json.Number `json:"id"`
+	Name    string      `json:"name"`
+	Records []DNSRecord `json:"records"`
+}
+
+type response struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	responseCodeOK = "OK"
+	recordTypeTXT  = "TXT"
+)
+
+type dnsDomainGetResponse struct {
+	response
+	DNSDomain
+}
+
+type dnsDomainGetAllResponse struct {
+	response
+
+	Domains map[string]DNSDomain `json:"domains"`
+}
+
+const DefaultURL = "https://api.rackcorp.net/api/rest/v2.9/json.php"
+
+type RCClient struct {
+	client    *http.Client
+	URL       string
+	apiUUID   string
+	apiSecret string
+	userAgent string
+}
+
+func NewRCClient(client *http.Client, url, apiUUID, apiSecret, userAgent string) *RCClient {
+	return &RCClient{
+		client:    client,
+		URL:       url,
+		apiUUID:   apiUUID,
+		apiSecret: apiSecret,
+		userAgent: userAgent,
+	}
+}
+
+func (c *RCClient) apiReq(payload map[string]any) (*http.Response, error) {
+	reqBodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.URL,
+		bytes.NewReader(reqBodyBytes),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+	req.SetBasicAuth(c.apiUUID, c.apiSecret)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.client.Do(req)
+}
+
+func doAPI[T any](c *RCClient, payload map[string]any, result *T) error {
+	resp, err := c.apiReq(payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(result)
+
+	return err
+}
+
+func (c *RCClient) DNSDomainGetAll() (map[string]DNSDomain, error) {
+	reqPayload := map[string]any{
+		"cmd": "dns.domain.getall",
+	}
+
+	var apiResp dnsDomainGetAllResponse
+
+	err := doAPI(c, reqPayload, &apiResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if apiResp.Code != responseCodeOK {
+		return nil, fmt.Errorf("api error: %s", apiResp.Message)
+	}
+
+	return apiResp.Domains, nil
+}
+
+func (c *RCClient) DNSDomainGet(domainID json.Number) (*DNSDomain, error) {
+	reqPayload := map[string]any{
+		"cmd": "dns.domain.get",
+		"id":  domainID,
+	}
+
+	var apiResp dnsDomainGetResponse
+
+	err := doAPI(c, reqPayload, &apiResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if apiResp.Code != responseCodeOK {
+		return nil, fmt.Errorf("api error: %s", apiResp.Message)
+	}
+
+	return &apiResp.DNSDomain, nil
+}
+
+func (c *RCClient) DNSRecordCreateTXT(domainID json.Number, lookup, data string, ttl int) error {
+	record := DNSRecord{
+		ID:       "0",
+		Lookup:   lookup,
+		Type:     recordTypeTXT,
+		Data:     data,
+		TTL:      json.Number(strconv.Itoa(ttl)),
+		DomainID: domainID,
+	}
+
+	reqPayload := map[string]any{
+		"cmd": "dns.record.create",
+		"data": map[json.Number]DNSRecord{
+			record.ID: record,
+		},
+	}
+
+	var apiResp response
+
+	err := doAPI(c, reqPayload, &apiResp)
+	if err != nil {
+		return err
+	}
+
+	if apiResp.Code != responseCodeOK {
+		return fmt.Errorf("api error: %s", apiResp.Message)
+	}
+
+	return nil
+}
+
+func (c *RCClient) DNSRecordUpdate(record DNSRecord) error {
+	reqPayload := map[string]any{
+		"cmd": "dns.record.update",
+		"data": map[json.Number]DNSRecord{
+			record.ID: record,
+		},
+	}
+
+	var apiResp response
+
+	err := doAPI(c, reqPayload, &apiResp)
+	if err != nil {
+		return err
+	}
+
+	if apiResp.Code != responseCodeOK {
+		return fmt.Errorf("api error: %s", apiResp.Message)
+	}
+
+	return nil
+}
+
+func (c *RCClient) DNSRecordDelete(recordID json.Number) error {
+	reqPayload := map[string]any{
+		"cmd": "dns.record.delete",
+		"id":  recordID,
+	}
+
+	var apiResp response
+
+	err := doAPI(c, reqPayload, &apiResp)
+	if err != nil {
+		return err
+	}
+
+	if apiResp.Code != responseCodeOK {
+		return fmt.Errorf("api error: %s", apiResp.Message)
+	}
+
+	return nil
+}
+
+func FindDomain(domains map[string]DNSDomain, domainName string) *DNSDomain {
+	for _, domain := range domains {
+		if domain.Name == domainName {
+			return &domain
+		}
+	}
+
+	return nil
+}
+
+func FindTXTRecord(records []DNSRecord, lookup string) *DNSRecord {
+	for _, record := range records {
+		if record.Lookup == lookup && record.Type == recordTypeTXT {
+			return &record
+		}
+	}
+
+	return nil
+}

--- a/providers/dns/rackcorp/internal/client.go
+++ b/providers/dns/rackcorp/internal/client.go
@@ -44,6 +44,11 @@ type dnsDomainGetAllResponse struct {
 	Domains map[string]DNSDomain `json:"domains"`
 }
 
+type dnsRecordCreateResponse struct {
+	response
+	Data []DNSRecord `json:"data"`
+}
+
 const DefaultURL = "https://api.rackcorp.net/api/rest/v2.9/json.php"
 
 type RCClient struct {
@@ -143,7 +148,7 @@ func (c *RCClient) DNSDomainGet(domainID json.Number) (*DNSDomain, error) {
 	return &apiResp.DNSDomain, nil
 }
 
-func (c *RCClient) DNSRecordCreateTXT(domainID json.Number, lookup, data string, ttl int) error {
+func (c *RCClient) DNSRecordCreateTXT(domainID json.Number, lookup, data string, ttl int) (*DNSRecord, error) {
 	record := DNSRecord{
 		ID:       "0",
 		Lookup:   lookup,
@@ -160,40 +165,22 @@ func (c *RCClient) DNSRecordCreateTXT(domainID json.Number, lookup, data string,
 		},
 	}
 
-	var apiResp response
+	var apiResp dnsRecordCreateResponse
 
 	err := doAPI(c, reqPayload, &apiResp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if apiResp.Code != responseCodeOK {
-		return fmt.Errorf("api error: %s", apiResp.Message)
+		return nil, fmt.Errorf("api error: %s", apiResp.Message)
 	}
 
-	return nil
-}
-
-func (c *RCClient) DNSRecordUpdate(record DNSRecord) error {
-	reqPayload := map[string]any{
-		"cmd": "dns.record.update",
-		"data": map[json.Number]DNSRecord{
-			record.ID: record,
-		},
+	if len(apiResp.Data) == 0 {
+		return nil, fmt.Errorf("no record returned")
 	}
 
-	var apiResp response
-
-	err := doAPI(c, reqPayload, &apiResp)
-	if err != nil {
-		return err
-	}
-
-	if apiResp.Code != responseCodeOK {
-		return fmt.Errorf("api error: %s", apiResp.Message)
-	}
-
-	return nil
+	return &apiResp.Data[0], nil
 }
 
 func (c *RCClient) DNSRecordDelete(recordID json.Number) error {
@@ -226,9 +213,9 @@ func FindDomain(domains map[string]DNSDomain, domainName string) *DNSDomain {
 	return nil
 }
 
-func FindTXTRecord(records []DNSRecord, lookup string) *DNSRecord {
+func FindTXTRecord(records []DNSRecord, lookup string, data string) *DNSRecord {
 	for _, record := range records {
-		if record.Lookup == lookup && record.Type == recordTypeTXT {
+		if record.Lookup == lookup && record.Type == recordTypeTXT && record.Data == data {
 			return &record
 		}
 	}

--- a/providers/dns/rackcorp/rackcorp.go
+++ b/providers/dns/rackcorp/rackcorp.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-acme/lego/v5/challenge"
@@ -62,6 +62,9 @@ func NewDefaultConfig() *Config {
 type DNSProvider struct {
 	config *Config
 	client *internal.RCClient
+
+	mu        sync.Mutex
+	recordIDs map[string]json.Number
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Rackcorp.
@@ -88,7 +91,24 @@ func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 		useragent.Get(),
 	)
 
-	return &DNSProvider{config: config, client: client}, nil
+	return &DNSProvider{
+		config:    config,
+		client:    client,
+		recordIDs: make(map[string]json.Number),
+	}, nil
+}
+
+func (d *DNSProvider) storeRecordID(token string, recordID json.Number) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.recordIDs[token] = recordID
+}
+
+func (d *DNSProvider) getRecordID(token string) (json.Number, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	recordID, found := d.recordIDs[token]
+	return recordID, found
 }
 
 // Present creates a TXT record to fulfill the dns-01 challenge.
@@ -105,37 +125,28 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		return err
 	}
 
-	record := internal.FindTXTRecord(zone.Records, info.Prefix)
+	record := internal.FindTXTRecord(zone.Records, info.Prefix, info.Value)
 	if record != nil {
-		record.Data = info.Value
-		record.TTL = json.Number(strconv.Itoa(d.config.TTL))
-
-		return d.client.DNSRecordUpdate(*record)
+		d.storeRecordID(token, record.ID)
+		return nil
 	}
 
-	return d.client.DNSRecordCreateTXT(zone.ID, info.Prefix, info.Value, d.config.TTL)
+	record, err = d.client.DNSRecordCreateTXT(zone.ID, info.Prefix, info.Value, d.config.TTL)
+	if err != nil {
+		return err
+	}
+	d.storeRecordID(token, record.ID)
+	return nil
 }
 
 // CleanUp removes the TXT record matching the specified parameters.
 func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
-	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
-
-	zone, err := d.getHostedZone(ctx, info.EffectiveFQDN)
-	if err != nil {
-		return err
+	recordID, ok := d.getRecordID(token)
+	if !ok {
+		info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+		return fmt.Errorf("rackcorp: unknown record ID for '%s' '%s'", info.EffectiveFQDN, token)
 	}
-
-	zone, err = d.client.DNSDomainGet(zone.ID)
-	if err != nil {
-		return err
-	}
-
-	record := internal.FindTXTRecord(zone.Records, info.Prefix)
-	if record != nil {
-		return d.client.DNSRecordDelete(record.ID)
-	}
-
-	return nil
+	return d.client.DNSRecordDelete(recordID)
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.

--- a/providers/dns/rackcorp/rackcorp.go
+++ b/providers/dns/rackcorp/rackcorp.go
@@ -1,0 +1,166 @@
+package rackcorp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-acme/lego/v5/challenge"
+	"github.com/go-acme/lego/v5/challenge/dns01"
+	"github.com/go-acme/lego/v5/internal/useragent"
+	"github.com/go-acme/lego/v5/platform/env"
+	"github.com/go-acme/lego/v5/providers/dns/internal/clientdebug"
+	"github.com/go-acme/lego/v5/providers/dns/rackcorp/internal"
+)
+
+// Environment variables names.
+const (
+	envNamespace = "RACKCORP_"
+
+	EnvAPIURL    = envNamespace + "API_URL"
+	EnvAPIUUID   = envNamespace + "API_UUID"
+	EnvAPISecret = envNamespace + "API_SECRET"
+
+	EnvTTL                = envNamespace + "TTL"
+	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
+	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
+	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+)
+
+var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
+
+// Config is used to configure the creation of the DNSProvider.
+type Config struct {
+	URL                string
+	APIUUID            string
+	APISecret          string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider.
+func NewDefaultConfig() *Config {
+	return &Config{
+		URL:                env.GetOrDefaultString(EnvAPIURL, internal.DefaultURL),
+		APIUUID:            env.GetOrDefaultString(EnvAPIUUID, ""),
+		APISecret:          env.GetOrDefaultString(EnvAPISecret, ""),
+		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 10*time.Second),
+		},
+	}
+}
+
+type DNSProvider struct {
+	config *Config
+	client *internal.RCClient
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for Rackcorp.
+// Credentials must be passed in the two environment variables,
+// `RACKCORP_API_UUID` and `RACKCORP_API_SECRET`.
+func NewDNSProvider() (*DNSProvider, error) {
+	config := NewDefaultConfig()
+	return NewDNSProviderConfig(config)
+}
+
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("rackcorp: the configuration of the DNS provider is nil")
+	}
+
+	if config.APIUUID == "" || config.APISecret == "" {
+		return nil, errors.New("rackcorp: API credentials are missing")
+	}
+
+	client := internal.NewRCClient(clientdebug.Wrap(config.HTTPClient),
+		config.URL,
+		config.APIUUID,
+		config.APISecret,
+		useragent.Get(),
+	)
+
+	return &DNSProvider{config: config, client: client}, nil
+}
+
+// Present creates a TXT record to fulfill the dns-01 challenge.
+func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string) error {
+	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+
+	zone, err := d.getHostedZone(ctx, info.EffectiveFQDN)
+	if err != nil {
+		return err
+	}
+
+	zone, err = d.client.DNSDomainGet(zone.ID)
+	if err != nil {
+		return err
+	}
+
+	record := internal.FindTXTRecord(zone.Records, info.Prefix)
+	if record != nil {
+		record.Data = info.Value
+		record.TTL = json.Number(strconv.Itoa(d.config.TTL))
+
+		return d.client.DNSRecordUpdate(*record)
+	}
+
+	return d.client.DNSRecordCreateTXT(zone.ID, info.Prefix, info.Value, d.config.TTL)
+}
+
+// CleanUp removes the TXT record matching the specified parameters.
+func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
+	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+
+	zone, err := d.getHostedZone(ctx, info.EffectiveFQDN)
+	if err != nil {
+		return err
+	}
+
+	zone, err = d.client.DNSDomainGet(zone.ID)
+	if err != nil {
+		return err
+	}
+
+	record := internal.FindTXTRecord(zone.Records, info.Prefix)
+	if record != nil {
+		return d.client.DNSRecordDelete(record.ID)
+	}
+
+	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+func (d *DNSProvider) getHostedZone(ctx context.Context, fqdn string) (*internal.DNSDomain, error) {
+	authZone, err := dns01.DefaultClient().FindZoneByFqdn(ctx, fqdn)
+	if err != nil {
+		return nil, fmt.Errorf("could not find zone: %w", err)
+	}
+
+	authZone = dns01.UnFqdn(authZone)
+
+	domains, err := d.client.DNSDomainGetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	domain := internal.FindDomain(domains, authZone)
+	if domain == nil {
+		return nil, fmt.Errorf("could not find domain: %s", authZone)
+	}
+
+	return domain, nil
+}

--- a/providers/dns/rackcorp/rackcorp.toml
+++ b/providers/dns/rackcorp/rackcorp.toml
@@ -1,0 +1,32 @@
+Name = "Rackcorp"
+Description = ''''''
+URL = "https://rackcorp.com"
+Code = "rackcorp"
+Since = "v5.1.0"
+
+Example = '''
+RACKCORP_API_UUID=xxxx \
+RACKCORP_API_SECRET=xxxx \
+lego run --dns rackcorp -d '*.example.com' -d example.com
+'''
+
+Additional = '''
+## Description
+
+To authenticate you need to provide a valid API key UUID and Secret.
+The API key must have permissions for: dns.domain.getall, dns.domain.get,
+  dns.record.create, dns.record.get, dns.record.update, and dns.record.delete.
+'''
+
+[Configuration]
+  [Configuration.Credentials]
+    RACKCORP_API_UUID = "API key"
+    RACKCORP_API_SECRET = "API key"
+  [Configuration.Additional]
+    RACKCORP_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
+    RACKCORP_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 60)"
+    RACKCORP_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
+    RACKCORP_HTTP_TIMEOUT = "API request timeout in seconds (Default: 10)"
+
+[Links]
+  API = "https://github.com/RackCorpCloud/rackcorp-api/wiki/RACKCORP-REST-API"

--- a/providers/dns/rackcorp/rackcorp_test.go
+++ b/providers/dns/rackcorp/rackcorp_test.go
@@ -1,0 +1,156 @@
+package rackcorp
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-acme/lego/v5/internal/tester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const envDomain = envNamespace + "DOMAIN"
+
+var envTest = tester.NewEnvTest(EnvAPIURL, EnvAPIUUID, EnvAPISecret).
+	WithDomain(envDomain).
+	WithLiveTestRequirements(EnvAPIUUID, EnvAPISecret, envDomain)
+
+func TestNewDNSProvider(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			desc: "success",
+			envVars: map[string]string{
+				EnvAPIUUID:   "my_uuid",
+				EnvAPISecret: "my_secret",
+			},
+		},
+		{
+			desc: "success: url",
+			envVars: map[string]string{
+				EnvAPIUUID:   "my_uuid",
+				EnvAPISecret: "my_secret",
+				EnvAPIURL:    "https://api.rackcorp.net/api/rest/v2.8/json.php",
+			},
+		},
+		{
+			desc: "missing API credentials",
+			envVars: map[string]string{
+				EnvAPIUUID:   "",
+				EnvAPISecret: "",
+			},
+			expected: "rackcorp: API credentials are missing",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer envTest.RestoreEnv()
+
+			envTest.ClearEnv()
+
+			envTest.Apply(test.envVars)
+
+			p, err := NewDNSProvider()
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+				require.NotNil(t, p.client)
+
+				baseURL := os.Getenv(EnvAPIURL)
+				if baseURL != "" {
+					assert.Equal(t, baseURL, p.client.URL)
+				}
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestNewDNSProviderConfig(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		apiUUID   string
+		apiSecret string
+		url       string
+		expected  string
+	}{
+		{
+			desc:      "success",
+			apiUUID:   "my_uuid",
+			apiSecret: "my_secret",
+			url:       "",
+		},
+		{
+			desc:      "success: url",
+			apiUUID:   "my_uuid",
+			apiSecret: "my_secret",
+			url:       "https://api.rackcorp.net/api/rest/v2.8/json.php",
+		},
+		{
+			desc:     "missing API credentials",
+			expected: "rackcorp: API credentials are missing",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			config := NewDefaultConfig()
+			config.APIUUID = test.apiUUID
+			config.APISecret = test.apiSecret
+			config.URL = test.url
+
+			p, err := NewDNSProviderConfig(config)
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+				require.NotNil(t, p.client)
+
+				if test.url != "" {
+					assert.Equal(t, test.url, p.client.URL)
+				}
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestLivePresent(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	err = provider.Present(t.Context(), envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}
+
+func TestLiveCleanUp(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	err = provider.CleanUp(t.Context(), envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}

--- a/providers/dns/zz_gen_dns_providers.go
+++ b/providers/dns/zz_gen_dns_providers.go
@@ -163,6 +163,7 @@ import (
 	"github.com/go-acme/lego/v5/providers/dns/plesk"
 	"github.com/go-acme/lego/v5/providers/dns/pointdns"
 	"github.com/go-acme/lego/v5/providers/dns/porkbun"
+	"github.com/go-acme/lego/v5/providers/dns/rackcorp"
 	"github.com/go-acme/lego/v5/providers/dns/rackspace"
 	"github.com/go-acme/lego/v5/providers/dns/rage4"
 	"github.com/go-acme/lego/v5/providers/dns/rainyun"
@@ -538,6 +539,8 @@ func NewDNSChallengeProviderByName(name string) (challenge.Provider, error) {
 		return pointdns.NewDNSProvider()
 	case "porkbun":
 		return porkbun.NewDNSProvider()
+	case "rackcorp":
+		return rackcorp.NewDNSProvider()
 	case "rackspace":
 		return rackspace.NewDNSProvider()
 	case "rage4":


### PR DESCRIPTION
Closes #3101

Adopts improvements from #3103.

Has been verified to work correctly with:
```sh
make build
rm -rf .lego

RACKCORP_API_UUID="xxx" \
RACKCORP_API_SECRET="yyy" \
./dist/lego run --dns rackcorp -d '*.example.com' -d example.com -s letsencrypt-staging
```