### PR TITLE
xinnet: remove URL trailing slash

### DIFF
--- a/providers/dns/xinnet/internal/client.go
+++ b/providers/dns/xinnet/internal/client.go
@@ -47,7 +47,7 @@ func NewClient(signer RequestSigner) (*Client, error) {
 // CreateRecord creates a record.
 // https://apidoc.xin.cn/doc-7283900
 func (c *Client) CreateRecord(ctx context.Context, record Record) (int64, error) {
-	endpoint := c.BaseURL.JoinPath("api", "dns", "create", "/")
+	endpoint := c.BaseURL.JoinPath("api", "dns", "create")
 
 	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, record)
 	if err != nil {
@@ -67,7 +67,7 @@ func (c *Client) CreateRecord(ctx context.Context, record Record) (int64, error)
 // DeleteRecord deletes a record.
 // https://apidoc.xin.cn/doc-7283901
 func (c *Client) DeleteRecord(ctx context.Context, domain string, recordID int64) error {
-	endpoint := c.BaseURL.JoinPath("api", "dns", "delete", "/")
+	endpoint := c.BaseURL.JoinPath("api", "dns", "delete")
 
 	payload := map[string]any{
 		"domainName": domain,

--- a/providers/dns/xinnet/internal/client_test.go
+++ b/providers/dns/xinnet/internal/client_test.go
@@ -40,7 +40,7 @@ func mockBuilder() *servermock.Builder[*Client] {
 
 func TestClient_CreateRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /api/dns/create/",
+		Route("POST /api/dns/create",
 			servermock.ResponseFromFixture("create_record.json"),
 			servermock.CheckRequestJSONBodyFromFixture("create_record-request.json"),
 			servermock.CheckHeader().
@@ -66,7 +66,7 @@ func TestClient_CreateRecord(t *testing.T) {
 
 func TestClient_DeleteRecord(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /api/dns/delete/",
+		Route("POST /api/dns/delete",
 			servermock.ResponseFromFixture("delete_record.json"),
 			servermock.CheckRequestJSONBodyFromFixture("delete_record-request.json"),
 			servermock.CheckHeader().
@@ -81,7 +81,7 @@ func TestClient_DeleteRecord(t *testing.T) {
 
 func TestClient_DeleteRecord_error(t *testing.T) {
 	client := mockBuilder().
-		Route("POST /api/dns/delete/",
+		Route("POST /api/dns/delete",
 			servermock.ResponseFromFixture("error.json")).
 		Build(t)
 

--- a/providers/dns/xinnet/internal/signer.go
+++ b/providers/dns/xinnet/internal/signer.go
@@ -44,7 +44,7 @@ func (s *Signer) Sign(req *http.Request) error {
 
 	timestamp := s.clock().UTC().Format("20060102T150405Z")
 
-	stringToSign := algorithm + "\n" + timestamp + "\n" + req.Method + "\n" + req.URL.Path + "\n" + string(reqBody)
+	stringToSign := algorithm + "\n" + timestamp + "\n" + req.Method + "\n" + req.URL.Path + `/` + "\n" + string(reqBody)
 
 	h := hmac.New(sha256.New, []byte(s.secret))
 	h.Write([]byte(stringToSign))

--- a/providers/dns/xinnet/internal/signer_test.go
+++ b/providers/dns/xinnet/internal/signer_test.go
@@ -18,7 +18,7 @@ func TestSigner_Sign(t *testing.T) {
 		return time.Date(2024, 6, 5, 8, 55, 45, 0, time.UTC)
 	}
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/domain/check/", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/domain/check", http.NoBody)
 
 	err = signer.Sign(req)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #3269

<details><summary>How to test this PR?</summary>

1. You need [Go](https://go.dev/doc/install)
2. Check out the PR:
    ```bash
    git clone https://github.com/ldez/lego.git
    cd lego
    git checkout fix/dns/xinnet/url-path
    ```
3. Compile lego:
    - if you have `make`: `make build`
    - if you don't have `make`: `go build -o dist/lego ./cmd/lego`
4. Run the following command with your information (email, domain, credentials):
    ```bash
    XINNET_SECRET="xxx" \
    XINNET_AGENT_ID="agent12345" \
    ./dist/lego run --dns xinnet -d '*.example.com' -d example.com -s letsencrypt-staging
    ```
   **The wildcard domain is important**
5. Before each run of the command, you should clean your local environment:
    ```bash
    rm -rf .lego
    ```

</details>
