### PR TITLE
Add DNS provider for FENO

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,184 +158,184 @@ If your DNS provider is not supported, please open an [issue](https://github.com
   <td><a href="https://go-acme.github.io/lego/dns/exec/">External program</a></td>
 </tr><tr>
   <td><a href="https://go-acme.github.io/lego/dns/f5xc/">F5 XC</a></td>
+  <td><a href="https://go-acme.github.io/lego/dns/feno/">FENO</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/fornex/">Fornex</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/freemyip/">freemyip.com</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/namesurfer/">FusionLayer NameSurfer</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/namesurfer/">FusionLayer NameSurfer</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gcore/">G-Core</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gandi/">Gandi</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gandiv5/">Gandi Live DNS (v5)</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/gehirn/">Gehirn</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/gehirn/">Gehirn</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gigahostno/">Gigahost.no</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/glesys/">Glesys</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gname/">Gname</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/godaddy/">Go Daddy</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/godaddy/">Go Daddy</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gcloud/">Google Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/gravity/">Gravity</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hetzner/">Hetzner</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/hostingde/">Hosting.de</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/hostingde/">Hosting.de</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hostingnl/">Hosting.nl</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hostinger/">Hostinger</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hosttech/">Hosttech</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/hostup/">HostUp</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/hostup/">HostUp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/httpreq/">HTTP request</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/httpnet/">http.net</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/huaweicloud/">Huawei Cloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/hurricane/">Hurricane Electric DNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/hurricane/">Hurricane Electric DNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/hyperone/">HyperOne</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ibmcloud/">IBM Cloud (SoftLayer)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/iijdpf/">IIJ DNS Platform Service</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/infoblox/">Infoblox</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/infoblox/">Infoblox</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/infomaniak/">Infomaniak</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/internetbs/">Internet.bs</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/inwx/">INWX</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ionos/">Ionos</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ionos/">Ionos</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ionoscloud/">Ionos Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ipv64/">IPv64</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ispconfig/">ISPConfig 3</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ispconfigddns/">ISPConfig 3 - Dynamic DNS (DDNS) Module</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ispconfigddns/">ISPConfig 3 - Dynamic DNS (DDNS) Module</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/jdcloud/">JD Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/joker/">Joker</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/acmedns/">Joohoi&#39;s ACME-DNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/katapult/">Katapult</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/katapult/">Katapult</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/keyhelp/">KeyHelp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/leaseweb/">Leaseweb</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/liara/">Liara</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/limacity/">Lima-City</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/limacity/">Lima-City</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/linode/">Linode (v4)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/liquidweb/">Liquid Web</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/loopia/">Loopia</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/luadns/">LuaDNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/luadns/">LuaDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mailinabox/">Mail-in-a-Box</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/manageengine/">ManageEngine CloudDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/manual/">Manual</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/metaname/">Metaname</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/metaname/">Metaname</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/metaregistrar/">Metaregistrar</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mijnhost/">mijn.host</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mittwald/">Mittwald</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/myaddr/">myaddr.{tools,dev,io}</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/myaddr/">myaddr.{tools,dev,io}</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mydnsjp/">MyDNS.jp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/mythicbeasts/">MythicBeasts</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/namedotcom/">Name.com</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/namecheap/">Namecheap</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/namecheap/">Namecheap</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/namesilo/">Namesilo</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nearlyfreespeech/">NearlyFreeSpeech.NET</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nederhost/">NederHost</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/neodigit/">Neodigit</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/neodigit/">Neodigit</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/netcup/">Netcup</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/netlify/">Netlify</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/netnod/">Netnod</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/nexdns/">NexDNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/nexdns/">NexDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ngenix/">Ngenix</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nicmanager/">Nicmanager</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nifcloud/">NIFCloud</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/njalla/">Njalla</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/njalla/">Njalla</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nodion/">Nodion</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ns1/">NS1</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/octenium/">Octenium</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/omglol/">omg.lol</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/omglol/">omg.lol</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/onlinenet/">Online.net</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/otc/">Open Telekom Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/openprovider/">Openprovider</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/opusdns/">OpusDNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/opusdns/">OpusDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/oraclecloud/">Oracle Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ovh/">OVH</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/plesk/">plesk.com</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/pointdns/">PointDNS/PointHQ</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/pointdns/">PointDNS/PointHQ</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/porkbun/">Porkbun</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/poweradmin/">Poweradmin</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/pdns/">PowerDNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/rackspace/">Rackspace</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/rackspace/">Rackspace</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rage4/">Rage4</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rainyun/">Rain Yun/雨云</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rcodezero/">RcodeZero</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/regru/">reg.ru</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/regru/">reg.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/regfish/">Regfish</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/rimuhosting/">RimuHosting</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/nicru/">RU CENTER</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/sakuracloud/">Sakura Cloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/sakuracloud/">Sakura Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/scaleway/">Scaleway</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/scannet/">ScanNet</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selectel/">Selectel</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/selectelv2/">Selectel v2</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/selectelv2/">Selectel v2</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/selfhostde/">SelfHost.(de|eu)</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/servercow/">Servercow</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/shellrent/">Shellrent</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/simply/">Simply.com</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/simply/">Simply.com</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/sonic/">Sonic</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/spaceship/">Spaceship</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/stackpath/">Stackpath (Deprecated)</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/syse/">Syse</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/syse/">Syse</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/technitium/">Technitium</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/tele3/">Tele3</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/tencentcloud/">Tencent Cloud DNS</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/edgeone/">Tencent EdgeOne</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/edgeone/">Tencent EdgeOne</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/timewebcloud/">Timeweb Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/todaynic/">TodayNIC/时代互联</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/transip/">TransIP</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/ucloud/">UCloud</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/ucloud/">UCloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/ultradns/">Ultradns</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/uniteddomains/">United-Domains</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/variomedia/">Variomedia</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/veesp/">Veesp</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/veesp/">Veesp</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vegadns/">VegaDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vercel/">Vercel</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/versio/">Versio.[nl|eu|uk]</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vinyldns/">VinylDNS</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vinyldns/">VinylDNS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/virtualname/">Virtualname</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vkcloud/">VK Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/volcengine/">Volcano Engine/火山引擎</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/vscale/">Vscale</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/vscale/">Vscale</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/vultr/">Vultr</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/wannafind/">Wannafind</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/webnamesca/">webnames.ca</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/webnamesru/">webnames.ru</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/webnamesru/">webnames.ru</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/websupport/">Websupport</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/wedos/">WEDOS</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/westcn/">West.cn/西部数码</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/xinnet/">Xinnet</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/xinnet/">Xinnet</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandex360/">Yandex 360</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandexcloud/">Yandex Cloud</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/yandex/">Yandex PDD</a></td>
-  <td><a href="https://go-acme.github.io/lego/dns/zilore/">Zilore</a></td>
 </tr><tr>
+  <td><a href="https://go-acme.github.io/lego/dns/zilore/">Zilore</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zoneee/">Zone.ee</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zoneedit/">ZoneEdit</a></td>
   <td><a href="https://go-acme.github.io/lego/dns/zonomi/">Zonomi</a></td>
-  <td></td>
 </tr></table>
 
 <!-- END DNS PROVIDERS LIST -->

--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -87,6 +87,7 @@ func allDNSCodes() string {
 		"exec",
 		"exoscale",
 		"f5xc",
+		"feno",
 		"fornex",
 		"freemyip",
 		"gandi",
@@ -1856,6 +1857,26 @@ func displayDNSHelp(w io.Writer, name string) error {
 
 		ew.writeln()
 		ew.writeln(`More information: https://go-acme.github.io/lego/dns/f5xc`)
+
+	case "feno":
+		// generated from: providers/dns/feno/feno.toml
+		ew.writeln(`Configuration for FENO.`)
+		ew.writeln(`Code:	'feno'`)
+		ew.writeln(`Since:	'v5.5.0'`)
+		ew.writeln()
+
+		ew.writeln(`Credentials:`)
+		ew.writeln(`	- "FENO_API_KEY":	API key ('feno_live_…')`)
+		ew.writeln()
+
+		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "FENO_HTTP_TIMEOUT":	API request timeout in seconds (Default: 30)`)
+		ew.writeln(`	- "FENO_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 2)`)
+		ew.writeln(`	- "FENO_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 120)`)
+		ew.writeln(`	- "FENO_TTL":	The TTL of the TXT record used for the DNS challenge in seconds (Default: 120, minimum: 15)`)
+
+		ew.writeln()
+		ew.writeln(`More information: https://go-acme.github.io/lego/dns/feno`)
 
 	case "fornex":
 		// generated from: providers/dns/fornex/fornex.toml

--- a/docs/content/dns/zz_gen_feno.md
+++ b/docs/content/dns/zz_gen_feno.md
@@ -1,0 +1,72 @@
+---
+title: "FENO"
+date: 2019-03-03T16:39:46+01:00
+draft: false
+slug: feno
+dnsprovider:
+  since:    "v5.5.0"
+  code:     "feno"
+  url:      "https://feno.no/"
+---
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/feno/feno.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+
+
+Configuration for [FENO](https://feno.no/).
+
+
+<!--more-->
+
+- Code: `feno`
+- Since: v5.5.0
+
+
+Here is an example bash command using the FENO provider:
+
+```bash
+FENO_API_KEY="feno_live_xxx" \
+lego run --dns feno -d '*.example.no' -d example.no
+```
+
+
+
+
+## Credentials
+
+| Environment Variable Name | Description |
+|-----------------------|-------------|
+| `FENO_API_KEY` | API key (`feno_live_…`) |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+
+## Additional Configuration
+
+| Environment Variable Name | Description |
+|--------------------------------|-------------|
+| `FENO_HTTP_TIMEOUT` | API request timeout in seconds (Default: 30) |
+| `FENO_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 2) |
+| `FENO_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 120) |
+| `FENO_TTL` | The TTL of the TXT record used for the DNS challenge in seconds (Default: 120, minimum: 15) |
+
+The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
+More information [here]({{% ref "dns#configuration-and-credentials" %}}).
+
+FENO only hosts `.no` domains, and the domain must use the FENO nameservers.
+
+Create the API key in the FENO dashboard with the `acme:write` scope only:
+it can write TXT records at `_acme-challenge*` and nothing else.
+
+
+
+## More information
+
+- [API documentation](https://github.com/mrerikcodes/feno-api/blob/main/docs/ACME.md)
+- [Go client](https://github.com/mrerikcodes/libdns-feno)
+
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->
+<!-- providers/dns/feno/feno.toml -->
+<!-- THIS DOCUMENTATION IS AUTO-GENERATED. PLEASE DO NOT EDIT. -->

--- a/providers/dns/feno/feno.go
+++ b/providers/dns/feno/feno.go
@@ -1,0 +1,259 @@
+// Package feno implements a DNS provider for solving the DNS-01 challenge using FENO.
+package feno
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-acme/lego/v5/challenge"
+	"github.com/go-acme/lego/v5/challenge/dns01"
+	"github.com/go-acme/lego/v5/platform/env"
+	"github.com/go-acme/lego/v5/providers/dns/feno/internal"
+	"github.com/go-acme/lego/v5/providers/dns/internal/clientdebug"
+)
+
+// Environment variables names.
+const (
+	envNamespace = "FENO_"
+
+	EnvAPIKey = envNamespace + "API_KEY"
+
+	EnvTTL                = envNamespace + "TTL"
+	EnvPropagationTimeout = envNamespace + "PROPAGATION_TIMEOUT"
+	EnvPollingInterval    = envNamespace + "POLLING_INTERVAL"
+	EnvHTTPTimeout        = envNamespace + "HTTP_TIMEOUT"
+)
+
+// minTTL is the lowest TTL the FENO API accepts.
+const minTTL = 15
+
+var _ challenge.ProviderTimeout = (*DNSProvider)(nil)
+
+// Config is used to configure the creation of the DNSProvider.
+type Config struct {
+	APIKey string
+
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider.
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt(EnvTTL, dns01.DefaultTTL),
+		PropagationTimeout: env.GetOrDefaultSecond(EnvPropagationTimeout, 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond(EnvPollingInterval, dns01.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond(EnvHTTPTimeout, 30*time.Second),
+		},
+	}
+}
+
+// DNSProvider implements the challenge.Provider interface.
+type DNSProvider struct {
+	config *Config
+	client *internal.Client
+
+	zones       map[string]string
+	recordIDs   map[string]int
+	recordIDsMu sync.Mutex
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for FENO.
+// Credentials must be passed in the environment variable: FENO_API_KEY.
+func NewDNSProvider() (*DNSProvider, error) {
+	values, err := env.Get(EnvAPIKey)
+	if err != nil {
+		return nil, fmt.Errorf("feno: %w", err)
+	}
+
+	config := NewDefaultConfig()
+	config.APIKey = values[EnvAPIKey]
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for FENO.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("feno: the configuration of the DNS provider is nil")
+	}
+
+	if config.TTL < minTTL {
+		return nil, fmt.Errorf("feno: invalid TTL, TTL (%d) must be greater than %d", config.TTL, minTTL)
+	}
+
+	client, err := internal.NewClient(config.APIKey)
+	if err != nil {
+		return nil, fmt.Errorf("feno: %w", err)
+	}
+
+	if config.HTTPClient != nil {
+		client.HTTPClient = config.HTTPClient
+	}
+
+	client.HTTPClient = clientdebug.Wrap(client.HTTPClient)
+
+	return &DNSProvider{
+		config:    config,
+		client:    client,
+		zones:     make(map[string]string),
+		recordIDs: make(map[string]int),
+	}, nil
+}
+
+// Present creates a TXT record using the specified parameters.
+func (d *DNSProvider) Present(ctx context.Context, domain, token, keyAuth string) error {
+	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+
+	zone, err := d.findZone(ctx, info.EffectiveFQDN)
+	if err != nil {
+		return fmt.Errorf("feno: could not find zone for domain %q: %w", domain, err)
+	}
+
+	subDomain, err := dns01.ExtractSubDomain(info.EffectiveFQDN, zone)
+	if err != nil {
+		return fmt.Errorf("feno: %w", err)
+	}
+
+	record := internal.Record{
+		Type:  "TXT",
+		Name:  subDomain,
+		Value: info.Value,
+		TTL:   d.config.TTL,
+	}
+
+	newRecord, err := d.client.CreateRecord(ctx, zone, record)
+	if err != nil {
+		return fmt.Errorf("feno: create record: %w", err)
+	}
+
+	d.recordIDsMu.Lock()
+	d.zones[token] = zone
+	d.recordIDs[token] = newRecord.ID
+	d.recordIDsMu.Unlock()
+
+	return nil
+}
+
+// CleanUp removes the TXT record matching the specified parameters.
+func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
+	info := dns01.GetChallengeInfo(ctx, domain, keyAuth)
+
+	d.recordIDsMu.Lock()
+	zone, zoneOK := d.zones[token]
+	recordID, recordOK := d.recordIDs[token]
+	d.recordIDsMu.Unlock()
+
+	if !zoneOK {
+		var err error
+
+		zone, err = d.findZone(ctx, info.EffectiveFQDN)
+		if err != nil {
+			return fmt.Errorf("feno: could not find zone for domain %q: %w", domain, err)
+		}
+	}
+
+	if !recordOK {
+		var err error
+
+		recordID, err = d.findRecordID(ctx, zone, info)
+		if err != nil {
+			return fmt.Errorf("feno: %w", err)
+		}
+	}
+
+	err := d.client.DeleteRecord(ctx, zone, recordID)
+	if err != nil {
+		return fmt.Errorf("feno: delete record: %w", err)
+	}
+
+	d.recordIDsMu.Lock()
+	delete(d.zones, token)
+	delete(d.recordIDs, token)
+	d.recordIDsMu.Unlock()
+
+	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
+}
+
+// findZone walks the labels of the FQDN, asking the API which candidate is a zone hosted by FENO.
+// The registrable domain cannot be guessed from a label count: `.no` holds both plain second-level names and delegated sub-zones.
+func (d *DNSProvider) findZone(ctx context.Context, fqdn string) (string, error) {
+	var lastErr error
+
+	for candidate := range dns01.UnFqdnDomainsSeq(fqdn) {
+		if !strings.Contains(candidate, ".") {
+			// TLD.
+			break
+		}
+
+		if strings.HasPrefix(candidate, "_") {
+			// A label such as `_acme-challenge` is never a zone apex.
+			continue
+		}
+
+		zone, err := d.client.GetDomain(ctx, candidate)
+		if err != nil {
+			var apiErr *internal.APIError
+			if !errors.As(err, &apiErr) {
+				return "", err
+			}
+
+			switch apiErr.StatusCode {
+			case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
+				// A key problem looks like "domain not found" all the way up to the TLD.
+				return "", err
+			case http.StatusNotFound:
+				lastErr = err
+				continue
+			default:
+				return "", err
+			}
+		}
+
+		if !zone.FenoNameservers {
+			return "", fmt.Errorf("the zone %q does not use FENO nameservers", zone.Domain)
+		}
+
+		return zone.Domain, nil
+	}
+
+	if lastErr != nil {
+		return "", fmt.Errorf("no zone found for %q: %w", fqdn, lastErr)
+	}
+
+	return "", fmt.Errorf("no zone found for %q", fqdn)
+}
+
+func (d *DNSProvider) findRecordID(ctx context.Context, zone string, info dns01.ChallengeInfo) (int, error) {
+	subDomain, err := dns01.ExtractSubDomain(info.EffectiveFQDN, zone)
+	if err != nil {
+		return 0, err
+	}
+
+	records, err := d.client.ListRecords(ctx, zone)
+	if err != nil {
+		return 0, fmt.Errorf("list records: %w", err)
+	}
+
+	for _, record := range records {
+		if record.Type == "TXT" && strings.EqualFold(record.Name, subDomain) && record.Value == info.Value {
+			return record.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("record not found for '%s' '%s'", info.EffectiveFQDN, info.Value)
+}

--- a/providers/dns/feno/feno.toml
+++ b/providers/dns/feno/feno.toml
@@ -1,0 +1,30 @@
+Name = "FENO"
+Description = ''''''
+URL = "https://feno.no/"
+Code = "feno"
+Since = "v5.5.0"
+
+Example = '''
+FENO_API_KEY="feno_live_xxx" \
+lego run --dns feno -d '*.example.no' -d example.no
+'''
+
+Additional = '''
+FENO only hosts `.no` domains, and the domain must use the FENO nameservers.
+
+Create the API key in the FENO dashboard with the `acme:write` scope only:
+it can write TXT records at `_acme-challenge*` and nothing else.
+'''
+
+[Configuration]
+  [Configuration.Credentials]
+    FENO_API_KEY = "API key (`feno_live_…`)"
+  [Configuration.Additional]
+    FENO_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 2)"
+    FENO_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 120)"
+    FENO_TTL = "The TTL of the TXT record used for the DNS challenge in seconds (Default: 120, minimum: 15)"
+    FENO_HTTP_TIMEOUT = "API request timeout in seconds (Default: 30)"
+
+[Links]
+  API = "https://github.com/mrerikcodes/feno-api/blob/main/docs/ACME.md"
+  GoClient = "https://github.com/mrerikcodes/libdns-feno"

--- a/providers/dns/feno/feno_test.go
+++ b/providers/dns/feno/feno_test.go
@@ -1,0 +1,267 @@
+package feno
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-acme/lego/v5/internal/tester"
+	"github.com/go-acme/lego/v5/internal/tester/servermock"
+	"github.com/stretchr/testify/require"
+)
+
+const envDomain = envNamespace + "DOMAIN"
+
+var envTest = tester.NewEnvTest(EnvAPIKey).WithDomain(envDomain)
+
+func TestNewDNSProvider(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			desc: "success",
+			envVars: map[string]string{
+				EnvAPIKey: "secret",
+			},
+		},
+		{
+			desc:     "missing credentials",
+			envVars:  map[string]string{},
+			expected: "feno: some credentials information are missing: FENO_API_KEY",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer envTest.RestoreEnv()
+
+			envTest.ClearEnv()
+
+			envTest.Apply(test.envVars)
+
+			p, err := NewDNSProvider()
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+				require.NotNil(t, p.client)
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestNewDNSProviderConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		apiKey   string
+		ttl      int
+		expected string
+	}{
+		{
+			desc:   "success",
+			apiKey: "secret",
+			ttl:    120,
+		},
+		{
+			desc:     "missing credentials",
+			ttl:      120,
+			expected: "feno: credentials missing",
+		},
+		{
+			desc:     "invalid TTL",
+			apiKey:   "secret",
+			ttl:      10,
+			expected: "feno: invalid TTL, TTL (10) must be greater than 15",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			config := NewDefaultConfig()
+			config.APIKey = test.apiKey
+			config.TTL = test.ttl
+
+			p, err := NewDNSProviderConfig(config)
+
+			if test.expected == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+				require.NotNil(t, p.config)
+				require.NotNil(t, p.client)
+			} else {
+				require.EqualError(t, err, test.expected)
+			}
+		})
+	}
+}
+
+func TestLivePresent(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	err = provider.Present(t.Context(), envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}
+
+func TestLiveCleanUp(t *testing.T) {
+	if !envTest.IsLiveTest() {
+		t.Skip("skipping live test")
+	}
+
+	envTest.RestoreEnv()
+
+	provider, err := NewDNSProvider()
+	require.NoError(t, err)
+
+	err = provider.CleanUp(t.Context(), envTest.GetDomain(), "", "123d==")
+	require.NoError(t, err)
+}
+
+func mockBuilder() *servermock.Builder[*DNSProvider] {
+	return servermock.NewBuilder(
+		func(server *httptest.Server) (*DNSProvider, error) {
+			config := NewDefaultConfig()
+			config.APIKey = "secret"
+			config.HTTPClient = server.Client()
+
+			p, err := NewDNSProviderConfig(config)
+			if err != nil {
+				return nil, err
+			}
+
+			p.client.BaseURL, _ = url.Parse(server.URL)
+
+			return p, nil
+		},
+		servermock.CheckHeader().
+			WithJSONHeaders().
+			WithAuthorization("Bearer secret"),
+	)
+}
+
+func TestDNSProvider_Present(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromInternal("get_domain.json")).
+		Route("POST /domains/example.no/dns",
+			servermock.ResponseFromInternal("create_record.json").
+				WithStatusCode(http.StatusCreated),
+			servermock.CheckRequestJSONBodyFromInternal("create_record-request.json"),
+		).
+		Build(t)
+
+	err := provider.Present(t.Context(), "example.no", "abc", "123d==")
+	require.NoError(t, err)
+
+	require.Equal(t, "example.no", provider.zones["abc"])
+	require.Equal(t, 481522, provider.recordIDs["abc"])
+}
+
+func TestDNSProvider_Present_subdomain(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/www.example.no",
+			servermock.ResponseFromInternal("error_not_managed.json").
+				WithStatusCode(http.StatusNotFound)).
+		Route("GET /domains/example.no",
+			servermock.ResponseFromInternal("get_domain.json")).
+		Route("POST /domains/example.no/dns",
+			servermock.ResponseFromInternal("create_record.json").
+				WithStatusCode(http.StatusCreated),
+			servermock.CheckRequestJSONBody(`{"type":"TXT","name":"_acme-challenge.www","value":"ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY","ttl":120}`),
+		).
+		Build(t)
+
+	err := provider.Present(t.Context(), "www.example.no", "abc", "123d==")
+	require.NoError(t, err)
+
+	require.Equal(t, "example.no", provider.zones["abc"])
+}
+
+func TestDNSProvider_Present_notFenoNameservers(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromInternal("get_domain_not_feno_ns.json")).
+		Build(t)
+
+	err := provider.Present(t.Context(), "example.no", "abc", "123d==")
+	require.EqualError(t, err, `feno: could not find zone for domain "example.no": the zone "example.no" does not use FENO nameservers`)
+}
+
+func TestDNSProvider_Present_zoneNotFound(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/{domain}",
+			servermock.ResponseFromInternal("error_not_managed.json").
+				WithStatusCode(http.StatusNotFound)).
+		Build(t)
+
+	err := provider.Present(t.Context(), "www.example.no", "abc", "123d==")
+	require.EqualError(t, err, `feno: could not find zone for domain "www.example.no": no zone found for "_acme-challenge.www.example.no.": 404: Domain not found or not managed by this account (DOMAIN_NOT_MANAGED)`)
+}
+
+func TestDNSProvider_Present_insufficientScope(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/www.example.no",
+			servermock.ResponseFromInternal("error_insufficient_scope.json").
+				WithStatusCode(http.StatusForbidden)).
+		Build(t)
+
+	err := provider.Present(t.Context(), "www.example.no", "abc", "123d==")
+	require.EqualError(t, err, `feno: could not find zone for domain "www.example.no": 403: This key does not hold the required scope (INSUFFICIENT_SCOPE)`)
+}
+
+func TestDNSProvider_CleanUp(t *testing.T) {
+	provider := mockBuilder().
+		Route("DELETE /domains/example.no/dns/481522",
+			servermock.ResponseFromInternal("delete_record.json")).
+		Build(t)
+
+	token := "abc"
+
+	provider.zones[token] = "example.no"
+	provider.recordIDs[token] = 481522
+
+	err := provider.CleanUp(t.Context(), "example.no", token, "123d==")
+	require.NoError(t, err)
+
+	require.Empty(t, provider.zones)
+	require.Empty(t, provider.recordIDs)
+}
+
+func TestDNSProvider_CleanUp_withoutPresent(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromInternal("get_domain.json")).
+		Route("GET /domains/example.no/dns",
+			servermock.ResponseFromInternal("list_records.json")).
+		Route("DELETE /domains/example.no/dns/481523",
+			servermock.ResponseFromInternal("delete_record.json")).
+		Build(t)
+
+	// keyAuth "456d==" hashes to the second record of the fixture.
+	err := provider.CleanUp(t.Context(), "example.no", "abc", "456d==")
+	require.NoError(t, err)
+}
+
+func TestDNSProvider_CleanUp_recordNotFound(t *testing.T) {
+	provider := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromInternal("get_domain.json")).
+		Route("GET /domains/example.no/dns",
+			servermock.ResponseFromInternal("list_records.json")).
+		Build(t)
+
+	err := provider.CleanUp(t.Context(), "example.no", "abc", "unknown")
+	require.EqualError(t, err, "feno: record not found for '_acme-challenge.example.no.' 'sjpqhDnA3eVRWJPnyQweMjO4YW5jRHDyDcSSi882Cbw'")
+}

