### PR TITLE
docs: update required Go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ add new behavior or somehow alter code in a non-trivial way should **always** in
 
 Requirements:
 
-- `go` v1.25+
+- `go` v1.26+
 - environment variable: `GO111MODULE=on`
 
 First, you have to install [Go](https://golang.org/doc/install) and [golangci-lint](https://github.com/golangci/golangci-lint#install).


### PR DESCRIPTION
Hello, thanks for your excellent work.

I found that the minimum Go version was raised to 1.26 in #3233, but CONTRIBUTING.md still lists Go 1.25.

So this PR is fix documentation. thank you.