### PR TITLE
euserv: enforce order ID selection

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -1772,8 +1772,8 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln(`Additional Configuration:`)
 		ew.writeln(`	- "EUSERV_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
-		ew.writeln(`	- "EUSERV_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)
-		ew.writeln(`	- "EUSERV_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 60)`)
+		ew.writeln(`	- "EUSERV_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 10)`)
+		ew.writeln(`	- "EUSERV_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 360)`)
 		ew.writeln(`	- "EUSERV_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)`)
 
 		ew.writeln()

--- a/docs/content/dns/zz_gen_euserv.md
+++ b/docs/content/dns/zz_gen_euserv.md
@@ -52,8 +52,8 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
 | `EUSERV_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
-| `EUSERV_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |
-| `EUSERV_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 60) |
+| `EUSERV_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 10) |
+| `EUSERV_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 360) |
 | `EUSERV_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120) |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.

--- a/providers/dns/euserv/euserv.go
+++ b/providers/dns/euserv/euserv.go
@@ -47,8 +47,8 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
-		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, dns01.DefaultPropagationTimeout),
-		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 6*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, 10*time.Second),
 		HTTPClient: &http.Client{
 			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
 		},

--- a/providers/dns/euserv/euserv.go
+++ b/providers/dns/euserv/euserv.go
@@ -133,6 +133,11 @@ func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("euserv: %w", err)
 	}
 
+	err = d.client.ChooseOrder(ctx, d.config.OrderID)
+	if err != nil {
+		return fmt.Errorf("euserv: choose order: %w", err)
+	}
+
 	domainID, err := d.findDomainID(ctx, authZone, info.EffectiveFQDN)
 	if err != nil {
 		return fmt.Errorf("euserv: find domain ID: %w", err)
@@ -166,6 +171,11 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 	ctx = internal.WithContext(ctx, sessionID)
 
 	defer func() { _ = d.identifier.Logout(ctx) }()
+
+	err = d.client.ChooseOrder(ctx, d.config.OrderID)
+	if err != nil {
+		return fmt.Errorf("euserv: choose order: %w", err)
+	}
 
 	recordID, err := d.findRecordID(ctx, info)
 	if err != nil {

--- a/providers/dns/euserv/euserv.toml
+++ b/providers/dns/euserv/euserv.toml
@@ -17,8 +17,8 @@ lego run --email you@example.com --dns euserv -d '*.example.com' -d example.com
     EUSERV_PASSWORD = "The customer account password."
     EUSERV_ORDER_ID = "The order ID of the API contract that you want to use for this login session."
   [Configuration.Additional]
-    EUSERV_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
-    EUSERV_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 60)"
+    EUSERV_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 10)"
+    EUSERV_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 360)"
     EUSERV_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120)"
     EUSERV_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
 

--- a/providers/dns/euserv/internal/client.go
+++ b/providers/dns/euserv/internal/client.go
@@ -129,6 +129,39 @@ func (c *Client) SetRecord(ctx context.Context, request SetRecordRequest) error 
 	return nil
 }
 
+// ChooseOrder selects an order in your customer account.
+// https://support.euserv.com/api-doc/#api-Order-choose_order
+func (c *Client) ChooseOrder(ctx context.Context, orderID string) error {
+	endpoint, err := url.Parse(c.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	query := endpoint.Query()
+	query.Set("subaction", "choose_order")
+	query.Set("ord_no", orderID)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := newHTTPRequest(ctx, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	var response APIResponse
+
+	err = c.do(req, &response)
+	if err != nil {
+		return err
+	}
+
+	_, err = extractResponse[any](response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Client) do(req *http.Request, result any) error {
 	useragent.SetHeader(req.Header)
 

--- a/providers/dns/euserv/internal/client_test.go
+++ b/providers/dns/euserv/internal/client_test.go
@@ -126,3 +126,19 @@ func TestClient_GetRecords(t *testing.T) {
 
 	assert.Equal(t, expected, domains)
 }
+
+func TestClient_ChooseOrder(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /",
+			servermock.ResponseFromFixture("choose_order.json"),
+			servermock.CheckQueryParameter().Strict().
+				With("subaction", "choose_order").
+				With("ord_no", "orderA").
+				With("lang_id", "2").
+				With("method", "json"),
+		).
+		Build(t)
+
+	err := client.ChooseOrder(t.Context(), "orderA")
+	require.NoError(t, err)
+}

--- a/providers/dns/euserv/internal/fixtures/choose_order.json
+++ b/providers/dns/euserv/internal/fixtures/choose_order.json
@@ -1,0 +1,5 @@
+{
+  "message": "success",
+  "code": "100",
+  "result": []
+}


### PR DESCRIPTION
Fixes #3176

It also changes the default propagation timeout.


<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout fix/dns/euserv/order-id
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego` or `go build -o dist/lego.exe ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    ./dist/lego run --dns euserv -d '*.example.com' -d example.com -s letsencrypt-staging
    # or on Windows
    ./dist/lego.exe run --dns euserv -d '*.example.com' -d example.com -s letsencrypt-staging
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>