--- a/providers/dns/feno/internal/client.go
+++ b/providers/dns/feno/internal/client.go
@@ -1,0 +1,234 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/go-acme/lego/v5/internal/errutils"
+	"github.com/go-acme/lego/v5/internal/useragent"
+)
+
+// defaultBaseURL the default API endpoint.
+const defaultBaseURL = "https://api.feno.no/v1"
+
+// Client the FENO API client.
+type Client struct {
+	apiKey string
+
+	BaseURL    *url.URL
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new Client.
+func NewClient(apiKey string) (*Client, error) {
+	if apiKey == "" {
+		return nil, errors.New("credentials missing")
+	}
+
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	return &Client{
+		apiKey:     apiKey,
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// GetDomain gets one domain.
+// https://github.com/mrerikcodes/feno-api/blob/main/openapi.yaml
+func (c *Client) GetDomain(ctx context.Context, domain string) (*Domain, error) {
+	endpoint := c.BaseURL.JoinPath("domains", domain)
+
+	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := new(APIResponse[*Domain])
+
+	err = c.do(req, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Data, nil
+}
+
+// ListRecords lists the DNS records of a zone.
+// An `acme:write` key only sees the TXT records at `_acme-challenge*`.
+// https://github.com/mrerikcodes/feno-api/blob/main/openapi.yaml
+func (c *Client) ListRecords(ctx context.Context, zone string) ([]Record, error) {
+	endpoint := c.BaseURL.JoinPath("domains", zone, "dns")
+
+	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := new(APIResponse[*RecordList])
+
+	err = c.do(req, result)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Data == nil {
+		return nil, nil
+	}
+
+	return result.Data.Records, nil
+}
+
+// CreateRecord creates a DNS record inside a zone.
+// https://github.com/mrerikcodes/feno-api/blob/main/openapi.yaml
+func (c *Client) CreateRecord(ctx context.Context, zone string, record Record) (*Record, error) {
+	endpoint := c.BaseURL.JoinPath("domains", zone, "dns")
+
+	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, record)
+	if err != nil {
+		return nil, err
+	}
+
+	result := new(APIResponse[*Record])
+
+	err = c.do(req, result)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Data == nil || result.Data.ID == 0 {
+		return nil, errors.New("response carried no record id")
+	}
+
+	return result.Data, nil
+}
+
+// DeleteRecord deletes a DNS record from a zone.
+// https://github.com/mrerikcodes/feno-api/blob/main/openapi.yaml
+func (c *Client) DeleteRecord(ctx context.Context, zone string, recordID int) error {
+	endpoint := c.BaseURL.JoinPath("domains", zone, "dns", strconv.Itoa(recordID))
+
+	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.do(req, nil)
+}
+
+func (c *Client) do(req *http.Request, result any) error {
+	useragent.SetHeader(req.Header)
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return errutils.NewHTTPDoError(req, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode/100 != 2 {
+		return parseError(req, resp)
+	}
+
+	if result == nil {
+		return nil
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errutils.NewReadResponseError(req, resp.StatusCode, err)
+	}
+
+	err = json.Unmarshal(raw, result)
+	if err != nil {
+		return errutils.NewUnmarshalError(req, resp.StatusCode, raw, err)
+	}
+
+	var envelope APIResponse[json.RawMessage]
+
+	err = json.Unmarshal(raw, &envelope)
+	if err != nil {
+		return errutils.NewUnmarshalError(req, resp.StatusCode, raw, err)
+	}
+
+	if !envelope.Success {
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Code:       envelope.Code,
+			Message:    envelope.Error,
+			RequestID:  resp.Header.Get("X-Request-Id"),
+		}
+	}
+
+	return nil
+}
+
+func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, payload any) (*http.Request, error) {
+	buf := new(bytes.Buffer)
+
+	if payload != nil {
+		err := json.NewEncoder(buf).Encode(payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request JSON body: %w", err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), buf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+func parseError(req *http.Request, resp *http.Response) error {
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope APIResponse[json.RawMessage]
+
+	err := json.Unmarshal(raw, &envelope)
+	if err != nil || envelope.Error == "" {
+		return errutils.NewUnexpectedStatusCodeError(req, resp.StatusCode, raw)
+	}
+
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Code:       envelope.Code,
+		Message:    envelope.Error,
+		RequestID:  resp.Header.Get("X-Request-Id"),
+		RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+	}
+}
+
+// parseRetryAfter parses a Retry-After header (delta-seconds or HTTP-date).
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	if secs, err := strconv.Atoi(value); err == nil {
+		return max(time.Duration(secs)*time.Second, 0)
+	}
+
+	if t, err := http.ParseTime(value); err == nil {
+		return max(time.Until(t), 0)
+	}
+
+	return 0
+}

--- a/providers/dns/feno/internal/client_test.go
+++ b/providers/dns/feno/internal/client_test.go
@@ -1,0 +1,183 @@
+package internal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-acme/lego/v5/internal/tester/servermock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockBuilder() *servermock.Builder[*Client] {
+	return servermock.NewBuilder[*Client](
+		func(server *httptest.Server) (*Client, error) {
+			client, err := NewClient("secret")
+			if err != nil {
+				return nil, err
+			}
+
+			client.BaseURL, _ = url.Parse(server.URL)
+			client.HTTPClient = server.Client()
+
+			return client, nil
+		},
+		servermock.CheckHeader().
+			WithJSONHeaders().
+			WithAuthorization("Bearer secret"),
+	)
+}
+
+func TestClient_GetDomain(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /domains/example.no", servermock.ResponseFromFixture("get_domain.json")).
+		Build(t)
+
+	domain, err := client.GetDomain(t.Context(), "example.no")
+	require.NoError(t, err)
+
+	expected := &Domain{Domain: "example.no", Status: "active", FenoNameservers: true}
+
+	assert.Equal(t, expected, domain)
+}
+
+func TestClient_GetDomain_error(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromFixture("error_not_managed.json").
+				WithStatusCode(http.StatusNotFound).
+				WithHeader("X-Request-Id", "0b0a3d3e-6f7c-4a1e-9a1e-2c7c9e0c1a11"),
+		).
+		Build(t)
+
+	_, err := client.GetDomain(t.Context(), "example.no")
+	require.EqualError(t, err, "404: Domain not found or not managed by this account (DOMAIN_NOT_MANAGED) [request 0b0a3d3e-6f7c-4a1e-9a1e-2c7c9e0c1a11]")
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+	assert.Equal(t, "DOMAIN_NOT_MANAGED", apiErr.Code)
+}
+
+func TestClient_GetDomain_error_rateLimited(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.ResponseFromFixture("error_rate_limited.json").
+				WithStatusCode(http.StatusTooManyRequests).
+				WithHeader("Retry-After", "17"),
+		).
+		Build(t)
+
+	_, err := client.GetDomain(t.Context(), "example.no")
+	require.EqualError(t, err, "429: Rate limit exceeded (RATE_LIMITED) retry after 17s")
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+
+	assert.Equal(t, 17*time.Second, apiErr.RetryAfter)
+}
+
+func TestClient_GetDomain_error_unexpected(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /domains/example.no",
+			servermock.RawStringResponse("<html>Bad Gateway</html>").
+				WithStatusCode(http.StatusBadGateway),
+		).
+		Build(t)
+
+	_, err := client.GetDomain(t.Context(), "example.no")
+	require.EqualError(t, err, "unexpected status code: [status code: 502] body: <html>Bad Gateway</html>")
+
+	var apiErr *APIError
+	require.NotErrorAs(t, err, &apiErr)
+}
+
+func TestClient_ListRecords(t *testing.T) {
+	client := mockBuilder().
+		Route("GET /domains/example.no/dns", servermock.ResponseFromFixture("list_records.json")).
+		Build(t)
+
+	records, err := client.ListRecords(t.Context(), "example.no")
+	require.NoError(t, err)
+
+	expected := []Record{
+		{ID: 481522, Type: "TXT", Name: "_acme-challenge", Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY", TTL: 120},
+		{ID: 481523, Type: "TXT", Name: "_acme-challenge", Value: "7SZcH8jldJ5zSS3kgbe2KZDOO-PHTMEqGU37zLnmPyk", TTL: 120},
+	}
+
+	assert.Equal(t, expected, records)
+}
+
+func TestClient_CreateRecord(t *testing.T) {
+	client := mockBuilder().
+		Route("POST /domains/example.no/dns",
+			servermock.ResponseFromFixture("create_record.json").
+				WithStatusCode(http.StatusCreated),
+			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json"),
+		).
+		Build(t)
+
+	record := Record{
+		Type:  "TXT",
+		Name:  "_acme-challenge",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+		TTL:   120,
+	}
+
+	result, err := client.CreateRecord(t.Context(), "example.no", record)
+	require.NoError(t, err)
+
+	expected := &Record{
+		ID:    481522,
+		Type:  "TXT",
+		Name:  "_acme-challenge",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+		TTL:   120,
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+func TestClient_CreateRecord_error(t *testing.T) {
+	client := mockBuilder().
+		Route("POST /domains/example.no/dns",
+			servermock.ResponseFromFixture("error_insufficient_scope.json").
+				WithStatusCode(http.StatusForbidden),
+		).
+		Build(t)
+
+	record := Record{
+		Type:  "TXT",
+		Name:  "_acme-challenge",
+		Value: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+		TTL:   120,
+	}
+
+	_, err := client.CreateRecord(t.Context(), "example.no", record)
+	require.EqualError(t, err, "403: This key does not hold the required scope (INSUFFICIENT_SCOPE)")
+}
+
+func TestClient_DeleteRecord(t *testing.T) {
+	client := mockBuilder().
+		Route("DELETE /domains/example.no/dns/481522", servermock.ResponseFromFixture("delete_record.json")).
+		Build(t)
+
+	err := client.DeleteRecord(t.Context(), "example.no", 481522)
+	require.NoError(t, err)
+}
+
+func TestClient_DeleteRecord_error(t *testing.T) {
+	client := mockBuilder().
+		Route("DELETE /domains/example.no/dns/481522",
+			servermock.ResponseFromFixture("error_not_managed.json").
+				WithStatusCode(http.StatusNotFound),
+		).
+		Build(t)
+
+	err := client.DeleteRecord(t.Context(), "example.no", 481522)
+	require.EqualError(t, err, "404: Domain not found or not managed by this account (DOMAIN_NOT_MANAGED)")
+}

--- a/providers/dns/feno/internal/fixtures/create_record-request.json
+++ b/providers/dns/feno/internal/fixtures/create_record-request.json
@@ -1,0 +1,6 @@
+{
+  "type": "TXT",
+  "name": "_acme-challenge",
+  "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+  "ttl": 120
+}

--- a/providers/dns/feno/internal/fixtures/create_record.json
+++ b/providers/dns/feno/internal/fixtures/create_record.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "data": {
+    "id": 481522,
+    "type": "TXT",
+    "name": "_acme-challenge",
+    "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+    "ttl": 120,
+    "priority": null,
+    "weight": null,
+    "port": null,
+    "flags": null,
+    "tag": null
+  }
+}

--- a/providers/dns/feno/internal/fixtures/delete_record.json
+++ b/providers/dns/feno/internal/fixtures/delete_record.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "data": {
+    "deleted": true
+  }
+}

--- a/providers/dns/feno/internal/fixtures/error_insufficient_scope.json
+++ b/providers/dns/feno/internal/fixtures/error_insufficient_scope.json
@@ -1,0 +1,7 @@
+{
+  "success": false,
+  "error": "This key does not hold the required scope",
+  "code": "INSUFFICIENT_SCOPE",
+  "requestId": "0b0a3d3e-6f7c-4a1e-9a1e-2c7c9e0c1a12",
+  "data": null
+}

--- a/providers/dns/feno/internal/fixtures/error_not_managed.json
+++ b/providers/dns/feno/internal/fixtures/error_not_managed.json
@@ -1,0 +1,7 @@
+{
+  "success": false,
+  "error": "Domain not found or not managed by this account",
+  "code": "DOMAIN_NOT_MANAGED",
+  "requestId": "0b0a3d3e-6f7c-4a1e-9a1e-2c7c9e0c1a11",
+  "data": null
+}

--- a/providers/dns/feno/internal/fixtures/error_rate_limited.json
+++ b/providers/dns/feno/internal/fixtures/error_rate_limited.json
@@ -1,0 +1,7 @@
+{
+  "success": false,
+  "error": "Rate limit exceeded",
+  "code": "RATE_LIMITED",
+  "requestId": "0b0a3d3e-6f7c-4a1e-9a1e-2c7c9e0c1a13",
+  "data": null
+}

--- a/providers/dns/feno/internal/fixtures/get_domain.json
+++ b/providers/dns/feno/internal/fixtures/get_domain.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "data": {
+    "domain": "example.no",
+    "status": "active",
+    "fenoNameservers": true
+  }
+}

