### PR TITLE
websupport: fix get records filter

### DIFF
--- a/providers/dns/internal/active24/internal/client.go
+++ b/providers/dns/internal/active24/internal/client.go
@@ -77,6 +77,8 @@ func (c *Client) GetRecords(ctx context.Context, service string, filter RecordFi
 	query := endpoint.Query()
 	query.Add("filters", string(encodedFilter))
 
+	endpoint.RawQuery = query.Encode()
+
 	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err

--- a/providers/dns/internal/active24/internal/client.go
+++ b/providers/dns/internal/active24/internal/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-acme/lego/v5/internal/errutils"
+	querystring "github.com/google/go-querystring/query"
 )
 
 const defaultBaseURL = "https://rest.%s"
@@ -66,18 +67,15 @@ func (c *Client) GetServices(ctx context.Context) ([]Service, error) {
 
 // GetRecords lists of DNS records.
 // https://rest.active24.cz/v2/docs#/DNS/rest.v2.dns.record_f94908d4e0e48489468498fce87cb90b
-func (c *Client) GetRecords(ctx context.Context, service string, filter RecordFilter) ([]Record, error) {
+func (c *Client) GetRecords(ctx context.Context, service string, filter *RecordFilter) ([]Record, error) {
 	endpoint := c.BaseURL.JoinPath("v2", "service", service, "dns", "record")
 
-	encodedFilter, err := json.Marshal(filter)
+	values, err := querystring.Values(&Filters{RecordFilter: filter})
 	if err != nil {
 		return nil, fmt.Errorf("marshal records filter: %w", err)
 	}
 
-	query := endpoint.Query()
-	query.Add("filters", string(encodedFilter))
-
-	endpoint.RawQuery = query.Encode()
+	endpoint.RawQuery = values.Encode()
 
 	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/providers/dns/internal/active24/internal/client_test.go
+++ b/providers/dns/internal/active24/internal/client_test.go
@@ -92,13 +92,17 @@ func TestClient_GetRecords(t *testing.T) {
 	client := mockBuilder().
 		Route("GET /v2/service/aaa/dns/record",
 			servermock.ResponseFromFixture("records.json"),
+			servermock.CheckQueryParameter().Strict().
+				With("filters[content]", "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY").
+				With("filters[name]", "_acme-challenge").
+				With("filters[type][]", "TXT"),
 		).
 		Build(t)
 
-	filter := RecordFilter{
-		Name:    "example.com",
+	filter := &RecordFilter{
+		Name:    "_acme-challenge",
 		Type:    []string{"TXT"},
-		Content: "txt",
+		Content: "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY",
 	}
 
 	records, err := client.GetRecords(t.Context(), "aaa", filter)
@@ -126,8 +130,8 @@ func TestClient_GetRecords_errors(t *testing.T) {
 		).
 		Build(t)
 
-	filter := RecordFilter{
-		Name:    "example.com",
+	filter := &RecordFilter{
+		Name:    "_acme-challenge",
 		Type:    []string{"TXT"},
 		Content: "txt",
 	}

--- a/providers/dns/internal/active24/internal/types.go
+++ b/providers/dns/internal/active24/internal/types.go
@@ -51,15 +51,19 @@ type Service struct {
 	AutoExtend  bool    `json:"autoExtend,omitempty"`
 }
 
+type Filters struct {
+	*RecordFilter `url:"filters"`
+}
+
 type RecordFilter struct {
-	Name     string   `json:"name,omitempty"`
-	Type     []string `json:"type,omitempty"`
-	Content  string   `json:"content,omitempty"`
-	TTL      int      `json:"ttl,omitempty"`
-	Note     string   `json:"note,omitempty"`
-	Priority int      `json:"priority,omitempty"`
-	Port     int      `json:"port,omitempty"`
-	Weight   int      `json:"weight,omitempty"`
-	Flags    int      `json:"flags,omitempty"`
-	Tag      []string `json:"tag,omitempty"`
+	Name     string   `url:"name,omitempty"`
+	Type     []string `url:"type,brackets,omitempty"`
+	Content  string   `url:"content,omitempty"`
+	TTL      int      `url:"ttl,omitempty"`
+	Note     string   `url:"note,omitempty"`
+	Priority int      `url:"priority,omitempty"`
+	Port     int      `url:"port,omitempty"`
+	Weight   int      `url:"weight,omitempty"`
+	Flags    int      `url:"flags,omitempty"`
+	Tag      []string `url:"tag,omitempty"`
 }

--- a/providers/dns/internal/active24/internal/types_test.go
+++ b/providers/dns/internal/active24/internal/types_test.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"net/url"
+	"testing"
+
+	querystring "github.com/google/go-querystring/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilters_encode(t *testing.T) {
+	f := Filters{&RecordFilter{
+		Name: "_acme-challenge.foo",
+		Type: []string{"TXT"},
+	}}
+
+	values, err := querystring.Values(f)
+	require.NoError(t, err)
+
+	unescape, err := url.QueryUnescape(values.Encode())
+	require.NoError(t, err)
+
+	assert.Equal(t, "filters[name]=_acme-challenge.foo&filters[type][]=TXT", unescape)
+}

--- a/providers/dns/internal/active24/provider.go
+++ b/providers/dns/internal/active24/provider.go
@@ -105,7 +105,7 @@ func (d *DNSProvider) CleanUp(ctx context.Context, domain, token, keyAuth string
 		return fmt.Errorf("find service ID: %w", err)
 	}
 
-	recordID, err := d.findRecordID(ctx, strconv.Itoa(serviceID), info)
+	recordID, err := d.findRecordID(ctx, strconv.Itoa(serviceID), info, authZone)
 	if err != nil {
 		return fmt.Errorf("find record ID: %w", err)
 	}
@@ -145,10 +145,14 @@ func (d *DNSProvider) findServiceID(ctx context.Context, domain string) (int, er
 	return 0, fmt.Errorf("service not found for domain: %s", domain)
 }
 
-func (d *DNSProvider) findRecordID(ctx context.Context, serviceID string, info dns01.ChallengeInfo) (int, error) {
-	// NOTE(ldez): Despite the API documentation, the filter doesn't seem to work.
-	filter := internal.RecordFilter{
-		Name:    dns01.UnFqdn(info.EffectiveFQDN),
+func (d *DNSProvider) findRecordID(ctx context.Context, serviceID string, info dns01.ChallengeInfo, authZone string) (int, error) {
+	subDomain, err := dns01.ExtractSubDomain(info.EffectiveFQDN, authZone)
+	if err != nil {
+		return 0, err
+	}
+
+	filter := &internal.RecordFilter{
+		Name:    subDomain,
 		Type:    []string{"TXT"},
 		Content: info.Value,
 	}

--- a/providers/dns/internal/active24/provider_test.go
+++ b/providers/dns/internal/active24/provider_test.go
@@ -110,6 +110,10 @@ func TestDNSProvider_CleanUp(t *testing.T) {
 		).
 		Route("GET /v2/service/3333/dns/record",
 			servermock.ResponseFromInternal("records.json"),
+			servermock.CheckQueryParameter().Strict().
+				With("filters[content]", "ADw2sEd82DUgXcQ9hNBZThJs7zVJkR5v9JeSbAb9mZY").
+				With("filters[name]", "_acme-challenge").
+				With("filters[type][]", "TXT"),
 		).
 		Route("DELETE /v2/service/3333/dns/record/14",
 			servermock.Noop().


### PR DESCRIPTION
Fixes #3252

<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout fix/dns/websupport/filter
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    WEBSUPPORT_API_KEY=xxxx \
    WEBSUPPORT_SECRET=yyyy \
    ./dist/lego run --dns websupport -d '*.example.com' -d example.com -s letsencrypt-staging
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>
