### PR TITLE
fix infomaniak numeric DNS record IDs

### DIFF
--- a/providers/dns/infomaniak/internal/client.go
+++ b/providers/dns/infomaniak/internal/client.go
@@ -49,14 +49,17 @@ func (c *Client) CreateDNSRecord(ctx context.Context, domain *DNSDomain, record 
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	result := APIResponse[string]{}
+	// Infomaniak returns the newly-created DNS record ID as a JSON number.
+	// Keep the public method signature as string because DeleteDNSRecord uses
+	// the ID as a URL path segment.
+	result := APIResponse[uint64]{}
 
 	err = c.do(req, &result)
 	if err != nil {
 		return "", err
 	}
 
-	return result.Data, err
+	return strconv.FormatUint(result.Data, 10), nil
 }
 
 func (c *Client) DeleteDNSRecord(ctx context.Context, domainID uint64, recordID string) error {

--- a/providers/dns/infomaniak/internal/client_test.go
+++ b/providers/dns/infomaniak/internal/client_test.go
@@ -26,7 +26,7 @@ func mockBuilder() *servermock.Builder[*Client] {
 func TestClient_CreateDNSRecord(t *testing.T) {
 	client := mockBuilder().
 		Route("POST /1/domain/666/dns/record",
-			servermock.RawStringResponse(`{"result":"success","data": "123"}`),
+			servermock.RawStringResponse(`{"result":"success","data": 123}`),
 			servermock.CheckRequestJSONBodyFromFixture("create_dns_record-request.json")).
 		Build(t)
 


### PR DESCRIPTION
## Summary

Fix Infomaniak DNS record creation when its API returns the new record ID as a JSON number.

## Root cause

`POST /1/domain/{id}/dns/record` returns a successful response such as `{"result":"success","data":36352129}`. The provider decoded `data` as a string, causing JSON unmarshalling to fail after the TXT record had already been created.

## Change

Decode the record ID as `uint64` and convert it to a string for the existing cleanup URL path. Update the provider test to exercise the numeric API response.

## Validation

`go test ./providers/dns/infomaniak/...`