--- a/providers/dns/feno/internal/fixtures/get_domain_not_feno_ns.json
+++ b/providers/dns/feno/internal/fixtures/get_domain_not_feno_ns.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "data": {
+    "domain": "example.no",
+    "status": "active",
+    "fenoNameservers": false
+  }
+}

--- a/providers/dns/feno/internal/fixtures/list_records.json
+++ b/providers/dns/feno/internal/fixtures/list_records.json
@@ -1,0 +1,34 @@
+{
+  "success": true,
+  "data": {
+    "domainName": "example.no",
+    "records": [
+      {
+        "id": 481522,
+        "type": "TXT",
+        "name": "_acme-challenge",
+        "value": "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
+        "ttl": 120,
+        "priority": null,
+        "weight": null,
+        "port": null,
+        "flags": null,
+        "tag": null
+      },
+      {
+        "id": 481523,
+        "type": "TXT",
+        "name": "_acme-challenge",
+        "value": "7SZcH8jldJ5zSS3kgbe2KZDOO-PHTMEqGU37zLnmPyk",
+        "ttl": 120,
+        "priority": null,
+        "weight": null,
+        "port": null,
+        "flags": null,
+        "tag": null
+      }
+    ],
+    "filtered": true,
+    "filterReason": "scope"
+  }
+}

