### PR TITLE
netcup: allow to use new API key

### DIFF
--- a/cmd/zz_gen_cmd_dnshelp.go
+++ b/cmd/zz_gen_cmd_dnshelp.go
@@ -3230,12 +3230,12 @@ func displayDNSHelp(w io.Writer, name string) error {
 		ew.writeln()
 
 		ew.writeln(`Credentials:`)
-		ew.writeln(`	- "NETCUP_API_KEY":	API key`)
-		ew.writeln(`	- "NETCUP_API_PASSWORD":	API password`)
+		ew.writeln(`	- "NETCUP_API_KEY":	API key (CloudDNS or Legacy DNS)`)
 		ew.writeln(`	- "NETCUP_CUSTOMER_NUMBER":	Customer number`)
 		ew.writeln()
 
 		ew.writeln(`Additional Configuration:`)
+		ew.writeln(`	- "NETCUP_API_PASSWORD":	API password (Legacy DNS)`)
 		ew.writeln(`	- "NETCUP_HTTP_TIMEOUT":	API request timeout in seconds (Default: 10)`)
 		ew.writeln(`	- "NETCUP_POLLING_INTERVAL":	Time between DNS propagation check in seconds (Default: 30)`)
 		ew.writeln(`	- "NETCUP_PROPAGATION_TIMEOUT":	Maximum waiting time for DNS propagation in seconds (Default: 900)`)

--- a/docs/content/dns/zz_gen_netcup.md
+++ b/docs/content/dns/zz_gen_netcup.md
@@ -28,7 +28,6 @@ Here is an example bash command using the Netcup provider:
 ```bash
 NETCUP_CUSTOMER_NUMBER=xxxx \
 NETCUP_API_KEY=yyyy \
-NETCUP_API_PASSWORD=zzzz \
 lego run --dns netcup -d '*.example.com' -d example.com
 ```
 
@@ -39,8 +38,7 @@ lego run --dns netcup -d '*.example.com' -d example.com
 
 | Environment Variable Name | Description |
 |-----------------------|-------------|
-| `NETCUP_API_KEY` | API key |
-| `NETCUP_API_PASSWORD` | API password |
+| `NETCUP_API_KEY` | API key (CloudDNS or Legacy DNS) |
 | `NETCUP_CUSTOMER_NUMBER` | Customer number |
 
 The environment variable names can be suffixed by `_FILE` to reference a file instead of a value.
@@ -51,6 +49,7 @@ More information [here]({{% ref "dns#configuration-and-credentials" %}}).
 
 | Environment Variable Name | Description |
 |--------------------------------|-------------|
+| `NETCUP_API_PASSWORD` | API password (Legacy DNS) |
 | `NETCUP_HTTP_TIMEOUT` | API request timeout in seconds (Default: 10) |
 | `NETCUP_POLLING_INTERVAL` | Time between DNS propagation check in seconds (Default: 30) |
 | `NETCUP_PROPAGATION_TIMEOUT` | Maximum waiting time for DNS propagation in seconds (Default: 900) |

--- a/providers/dns/netcup/internal/client.go
+++ b/providers/dns/netcup/internal/client.go
@@ -28,7 +28,7 @@ type Client struct {
 
 // NewClient creates a netcup DNS client.
 func NewClient(customerNumber, apiKey, apiPassword string) (*Client, error) {
-	if customerNumber == "" || apiKey == "" || apiPassword == "" {
+	if customerNumber == "" || apiKey == "" {
 		return nil, errors.New("credentials missing")
 	}
 

--- a/providers/dns/netcup/netcup.go
+++ b/providers/dns/netcup/netcup.go
@@ -64,7 +64,7 @@ type DNSProvider struct {
 // Credentials must be passed in the environment variables:
 // NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, NETCUP_API_PASSWORD.
 func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get(EnvCustomerNumber, EnvAPIKey, EnvAPIPassword)
+	values, err := env.Get(EnvCustomerNumber, EnvAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("netcup: %w", err)
 	}
@@ -72,7 +72,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 	config := NewDefaultConfig()
 	config.Customer = values[EnvCustomerNumber]
 	config.Key = values[EnvAPIKey]
-	config.Password = values[EnvAPIPassword]
+	config.Password = env.GetOrFile(EnvAPIPassword)
 
 	return NewDNSProviderConfig(config)
 }

--- a/providers/dns/netcup/netcup.toml
+++ b/providers/dns/netcup/netcup.toml
@@ -7,16 +7,15 @@ Since = "v1.1.0"
 Example = '''
 NETCUP_CUSTOMER_NUMBER=xxxx \
 NETCUP_API_KEY=yyyy \
-NETCUP_API_PASSWORD=zzzz \
 lego run --dns netcup -d '*.example.com' -d example.com
 '''
 
 [Configuration]
   [Configuration.Credentials]
     NETCUP_CUSTOMER_NUMBER = "Customer number"
-    NETCUP_API_KEY = "API key"
-    NETCUP_API_PASSWORD = "API password"
+    NETCUP_API_KEY = "API key (CloudDNS or Legacy DNS)"
   [Configuration.Additional]
+    NETCUP_API_PASSWORD = "API password (Legacy DNS)"
     NETCUP_POLLING_INTERVAL = "Time between DNS propagation check in seconds (Default: 30)"
     NETCUP_PROPAGATION_TIMEOUT = "Maximum waiting time for DNS propagation in seconds (Default: 900)"
     NETCUP_HTTP_TIMEOUT = "API request timeout in seconds (Default: 10)"

--- a/providers/dns/netcup/netcup_test.go
+++ b/providers/dns/netcup/netcup_test.go
@@ -32,13 +32,21 @@ func TestNewDNSProvider(t *testing.T) {
 			},
 		},
 		{
+			desc: "success without API password",
+			envVars: map[string]string{
+				EnvCustomerNumber: "A",
+				EnvAPIKey:         "B",
+				EnvAPIPassword:    "",
+			},
+		},
+		{
 			desc: "missing credentials",
 			envVars: map[string]string{
 				EnvCustomerNumber: "",
 				EnvAPIKey:         "",
 				EnvAPIPassword:    "",
 			},
-			expected: "netcup: some credentials information are missing: NETCUP_CUSTOMER_NUMBER,NETCUP_API_KEY,NETCUP_API_PASSWORD",
+			expected: "netcup: some credentials information are missing: NETCUP_CUSTOMER_NUMBER,NETCUP_API_KEY",
 		},
 		{
 			desc: "missing customer number",
@@ -57,15 +65,6 @@ func TestNewDNSProvider(t *testing.T) {
 				EnvAPIPassword:    "C",
 			},
 			expected: "netcup: some credentials information are missing: NETCUP_API_KEY",
-		},
-		{
-			desc: "missing api password",
-			envVars: map[string]string{
-				EnvCustomerNumber: "A",
-				EnvAPIKey:         "B",
-				EnvAPIPassword:    "",
-			},
-			expected: "netcup: some credentials information are missing: NETCUP_API_PASSWORD",
 		},
 	}
 
@@ -106,6 +105,11 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			password: "C",
 		},
 		{
+			desc:     "success without API password",
+			customer: "A",
+			key:      "B",
+		},
+		{
 			desc:     "missing credentials",
 			expected: "netcup: credentials missing",
 		},
@@ -121,13 +125,6 @@ func TestNewDNSProviderConfig(t *testing.T) {
 			customer: "A",
 			key:      "",
 			password: "C",
-			expected: "netcup: credentials missing",
-		},
-		{
-			desc:     "missing password",
-			customer: "A",
-			key:      "B",
-			password: "",
 			expected: "netcup: credentials missing",
 		},
 	}


### PR DESCRIPTION
Fixes #3226


<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout feat/dns/netcup/clouddns
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    NETCUP_CUSTOMER_NUMBER=xxxx \
    NETCUP_API_KEY=yyyy \
    ./dist/lego run --dns netcup -d '*.example.com' -d example.com -s letsencrypt-staging
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>