--- a/providers/dns/feno/internal/types.go
+++ b/providers/dns/feno/internal/types.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"fmt"
+	"time"
+)
+
+// APIResponse is the FENO response envelope.
+type APIResponse[T any] struct {
+	Success bool   `json:"success"`
+	Data    T      `json:"data,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+// APIError is the error returned for every non-2xx response, and for 2xx responses whose envelope reports success=false.
+type APIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	RequestID  string
+	RetryAfter time.Duration
+}
+
+func (a *APIError) Error() string {
+	msg := fmt.Sprintf("%d: %s", a.StatusCode, a.Message)
+
+	if a.Code != "" {
+		msg += fmt.Sprintf(" (%s)", a.Code)
+	}
+
+	if a.RequestID != "" {
+		msg += fmt.Sprintf(" [request %s]", a.RequestID)
+	}
+
+	if a.RetryAfter > 0 {
+		msg += fmt.Sprintf(" retry after %s", a.RetryAfter)
+	}
+
+	return msg
+}
+
+// Domain is the minimal domain shape returned to an `acme:write` key.
+type Domain struct {
+	Domain          string `json:"domain"`
+	Status          string `json:"status"`
+	FenoNameservers bool   `json:"fenoNameservers"`
+}
+
+// Record is a DNS record.
+type Record struct {
+	ID    int    `json:"id,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Name  string `json:"name"` // Relative to the zone, "" is the apex.
+	Value string `json:"value,omitempty"`
+	TTL   int    `json:"ttl,omitempty"`
+}
+
+// RecordList is the payload of the record listing.
+type RecordList struct {
+	DomainName string   `json:"domainName"`
+	Records    []Record `json:"records"`
+	Filtered   bool     `json:"filtered"`
+}

--- a/providers/dns/zz_gen_dns_providers.go
+++ b/providers/dns/zz_gen_dns_providers.go
@@ -81,6 +81,7 @@ import (
 	"github.com/go-acme/lego/v5/providers/dns/exec"
 	"github.com/go-acme/lego/v5/providers/dns/exoscale"
 	"github.com/go-acme/lego/v5/providers/dns/f5xc"
+	"github.com/go-acme/lego/v5/providers/dns/feno"
 	"github.com/go-acme/lego/v5/providers/dns/fornex"
 	"github.com/go-acme/lego/v5/providers/dns/freemyip"
 	"github.com/go-acme/lego/v5/providers/dns/gandi"
@@ -380,6 +381,8 @@ func NewDNSChallengeProviderByName(name string) (challenge.Provider, error) {
 		return exoscale.NewDNSProvider()
 	case "f5xc":
 		return f5xc.NewDNSProvider()
+	case "feno":
+		return feno.NewDNSProvider()
 	case "fornex":
 		return fornex.NewDNSProvider()
 	case "freemyip":


### PR DESCRIPTION
Closes https://github.com/go-acme/lego/issues/3237


Live tests (`TestLivePresent`/`TestLiveCleanUp`) pass against a real FENO zone (`2002.no`).
